### PR TITLE
docs(roadmap): add pre-v0.82 hardening gates (v0.81.1–v0.81.4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,7 +391,7 @@ and durability foundations that must be proven before v1.0.
 | [v0.79.0](roadmap/v0.79.0.md) | Code Quality, API Ergonomics & Security: remove unused-import suppressions in src/refresh/codegen.rs and src/refresh/merge/mod.rs module-by-module (Q-1), convert internal create/alter API implementations to typed parameter structs eliminating too-many-arguments in business logic (Q-2), replace global #![allow(dead_code)] with narrower per-module allowances on pgrx/export boundaries (Q-3), remove or #[deprecated] consume_slot_changes() replacing with clearly named status function (Q-4), add SQL convenience helpers create_stream_table_fast_append_only/set_stream_table_refresh_policy/set_stream_table_storage_policy (A-1), add first-class pause_stream_table/resume_stream_table wrappers (A-2), add/strengthen semgrep CI rules for dynamic SQL distinguishing identifier/literal/OID boundaries (S-1), emit runtime WARNING when source has RLS enabled at create_stream_table time (S-2), CI test inspecting SECURITY DEFINER trigger functions for SET search_path (S-3), cleanup chaos test forcing three consecutive DELETE failures with alert and status verification (D-3), dbt adapter compatibility matrix with alter/drop/rebuild flow and version matrix tests (T-5) | ✅ Released | Large | [Full details](roadmap/v0.79.0.md-full.md) |
 | [v0.80.0](roadmap/v0.80.0.md) | Operational Excellence, Documentation Completeness & Final v1.0 Gate: add DVM fallback/performance reason codes to refresh history and health output — CORRELATED_SUBQUERY_DELTA_QUADRATIC, CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK, REGEX_COMPLEXITY_CLASSIFIER_UNCERTAIN (O-1), add health_check() threshold alert when invalidation ring overflow count increases in recent time window (O-2), add cleanup backlog trend metrics integrated into pgt_metrics_summary (O-3), docs lint comparing #[pg_extern] exports with SQL_REFERENCE.md entries (DOC-1), create docs/DVM_SUPPORT_MATRIX.md with every query pattern, fallback behavior, IMMEDIATE restrictions, and known-unsupported forms including q12/q20 entries (DOC-2), operational rollback runbook (backup requirements, snapshot recommendation, restore path, why downgrades are unsafe) (U-1), document upgrade E2E cutoff policy prominently in CHANGELOG and release notes (U-2), CI gate documentation in CONTRIBUTING.md describing which workflows gate PRs (B-1), review-by dates on cargo-deny advisory suppressions and require cargo-deny in PR gates (B-2), fuzz test for DVM snapshot fingerprint cache stability under OpTree refactoring (P-5), document internal event trigger functions in ARCHITECTURE comments (A-3) | ✅ Released | Large | [Full details](roadmap/v0.80.0.md-full.md) |
 
-### Assessment-16-Driven Scaling Arc (v0.81.x – v0.87.x)
+### Assessment-16 Scaling Arc and Pre-Scaling Hardening Gate (v0.81.x - v0.87.x)
 
 Driven by the findings in the v0.80.0 vision audit
 ([plans/PLAN_OVERALL_ASSESSMENT_16.md](plans/PLAN_OVERALL_ASSESSMENT_16.md)).
@@ -400,14 +400,25 @@ architecture (single-process compute ceiling, change buffer I/O amplification,
 no state externalization), performance (no vectorized batch processing, SPI
 overhead per refresh, no incremental MERGE), ergonomics (no declarative DDL,
 no auto-schema-evolution, no configuration advisor), and observability (no
-OpenTelemetry traces, no commit-to-visible latency metric). This seven-release
+OpenTelemetry traces, no commit-to-visible latency metric). This seven-minor-release
 arc implements the "Blueprint for Infinite Scaling" — transitioning pg_trickle
 from a world-class single-node extension to a distributed, auto-scaling IVM
 system capable of running on a developer laptop or a Kubernetes cluster.
 
+An August 2026 implementation audit after v0.81.0 found unresolved single-node
+correctness and resilience risks that must not be carried into a multi-process
+architecture. Four patch releases now form a mandatory pre-scaling gate. They
+add no major features: they make the existing frontier, CDC, DVM, SQL API,
+catalog, upgrade, scheduler, and resource contracts fail closed and prove them
+under adversarial concurrency. v0.82.0 is blocked until all four gates pass.
+
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|-------|--------------|
 | [v0.81.0](roadmap/v0.81.0.md) | Observability, Self-Tuning & Quick Wins: commit-to-visible latency metric using pg_xact_commit_timestamp (QW-1), configuration advisor function pgtrickle.tune_recommendations() (QW-2), preview/dry-run mode pgtrickle.preview_stream_table() (QW-3), OpenTelemetry trace spans on scheduler_tick/refresh_cycle/delta_execute/merge_apply with OTLP export (QW-4), bounded LRU eviction on thread-local L0/L1 template caches (QW-5), DeltaOperator trait for extensible operator dispatch (QW-6), split config.rs into config/scheduler.rs + config/cdc.rs + config/dvm.rs + config/monitoring.rs (QW-7), self-healing circuit breaker with auto-remediation for OOM/lock-timeout/sustained-lag (QW-8), chunked MERGE for large deltas with configurable merge_batch_size GUC (QW-9), stream table presets ('real-time'/'batch'/'cost-optimized') (QW-10) | ✅ Released | Large | [Full details](roadmap/v0.81.0.md) |
+| [v0.81.1](roadmap/v0.81.1.md) | Frontier & CDC Durability Gate: one safe frontier contract for manual/scheduled refresh, backend_xid/xmin/2PC holdback, database/tick-scoped immutable worker bounds, snapshot-aligned FULL refresh, no blind WAL slot fast-forward, atomic WAL-to-trigger cutover, missing-buffer fail-closed repair, common TopK/fused/fallback finalization, honest sync/UNLOGGED crash semantics | Planned | Large | [Full details](roadmap/v0.81.1.md) |
+| [v0.81.2](roadmap/v0.81.2.md) | DVM Semantic Fidelity Gate: private set-operation state and exact ALL multiplicity, positional/NULL-safe branches, nullable SUM and statistical accumulator correctness, scalar cardinality errors, LATERAL identity/IMMEDIATE safety, fail-closed volatility and AST rewrites, sound circular monotonicity admission, collision-free composite row identity | Planned | Large | [Full details](roadmap/v0.81.2.md) |
+| [v0.81.3](roadmap/v0.81.3.md) | Catalog, Privilege & Upgrade Integrity: fresh/upgrade catalog parity, explicit SQL ACL/ownership matrix, typed identifier and snapshot provenance safety, typed bulk lifecycle APIs and complete CDC cleanup, truthful logical restore, real old-binary upgrades, tag/runtime version equality, checked numeric contracts, generated SQL reference contracts | Planned | Large | [Full details](roadmap/v0.81.3.md) |
+| [v0.81.4](roadmap/v0.81.4.md) | Scheduler & Resource Resilience Gate: authoritative worker limits and race-free tokens, database-scoped pause/health state, persistent drain, enforceable refresh deadlines, complete self-healing/error accounting, bounded queue/catalog maintenance, scheduler-safe metrics/alerts, API resource ceilings and real fuzz/property assurance | Planned | Large | [Full details](roadmap/v0.81.4.md) |
 | [v0.82.0](roadmap/v0.82.0.md) | External Worker Foundation: extract DVM + MERGE into standalone pg_trickle_worker binary connecting via tokio-postgres (MT-1), advisory-lock-based work claiming with heartbeat monitoring and automatic failover (MT-2), DiffContext decomposition into CdcContext/CacheContext/OptimizationContext (MT-7), pg_stat_pgtrickle virtual system view for per-ST cumulative statistics (MT-9), adaptive worker pool sizing based on CPU utilization and refresh queue depth (MT-10), worker registration table pgt_worker_registry with health monitoring | Planned | Large | [Full details](roadmap/v0.82.0.md) |
 | [v0.83.0](roadmap/v0.83.0.md) | Performance Pipeline & CDC Extraction: pipelined refresh execution with portal-based streaming overlapping delta SQL and MERGE application (MT-3), external CDC consumer binary pg_trickle_cdc subscribing to logical replication with zero trigger overhead (MT-4), shared-memory change buffer ring for hot sources >10K writes/s with table-based overflow (MT-5), auto-schema-evolution via DDL event trigger for additive source changes (MT-6), pg_trickle.cdc_mode='external' GUC for zero-write-path-impact mode | Planned | Large | [Full details](roadmap/v0.83.0.md) |
 | [v0.84.0](roadmap/v0.84.0.md) | Vectorized Compute & Adaptive Engine: vectorized aggregate path using Arrow-compatible columnar batches with SIMD operations for pure-aggregate STs (MT-8), incremental window function computation replacing partition-based recomputation with proper incremental algorithms for ROW_NUMBER/RANK/DENSE_RANK/LAG/LEAD (LT-7), cost-based operator scheduling reordering operators within delta queries based on estimated cardinality (LT-9), parallel delta computation fan-out for multi-source joins (PERF-O4) | Planned | Large | [Full details](roadmap/v0.84.0.md) |
@@ -547,6 +558,14 @@ v0.79    ─── Code quality, API ergonomics & security: remove lint suppress
 v0.80    ─── Operational excellence & final v1.0 gate: DVM reason codes, ring overflow alert, backlog trends, pg_extern docs lint, DVM_SUPPORT_MATRIX, rollback runbook, upgrade cutoff docs, CI gate docs
     │
 v0.81    ─── Observability, self-tuning & quick wins: OTel traces, commit-to-visible metric, config advisor, chunked MERGE, self-healing, presets, DeltaOperator trait
+    │
+v0.81.1  ─── Frontier & CDC durability gate: safe bounds, snapshot-aligned FULL, WAL cutover, fail-closed buffers, common finalization, crash semantics
+    │
+v0.81.2  ─── DVM semantic fidelity gate: exact set operations, NULL aggregates, scalar/LATERAL correctness, volatility, monotonicity, row identity
+    │
+v0.81.3  ─── Catalog, privilege & upgrade integrity: schema parity, ACL matrix, identifier safety, restore, real upgrades, version and API contracts
+    │
+v0.81.4  ─── Scheduler & resource resilience gate: worker caps, database scoping, drain/deadlines, self-healing, bounded maintenance, adversarial assurance
     │
 v0.82    ─── External worker foundation: pg_trickle_worker binary, advisory lock coordination, adaptive pool sizing, pg_stat_pgtrickle view, DiffContext split
     │
@@ -859,19 +878,34 @@ dates complete the pre-v1.0 checklist.
 
 **v0.81.0 through v0.87.0 form the Assessment-16-Driven Scaling Arc**, driven
 by the findings in the v0.80.0 vision audit
-(plans/PLAN_OVERALL_ASSESSMENT_16.md). With correctness, documentation, and
-operational readiness proven across 15 prior assessment arcs, the project is
-architecturally sound for single-node deployment but structurally limited to
-one PostgreSQL backend process. This arc implements the "Blueprint for Infinite
-Scaling" — a backward-compatible transition from a world-class single-node
-extension to a distributed, auto-scaling IVM system.
+(plans/PLAN_OVERALL_ASSESSMENT_16.md). Prior assessments established a strong
+single-node architecture, but the post-v0.81.0 implementation audit found
+correctness and resilience gaps that require explicit closure before that
+architecture is distributed. The broader arc implements the "Blueprint for
+Infinite Scaling" — a backward-compatible transition from a world-class
+single-node extension to a distributed, auto-scaling IVM system.
 
 v0.81.0 delivers immediate observability and ergonomic wins: OpenTelemetry
 trace spans across the refresh hot path, a commit-to-visible latency metric
 for SLA compliance, a configuration advisor function that analyzes workloads
 and suggests optimal GUC values, chunked MERGE to reduce peak memory on large
 deltas, self-healing circuit breakers, and stream table presets for progressive
-disclosure. v0.82.0 introduces the external worker foundation: a standalone
+disclosure.
+
+The post-v0.81.0 implementation audit adds a mandatory four-release hardening
+gate before scaling work begins. v0.81.1 closes frontier, CDC durability, WAL
+cutover, crash-recovery, and refresh-finalization paths that could skip or hide
+committed changes. v0.81.2 enforces PostgreSQL semantics in the existing DVM
+surface, including set operations, NULL aggregates, scalar and LATERAL
+subqueries, volatility, circular monotonicity, and row identity. v0.81.3 makes
+fresh and upgraded catalogs identical, defines the privilege boundary, repairs
+lifecycle and restore contracts, and verifies real binary upgrades and release
+versions. v0.81.4 makes scheduler concurrency, database scoping, drain,
+deadlines, remediation, maintenance, metrics, and resource bounds reliable
+under stress. These releases add no major user-facing capability; they are the
+proof boundary that v0.82 must preserve.
+
+v0.82.0 introduces the external worker foundation: a standalone
 `pg_trickle_worker` binary that connects via tokio-postgres, claims work via
 advisory locks, and computes deltas outside the PostgreSQL process. The
 in-process scheduler becomes a coordinator that dispatches to external workers
@@ -892,4 +926,3 @@ Each phase is backward-compatible: a developer laptop continues running
 pg_trickle as a single in-process extension with zero additional infrastructure.
 A production Kubernetes cluster deploys the full distributed topology with
 auto-scaling workers.
-

--- a/plans/PLAN_OVERALL_ASSESSMENT_16.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_16.md
@@ -460,6 +460,10 @@ The action plan maps to the following release schedule:
 | Version | Theme | Items |
 |---------|-------|-------|
 | **v0.81.0** | Observability, Self-Tuning & Quick Wins | QW-1 through QW-10 |
+| **v0.81.1** | Frontier and CDC Durability Gate | Pre-scaling implementation audit; see [roadmap/v0.81.1.md](../roadmap/v0.81.1.md) |
+| **v0.81.2** | DVM Semantic Fidelity Gate | Pre-scaling implementation audit; see [roadmap/v0.81.2.md](../roadmap/v0.81.2.md) |
+| **v0.81.3** | Catalog, Privilege, and Upgrade Integrity | Pre-scaling implementation audit; see [roadmap/v0.81.3.md](../roadmap/v0.81.3.md) |
+| **v0.81.4** | Scheduler and Resource Resilience Gate | Pre-scaling implementation audit; see [roadmap/v0.81.4.md](../roadmap/v0.81.4.md) |
 | **v0.82.0** | External Worker Foundation | MT-1, MT-2, MT-7, MT-9, MT-10 |
 | **v0.83.0** | Performance Pipeline & CDC Extraction | MT-3, MT-4, MT-5, MT-6 |
 | **v0.84.0** | Vectorized Compute & Adaptive Engine | MT-8, LT-7, LT-9 |
@@ -508,4 +512,7 @@ detection and progressive opt-in.
 The immediate v0.81.0 release delivers quick wins (OTel tracing, commit-to-visible
 metric, configuration advisor, chunked MERGE, self-healing) that make the current
 single-node engine significantly more observable and self-tuning — valuable
-regardless of whether the distributed scaling path is pursued.
+regardless of whether the distributed scaling path is pursued. The subsequent
+v0.81.1-v0.81.4 implementation-audit gates strengthen existing durability, DVM,
+catalog, privilege, upgrade, scheduler, and resource contracts without adding
+major features. MT-1 and MT-2 begin only after those gates pass.

--- a/roadmap/v0.81.1.md
+++ b/roadmap/v0.81.1.md
@@ -1,0 +1,104 @@
+# v0.81.1 - Frontier and CDC Durability Gate
+
+> **Status:** Planned
+> **Scope:** Large
+> **Driven by:** August 2026 pre-scaling hardening review
+
+## Theme
+
+Eliminate every known path that can acknowledge, discard, or advance past a
+committed source change without first making that change durable and visible.
+This is a stop-the-line correctness release: v0.82.0 cannot begin until the
+frontier, CDC, crash-recovery, and refresh-finalization invariants below are
+proven under concurrency.
+
+## Non-Goals
+
+- No new CDC backend or transport.
+- No external workers.
+- No throughput optimization that weakens committed-change durability.
+
+## Items
+
+### DUR-81-1: One Safe Frontier Contract
+
+Replace raw current-LSN capture in manual refresh paths with the same safe
+upper-bound contract used by scheduled refreshes. The holdback probe must cover
+both `backend_xid` and `backend_xmin`, prepared transactions, and first-tick or
+restart behavior. Probe failure and an unknown initial bound fail closed rather
+than advancing to the current write LSN.
+
+The coordinator-captured bound becomes immutable job input, scoped by database
+and dispatch tick. Dynamic workers must never read a cluster-global watermark
+that another database scheduler can overwrite.
+
+### DUR-81-2: Snapshot-Aligned FULL Refresh
+
+Establish FULL refresh source positions from the same protected snapshot that
+materializes the stream table. Manual and scheduled FULL refreshes must either
+lock source writes while establishing the snapshot/bound or use an equivalent
+snapshot-safe protocol. A transaction that is invisible to the FULL query may
+not be included in its stored frontier.
+
+### DUR-81-3: WAL Consumption Without Blind Fast-Forward
+
+Remove direct replication-slot advancement to `pg_current_wal_lsn()` after a
+FULL refresh. Retained WAL may be released only after events are decoded into a
+durable shared change buffer or a snapshot-aligned proof shows that every
+dependent stream table materialized them.
+
+Make WAL-to-trigger fallback an ordered cutover: block source DML, install
+trigger capture, drain through a defined LSN, switch catalog state, then remove
+WAL resources. If the drain cannot be proven, force every dependent stream
+table through FULL reinitialization.
+
+### DUR-81-4: Missing CDC State Fails Closed
+
+A missing, truncated, malformed, or inaccessible required change buffer is not
+a zero-row differential refresh. Return a typed error, preserve the previous
+frontier, repair CDC infrastructure, and require a successful FULL
+reinitialization before differential refresh resumes.
+
+### DUR-81-5: Common Refresh Finalization
+
+Route normal differential, FULL fallback, TopK, and fused scheduler execution
+through one correctness finalizer. It must atomically handle frontier storage,
+`last_refresh_at` and `data_timestamp`, downstream stream-table CDC capture,
+buffer cleanup, refresh history, outbox delivery, cost summaries, and
+post-refresh actions.
+
+Disable scheduler fusion by default until a fused chain passes the same
+finalization contract. Approximate metadata is not acceptable for a successful
+refresh.
+
+### DUR-81-6: Honest Buffer Durability Modes
+
+Implement the documented `sync` behavior, including effective
+`synchronous_commit = on` for change-buffer writes. Reject unknown
+`change_buffer_durability` values instead of mapping them to `unlogged`, and
+make code, GUC descriptions, and documentation agree on the crash-safe default.
+
+Replace empty-table inference for UNLOGGED crash recovery with a durable crash
+generation or sentinel. New post-restart writes must not hide loss of older
+buffer rows, and a clean restart with an empty buffer must not trigger a false
+loss report.
+
+## Release Gate
+
+v0.81.1 will not ship until all of the following pass:
+
+- Idle READ COMMITTED writer, prepared transaction, first-tick, restart, and
+  writer-replacement tests prove that no invisible row is acknowledged.
+- A slow FULL refresh with concurrent commits converges for one stream table and
+  for two stream tables sharing the source.
+- Manual and scheduler refreshes pass the same long-transaction matrix.
+- WAL FULL refresh and WAL-to-trigger cutover tests account for every committed
+  event before slot advancement or resource removal.
+- Dropping a required buffer preserves the frontier and causes repair plus FULL
+  reinitialization.
+- TopK and fused-chain tests prove downstream propagation, metadata completion,
+  and bounded buffers.
+- A postmaster crash with pending UNLOGGED changes followed immediately by new
+  DML forces safe resynchronization.
+
+Any unexplained source-versus-stream-table mismatch is a release blocker.

--- a/roadmap/v0.81.2.md
+++ b/roadmap/v0.81.2.md
@@ -1,0 +1,112 @@
+# v0.81.2 - DVM Semantic Fidelity Gate
+
+> **Status:** Planned
+> **Scope:** Large
+> **Blocked by:** [v0.81.1](v0.81.1.md)
+> **Driven by:** August 2026 pre-scaling hardening review
+
+## Theme
+
+Make DIFFERENTIAL and IMMEDIATE results obey PostgreSQL semantics across the
+currently supported operator surface. Where a proof is not yet available,
+AUTO must use FULL and explicit incremental modes must fail with an actionable
+error. Silent approximation is never an acceptable fallback.
+
+## Non-Goals
+
+- No new SQL operators or aggregate families.
+- No expansion of the documented DVM support matrix.
+- No performance work unless it is required to preserve semantics safely.
+
+## Items
+
+### DVM-81-1: Set-Operation State Is Not User Data
+
+Separate INTERSECT and EXCEPT multiplicity state from the user-visible stream
+table. Direct `SELECT` results must exactly match PostgreSQL, including invisible
+values and the repeated rows required by `INTERSECT ALL` and `EXCEPT ALL`.
+Preserve one-sided counts when visibility crosses zero so later changes can
+restore rows correctly.
+
+Until that representation is proven, AUTO uses FULL and explicit DIFFERENTIAL
+or IMMEDIATE creation rejects these forms.
+
+### DVM-81-2: Positional and NULL-Safe Set Semantics
+
+Bind set-operation branches by ordinal position, not by the first branch's
+column names. Initialize and update state with NULL-safe equality using `IS NOT
+DISTINCT FROM`, including composite rows and branches with different aliases.
+
+### DVM-81-3: Nullable Aggregate Fidelity
+
+Track non-NULL input counts for every algebraically maintained non-DISTINCT
+`SUM`, not only FULL JOIN cases. Preserve SQL's NULL result for non-empty groups
+whose inputs are all NULL and for groups whose final non-NULL value is removed.
+Cover `FILTER` and expressions that wrap `SUM` in `COALESCE`.
+
+Cast statistical aggregate operands to their accumulator type before computing
+squares or cross-products so valid `STDDEV`, `VAR`, `CORR`, `COVAR`, and `REGR`
+inputs cannot overflow in a narrower source type.
+
+### DVM-81-4: Scalar Subquery Cardinality
+
+Remove injected `LIMIT 1` behavior from scalar-subquery snapshots. A defining
+query that produces multiple scalar rows must raise PostgreSQL's cardinality
+error atomically, without changing stream-table data or advancing its frontier.
+
+### DVM-81-5: LATERAL Dependency and Identity Safety
+
+Reject unsupported IMMEDIATE LATERAL inner-source mutations until transition
+tables drive the affected-outer-row branch correctly. Compute the complete set
+of outer dependencies and identity keys, preserve required hidden identity
+state, and never emit a broad `TRUE` deletion join when projected output does
+not retain outer identity.
+
+LATERAL precomputation is allowed only when all outer references are covered or
+functionally determined by its grouping keys.
+
+### DVM-81-6: Volatility and Rewrite Validation Fail Closed
+
+Treat STABLE expressions as unsupported for incremental maintenance unless an
+operator-specific proof shows unchanged rows remain semantically valid. AUTO
+uses FULL; explicit DIFFERENTIAL and IMMEDIATE reject unsafe cases.
+
+Complete volatility inspection across ORDER BY, FROM, GROUP BY, HAVING,
+LIMIT/OFFSET, LATERAL, JSON_TABLE-like expressions, and overloaded operators.
+An uninspectable expression or AST conversion failure must return a controlled
+fallback/error, never silently substitute `TRUE` or `NULL`.
+
+### DVM-81-7: Sound Circular Monotonicity Admission
+
+Conservatively reject LEFT/FULL joins, scalar subqueries, and LATERAL subqueries
+inside circular dependencies unless a specific monotonicity proof exists.
+Admission rules must reflect whether adding input can remove or replace output,
+not merely recurse through child operators.
+
+### DVM-81-8: Collision-Free Row Identity Encoding
+
+Replace delimiter-only composite hash encoding with an unambiguous framed or
+escaped encoding. Define migration behavior for persisted row IDs and CDC
+primary-key hashes so existing stream tables are safely reinitialized when the
+encoding changes.
+
+## Release Gate
+
+v0.81.2 will not ship until all of the following pass:
+
+- Direct reads match PostgreSQL for INTERSECT, EXCEPT, and both ALL variants
+  across initialization and repeated visibility-boundary crossings.
+- Differing branch aliases and NULL-containing composite rows pass every set
+  operation in FULL and incremental modes.
+- Property tests compare DIFFERENTIAL with FULL after every INSERT, UPDATE, and
+  DELETE for nullable SUM, scalar subqueries, and LATERAL queries.
+- Scalar cardinality violations leave data and frontiers unchanged, then recover
+  after the source is corrected.
+- Volatile and STABLE expressions in every supported clause either prove safe or
+  produce the documented FULL fallback/rejection.
+- Circular queries containing non-monotone operators are rejected while the
+  proven monotone fragment remains accepted.
+- Statistical aggregate boundary tests and adversarial composite-key hashing
+  pass with production types and production hash functions.
+
+Any unexplained DIFFERENTIAL-versus-FULL mismatch is a release blocker.

--- a/roadmap/v0.81.3.md
+++ b/roadmap/v0.81.3.md
@@ -1,0 +1,119 @@
+# v0.81.3 - Catalog, Privilege, and Upgrade Integrity
+
+> **Status:** Planned
+> **Scope:** Large
+> **Blocked by:** [v0.81.2](v0.81.2.md)
+> **Driven by:** August 2026 pre-scaling hardening review
+
+## Theme
+
+Make fresh installs, upgraded installs, documented role setups, backup/restore,
+and every mutating SQL API agree on one enforceable contract. This release
+closes lifecycle and release-engineering gaps before v0.82 introduces another
+process and a larger privilege surface.
+
+## Non-Goals
+
+- No trusted-extension conversion.
+- No new lifecycle APIs.
+- No new backup format or external control plane.
+
+## Items
+
+### CAT-81-1: Canonical Fresh-Install and Upgrade Schema
+
+Restore supported migration-era objects missing from the bootstrap schema,
+including snapshot/subscription catalogs and view-evolution columns. Ship an
+idempotent repair migration for affected installations.
+
+Generate normalized live-catalog manifests for fresh and upgraded databases.
+Compare relations, columns, types, defaults, constraints, indexes, function
+identity arguments, return types, volatility, strictness, parallel safety,
+owners, `prosecdef`, `proconfig`, and ACLs in both directions. A removed object
+or changed signature must fail CI just as an un-migrated addition does.
+
+### CAT-81-2: Explicit SQL Privilege Matrix
+
+Define and enforce ACLs for diagnostics, owner lifecycle operations,
+administrative controls, background/event-trigger entry points, and internal
+functions. Revoke mutating and internal functions from PUBLIC. Require owner or
+administrator authorization for stream-table changes, repair, snapshots,
+scheduler controls, drain, and restore.
+
+Use narrowly scoped, search-path-pinned SECURITY DEFINER functions only for
+internal catalog work. Arbitrary-SQL APIs such as `write_and_refresh` remain
+invoker-only. Role tests must execute the documented grants instead of testing a
+different privilege model.
+
+### CAT-81-3: Typed Identifier and Snapshot Provenance Safety
+
+Replace ad hoc identifier escaping with the central typed identifier builder.
+Snapshot restore/drop must resolve cataloged snapshot identity, verify
+provenance, and enforce ownership; an ordinary table must never be accepted as
+a snapshot merely because its name exists.
+
+### CAT-81-4: Lifecycle API Correctness
+
+Make bulk alter/drop call typed internal implementations rather than generated,
+unsupported, or signature-mismatched SQL. Define atomic or explicit per-item
+failure semantics, validate a closed JSON schema, and bound input cardinality.
+
+Clean CDC resources by their cataloged stable names for every supported polling
+source type. Removing the final consumer must leave no orphan buffers,
+snapshots, sequences, triggers, slots, or publications.
+
+### CAT-81-5: Truthful Logical Backup and Restore
+
+Implement OID rebinding and CDC reconstruction after logical restore, or replace
+the current no-op helper with a clear unsupported-state error and mandatory safe
+reinitialization. Classify every catalog as durable configuration,
+derived/rebuildable state, or intentionally excluded; register all durable user
+configuration with `pg_extension_config_dump`.
+
+Restore tests must use deliberately changed relation OIDs and prove capture of
+new DML without relying on post-data trigger restoration to hide missing repair.
+
+### CAT-81-6: Real Upgrade and Version Verification
+
+For the newest supported upgrade hop, create populated stream tables and CDC
+state with the actual released old binary, then restart on the new binary and
+verify pre- and post-upgrade mutations. Current-library execution against old
+SQL is not sufficient evidence of binary compatibility.
+
+Make publishing workflows reject a Git tag that differs from Cargo, META,
+control, install SQL, extension, runtime function, artifact, and OCI versions.
+Convert `pgtrickle.migrate()` into a read-only diagnostic or remove it; it must
+never claim to apply an extension migration or advance a private version ledger.
+
+### CAT-81-7: Validated API Contracts and Generated Reference
+
+Centralize finite/range validation and checked integer conversions for direct,
+preset, bulk-create, and alter paths. Add catalog constraints as defense in
+depth for values such as `max_delta_fraction`, TopK limits, and offsets.
+
+Generate SQL signatures, defaults, volatility, strictness, security mode, ACL
+classification, and supported upgrade hops from packaged SQL or a live catalog.
+Documentation checks must validate contracts, not merely search for function
+names.
+
+## Release Gate
+
+v0.81.3 will not ship until all of the following pass:
+
+- Fresh install and every supported upgrade path produce the same normalized
+  catalog manifest.
+- Snapshot, subscription, and view-evolution APIs pass on a fresh install and on
+  an upgraded install.
+- Documented administrator, owner, application, and unrelated roles pass a full
+  allow/deny matrix; PUBLIC cannot invoke mutating global controls.
+- Quoted, Unicode, whitespace, comment-marker, and semicolon-containing
+  identifiers are safe through create, alter, snapshot, restore, and drop.
+- Logical restore into changed OIDs rebuilds capture safely and preserves every
+  catalog classified as durable.
+- A real old binary with populated CDC state upgrades and converges with a fresh
+  defining-query result.
+- Tag/version mismatch, removed schema objects, signature drift, ACL drift,
+  NaN/infinity, and integer narrowing all fail CI before mutation or publish.
+
+No fresh/upgrade schema difference or privilege-boundary ambiguity may be
+waived for release.

--- a/roadmap/v0.81.4.md
+++ b/roadmap/v0.81.4.md
@@ -1,0 +1,110 @@
+# v0.81.4 - Scheduler and Resource Resilience Gate
+
+> **Status:** Planned
+> **Scope:** Large
+> **Blocked by:** [v0.81.3](v0.81.3.md)
+> **Driven by:** August 2026 pre-scaling hardening review
+
+## Theme
+
+Make the current in-process scheduler predictable under concurrency, multiple
+databases, blocked queries, crashes, large catalogs, and adversarial input. This
+is the final single-node resilience gate before external-worker coordination is
+introduced in v0.82.0.
+
+## Non-Goals
+
+- No external-worker protocol or adaptive external pool.
+- No new monitoring backend.
+- No scheduler feature expansion beyond making existing contracts reliable.
+
+## Items
+
+### OPS-81-1: Authoritative Worker Limits
+
+Use one effective cluster limit, including PostgreSQL's
+`max_parallel_workers`, for quota calculation and token acquisition. Make token
+reservation, worker registration, exit, and reconciliation race-free by
+tracking reserved/spawning and live workers separately or serializing state
+changes. A sampled reconciliation must never erase or invent capacity.
+
+### OPS-81-2: Database-Scoped Shared State
+
+Key pause entries, scheduler health, and watermark baselines by database OID as
+well as local `pgt_id`. Report bounded-capacity failures instead of returning
+success when a pause entry cannot be stored. Waiting for selected nodes to pause
+must not wait for unrelated work in another database.
+
+### OPS-81-3: Persistent Drain Semantics
+
+Keep dispatch disabled after `drain()` completes until an explicit resume or
+documented restart boundary. `is_drained()` must distinguish no request,
+draining, and drained, and must verify relevant workers rather than comparing
+epochs alone. Maintenance cannot race a new job immediately after drain returns.
+
+### OPS-81-4: Enforceable Refresh Deadlines
+
+Add bounded, configurable lock and statement deadlines for scheduled refreshes
+and apply them with transaction-local settings. Timeout outcomes must be typed,
+retryable where appropriate, visible in health/history, and guaranteed to
+release worker tokens and unblock drain.
+
+### OPS-81-5: Complete Self-Healing and Error Accounting
+
+Implement the documented temporary memory reduction, lock backoff, and reset
+after successful cycles, or narrow the public contract to behavior that exists.
+Inline and dynamic workers must share one persistent error-accounting,
+remediation, and suspension path; in-memory dispatcher retries may not mask
+repeated catalog-visible failure.
+
+### OPS-81-6: Bounded Queue and Catalog Maintenance
+
+Make queue-depth gauges reflect currently queued work by decrementing on claim,
+cancel, spawn failure, and recovery. Periodically reconcile against catalog
+state. Prune terminal jobs during normal uptime and limit history/cleanup work
+per tick so a large retention backlog cannot monopolize dispatch.
+
+### OPS-81-7: Scheduler-Safe Metrics and Alerts
+
+Collect metrics only for an actual scrape rather than on every scheduler tick,
+honor configured request deadlines, and prevent slow clients from delaying
+dispatch. Standardize and document the bind address.
+
+Build oversized alerts as valid structured JSON with character-boundary
+truncation. Replace modulo-window reminders with last-emitted timestamps so
+fast ticks cannot duplicate alerts and slow ticks cannot miss them.
+
+### OPS-81-8: Resource Ceilings and Adversarial Assurance
+
+Set conservative finite defaults and hard maxima for parse complexity, bulk
+cardinality, pause arrays, and blocking control timeouts. Cancellation or client
+disconnect must not strand scheduler state.
+
+Make fuzz/property workflow names match reality: enumerate one target set for
+smoke and nightly runs, exercise real SQL-facing parser/rewrite and CDC decode
+entry points, assert property case counts, and detect variable-built dynamic SQL
+in mandatory linting.
+
+## Release Gate
+
+v0.81.4 will not ship until all of the following pass:
+
+- Multi-database stress with delayed worker startup and forced exits never
+  exceeds configured worker limits and always recovers capacity.
+- Identical `pgt_id` values in two databases have independent pause, scheduler
+  health, and watermark state.
+- Drain remains active across several scheduler intervals and resumes only via
+  the documented action.
+- Blocked locks and overlong refreshes terminate at configured deadlines,
+  release tokens, record typed outcomes, and permit drain.
+- OOM and lock-timeout injection proves remediation, reset, and eventual
+  suspension in serial and parallel modes.
+- Queue depth returns to zero and expired job/history cleanup progresses under
+  continuous refresh load without unbounded tick latency.
+- Idle metrics cause zero collection queries; slow scrapes stay within their
+  budget; arbitrary Unicode alerts remain valid JSON below PostgreSQL limits.
+- Oversized SQL/JSON/control inputs fail before expensive work, and every fuzz
+  target runs in both smoke and nightly workflows.
+
+The release requires a sustained multi-database soak with no leaked tokens,
+stuck drain state, unbounded catalog growth, or unexplained refresh mismatch.

--- a/roadmap/v0.82.0.md
+++ b/roadmap/v0.82.0.md
@@ -2,6 +2,7 @@
 
 > **Status:** Planned  
 > **Scope:** Large  
+> **Blocked by:** [v0.81.1](v0.81.1.md), [v0.81.2](v0.81.2.md), [v0.81.3](v0.81.3.md), and [v0.81.4](v0.81.4.md)
 > **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — MT-1, MT-2, MT-7, MT-9, MT-10
 
 ## Theme
@@ -15,6 +16,12 @@ available, falling back to in-process execution when not.
 This is the foundational architectural change that enables horizontal scaling
 in later releases. The system remains fully backward-compatible: deployments
 without external workers continue operating exactly as before.
+
+External-worker implementation starts only after the v0.81.1-v0.81.4
+pre-scaling gates prove the current single-node frontier, DVM, catalog,
+privilege, upgrade, scheduler, and resource contracts. The worker protocol must
+preserve those proven invariants rather than creating parallel implementations
+of refresh finalization, error accounting, or frontier selection.
 
 ## Items
 


### PR DESCRIPTION
## Summary

Introduces the **pre-v0.82 hardening gate** — a mandatory four-release arc
(v0.81.1 through v0.81.4) that must be completed before the external-worker
scaling work in v0.82.0 begins. The post-v0.81.0 implementation audit found
correctness and resilience gaps that require explicit closure to ensure the
single-node architecture is sound before it is distributed.

## Changes

### ROADMAP.md

- Inserts v0.81.1–v0.81.4 into the release table between v0.81.0 and v0.82.0.
- Extends the ASCII version timeline with the four new hardening nodes.
- Rewrites the Assessment-16 arc narrative to reflect that correctness and
  resilience gaps must be closed first; the "Blueprint for Infinite Scaling"
  framing is preserved but now follows the hardening gate.

### plans/PLAN_OVERALL_ASSESSMENT_16.md

- Minor wording update to align the assessment summary with the revised arc
  narrative.

### New roadmap files

| File | Release | Theme |
|------|---------|-------|
| `roadmap/v0.81.1.md` | Frontier & CDC Durability Gate | Eliminates every path that can acknowledge, discard, or advance past a committed source change without durability. Covers: safe frontier contract (DUR-81-1), snapshot-aligned FULL refresh (DUR-81-2), WAL consumption without blind fast-forward (DUR-81-3), fail-closed missing CDC state (DUR-81-4), common refresh finalization (DUR-81-5), honest buffer durability modes (DUR-81-6). |
| `roadmap/v0.81.2.md` | DVM Semantic Fidelity Gate | Enforces PostgreSQL semantics across DIFFERENTIAL and IMMEDIATE results: set-operation multiplicity, NULL-safe aggregates, scalar/LATERAL correctness, volatility gating, circular monotonicity, and row identity. |
| `roadmap/v0.81.3.md` | Catalog, Privilege & Upgrade Integrity | Makes fresh installs, upgraded installs, documented role setups, backup/restore, and every mutating SQL API agree on one enforceable contract. Includes real binary upgrade verification and release-version equality. |
| `roadmap/v0.81.4.md` | Scheduler & Resource Resilience Gate | Makes the in-process scheduler predictable under concurrency, multiple databases, blocked queries, crashes, large catalogs, and adversarial input. The final single-node gate before external-worker coordination. |

### roadmap/v0.82.0.md

- Adds a `Blocked by` reference to v0.81.4 to enforce the gate ordering.

## Motivation

The v0.81.0 release delivered observability and ergonomic wins, but a
post-release audit identified several classes of correctness and resilience
issues:

- **Frontier/CDC paths** that can acknowledge or advance past committed changes
  without durability guarantees.
- **DVM semantic gaps** where DIFFERENTIAL produces results that differ from
  what PostgreSQL would return for the equivalent query.
- **Catalog and lifecycle inconsistencies** between fresh installs and upgrade
  paths, and gaps in privilege and restore contracts.
- **Scheduler brittleness** under real-world concurrency, multi-database
  deployments, crash scenarios, and resource pressure.

These are stop-the-line issues. Distributing an architecture that has these gaps
would compound them and make them significantly harder to fix. The four hardening
releases add no major user-facing capability; they are the proof boundary that
v0.82 must preserve.

## Type of change

- [x] Documentation / roadmap only (no production code changes)
