### PR TITLE
docs(roadmap): reshape v0.82–v1.0 around a product thesis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,46 +391,62 @@ and durability foundations that must be proven before v1.0.
 | [v0.79.0](roadmap/v0.79.0.md) | Code Quality, API Ergonomics & Security: remove unused-import suppressions in src/refresh/codegen.rs and src/refresh/merge/mod.rs module-by-module (Q-1), convert internal create/alter API implementations to typed parameter structs eliminating too-many-arguments in business logic (Q-2), replace global #![allow(dead_code)] with narrower per-module allowances on pgrx/export boundaries (Q-3), remove or #[deprecated] consume_slot_changes() replacing with clearly named status function (Q-4), add SQL convenience helpers create_stream_table_fast_append_only/set_stream_table_refresh_policy/set_stream_table_storage_policy (A-1), add first-class pause_stream_table/resume_stream_table wrappers (A-2), add/strengthen semgrep CI rules for dynamic SQL distinguishing identifier/literal/OID boundaries (S-1), emit runtime WARNING when source has RLS enabled at create_stream_table time (S-2), CI test inspecting SECURITY DEFINER trigger functions for SET search_path (S-3), cleanup chaos test forcing three consecutive DELETE failures with alert and status verification (D-3), dbt adapter compatibility matrix with alter/drop/rebuild flow and version matrix tests (T-5) | ✅ Released | Large | [Full details](roadmap/v0.79.0.md-full.md) |
 | [v0.80.0](roadmap/v0.80.0.md) | Operational Excellence, Documentation Completeness & Final v1.0 Gate: add DVM fallback/performance reason codes to refresh history and health output — CORRELATED_SUBQUERY_DELTA_QUADRATIC, CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK, REGEX_COMPLEXITY_CLASSIFIER_UNCERTAIN (O-1), add health_check() threshold alert when invalidation ring overflow count increases in recent time window (O-2), add cleanup backlog trend metrics integrated into pgt_metrics_summary (O-3), docs lint comparing #[pg_extern] exports with SQL_REFERENCE.md entries (DOC-1), create docs/DVM_SUPPORT_MATRIX.md with every query pattern, fallback behavior, IMMEDIATE restrictions, and known-unsupported forms including q12/q20 entries (DOC-2), operational rollback runbook (backup requirements, snapshot recommendation, restore path, why downgrades are unsafe) (U-1), document upgrade E2E cutoff policy prominently in CHANGELOG and release notes (U-2), CI gate documentation in CONTRIBUTING.md describing which workflows gate PRs (B-1), review-by dates on cargo-deny advisory suppressions and require cargo-deny in PR gates (B-2), fuzz test for DVM snapshot fingerprint cache stability under OpTree refactoring (P-5), document internal event trigger functions in ARCHITECTURE comments (A-3) | ✅ Released | Large | [Full details](roadmap/v0.80.0.md-full.md) |
 
-### Assessment-16 Scaling Arc and Pre-Scaling Hardening Gate (v0.81.x - v0.87.x)
+### Product Arc & Hardening Gate (v0.81.x – v0.87.x)
 
-Driven by the findings in the v0.80.0 vision audit
-([plans/PLAN_OVERALL_ASSESSMENT_16.md](plans/PLAN_OVERALL_ASSESSMENT_16.md)).
-The assessment identified 7 HIGH, 18 MEDIUM, and 12 LOW findings across
-architecture (single-process compute ceiling, change buffer I/O amplification,
-no state externalization), performance (no vectorized batch processing, SPI
-overhead per refresh, no incremental MERGE), ergonomics (no declarative DDL,
-no auto-schema-evolution, no configuration advisor), and observability (no
-OpenTelemetry traces, no commit-to-visible latency metric). This seven-minor-release
-arc implements the "Blueprint for Infinite Scaling" — transitioning pg_trickle
-from a world-class single-node extension to a distributed, auto-scaling IVM
-system capable of running on a developer laptop or a Kubernetes cluster.
+The core thing users are buying is not "distributed incremental computation".
+It is:
+
+> **"I have an expensive PostgreSQL query. Keep its result fresh automatically,
+> without hammering my database, and make it safe enough that I can forget about
+> it."**
+
+pg_trickle already has unusually broad SQL coverage, automatic FULL fallback,
+DAGs, repair tooling, observability, PgBouncer support and Citus support. This
+arc stops broadening the feature surface and turns that machinery into a
+polished product, in the order users actually care about: correctness, low
+impact on the primary database, freshness, normal SQL, predictability, easy
+troubleshooting, easy lifecycle, performance, zero babysitting, and a stable
+1.0 API.
 
 An August 2026 implementation audit after v0.81.0 found unresolved single-node
-correctness and resilience risks that must not be carried into a multi-process
-architecture. Four patch releases now form a mandatory pre-scaling gate. They
-add no major features: they make the existing frontier, CDC, DVM, SQL API,
-catalog, upgrade, scheduler, and resource contracts fail closed and prove them
-under adversarial concurrency. v0.82.0 is blocked until all four gates pass.
+correctness and resilience risks. Four patch releases now form a mandatory
+hardening gate. They add no features: they make the existing frontier, CDC,
+DVM, SQL API, catalog, upgrade, scheduler, and resource contracts fail closed
+and prove them under adversarial concurrency. **v0.82.0 is blocked until all
+four gates pass** — correctness is the first thing users care about, so nothing
+in the product arc ships on top of an unproven foundation.
 
-| Version | Theme | Status | Scope | Full details |
-|---------|-------|--------|-------|--------------|
-| [v0.81.0](roadmap/v0.81.0.md) | Observability, Self-Tuning & Quick Wins: commit-to-visible latency metric using pg_xact_commit_timestamp (QW-1), configuration advisor function pgtrickle.tune_recommendations() (QW-2), preview/dry-run mode pgtrickle.preview_stream_table() (QW-3), OpenTelemetry trace spans on scheduler_tick/refresh_cycle/delta_execute/merge_apply with OTLP export (QW-4), bounded LRU eviction on thread-local L0/L1 template caches (QW-5), DeltaOperator trait for extensible operator dispatch (QW-6), split config.rs into config/scheduler.rs + config/cdc.rs + config/dvm.rs + config/monitoring.rs (QW-7), self-healing circuit breaker with auto-remediation for OOM/lock-timeout/sustained-lag (QW-8), chunked MERGE for large deltas with configurable merge_batch_size GUC (QW-9), stream table presets ('real-time'/'batch'/'cost-optimized') (QW-10) | ✅ Released | Large | [Full details](roadmap/v0.81.0.md) |
-| [v0.81.1](roadmap/v0.81.1.md) | Frontier & CDC Durability Gate: one safe frontier contract for manual/scheduled refresh, backend_xid/xmin/2PC holdback, database/tick-scoped immutable worker bounds, snapshot-aligned FULL refresh, no blind WAL slot fast-forward, atomic WAL-to-trigger cutover, missing-buffer fail-closed repair, common TopK/fused/fallback finalization, honest sync/UNLOGGED crash semantics | Planned | Large | [Full details](roadmap/v0.81.1.md) |
-| [v0.81.2](roadmap/v0.81.2.md) | DVM Semantic Fidelity Gate: private set-operation state and exact ALL multiplicity, positional/NULL-safe branches, nullable SUM and statistical accumulator correctness, scalar cardinality errors, LATERAL identity/IMMEDIATE safety, fail-closed volatility and AST rewrites, sound circular monotonicity admission, collision-free composite row identity | Planned | Large | [Full details](roadmap/v0.81.2.md) |
-| [v0.81.3](roadmap/v0.81.3.md) | Catalog, Privilege & Upgrade Integrity: fresh/upgrade catalog parity, explicit SQL ACL/ownership matrix, typed identifier and snapshot provenance safety, typed bulk lifecycle APIs and complete CDC cleanup, truthful logical restore, real old-binary upgrades, tag/runtime version equality, checked numeric contracts, generated SQL reference contracts | Planned | Large | [Full details](roadmap/v0.81.3.md) |
-| [v0.81.4](roadmap/v0.81.4.md) | Scheduler & Resource Resilience Gate: authoritative worker limits and race-free tokens, database-scoped pause/health state, persistent drain, enforceable refresh deadlines, complete self-healing/error accounting, bounded queue/catalog maintenance, scheduler-safe metrics/alerts, API resource ceilings and real fuzz/property assurance | Planned | Large | [Full details](roadmap/v0.81.4.md) |
-| [v0.82.0](roadmap/v0.82.0.md) | External Worker Foundation: extract DVM + MERGE into standalone pg_trickle_worker binary connecting via tokio-postgres (MT-1), advisory-lock-based work claiming with heartbeat monitoring and automatic failover (MT-2), DiffContext decomposition into CdcContext/CacheContext/OptimizationContext (MT-7), pg_stat_pgtrickle virtual system view for per-ST cumulative statistics (MT-9), adaptive worker pool sizing based on CPU utilization and refresh queue depth (MT-10), worker registration table pgt_worker_registry with health monitoring | Planned | Large | [Full details](roadmap/v0.82.0.md) |
-| [v0.83.0](roadmap/v0.83.0.md) | Performance Pipeline & CDC Extraction: pipelined refresh execution with portal-based streaming overlapping delta SQL and MERGE application (MT-3), external CDC consumer binary pg_trickle_cdc subscribing to logical replication with zero trigger overhead (MT-4), shared-memory change buffer ring for hot sources >10K writes/s with table-based overflow (MT-5), auto-schema-evolution via DDL event trigger for additive source changes (MT-6), pg_trickle.cdc_mode='external' GUC for zero-write-path-impact mode | Planned | Large | [Full details](roadmap/v0.83.0.md) |
-| [v0.84.0](roadmap/v0.84.0.md) | Vectorized Compute & Adaptive Engine: vectorized aggregate path using Arrow-compatible columnar batches with SIMD operations for pure-aggregate STs (MT-8), incremental window function computation replacing partition-based recomputation with proper incremental algorithms for ROW_NUMBER/RANK/DENSE_RANK/LAG/LEAD (LT-7), cost-based operator scheduling reordering operators within delta queries based on estimated cardinality (LT-9), parallel delta computation fan-out for multi-source joins (PERF-O4) | Planned | Large | [Full details](roadmap/v0.84.0.md) |
-| [v0.85.0](roadmap/v0.85.0.md) | Kubernetes-Native Deployment: Kubernetes operator with StreamTableCluster CRD managing worker Deployments and HPA policies (LT-1), external change log backend supporting Kafka/NATS JetStream/local WAL files as intermediate storage (LT-2), declarative SQL syntax CREATE STREAM TABLE name AS SELECT via ProcessUtility_hook (LT-6), CDC consumer StatefulSet with exactly-once delivery, metrics adapter exposing CDC lag as Kubernetes custom metric for HPA | Planned | Very Large | [Full details](roadmap/v0.85.0.md) |
-| [v0.86.0](roadmap/v0.86.0.md) | Distributed Delta Computation: partitioned delta computation by source key ranges across multiple workers (LT-3), read-replica DVM execution running delta computation on streaming replicas and applying results to primary (LT-4), zero-copy change buffer protocol using shared memory and UNIX domain sockets for same-host transfer (LT-10), worker affinity and data locality optimization for partition-aligned scheduling | Planned | Very Large | [Full details](roadmap/v0.86.0.md) |
-| [v0.87.0](roadmap/v0.87.0.md) | Enterprise Federation & State Management: multi-cluster federation coordinating stream tables across PostgreSQL clusters with global DAG and cross-cluster frontier synchronization (LT-5), state checkpointing to object storage (S3/GCS) for disaster recovery independent of pg_basebackup (LT-8), global priority queue and resource governor for multi-database clusters, zero-config adaptive mode detection (laptop/server/production/kubernetes) | Planned | Very Large | [Full details](roadmap/v0.87.0.md) |
+The distributed work that previously occupied v0.82.0 and v0.85.0–v0.87.0
+(external workers, external CDC consumers, Kubernetes operators, cross-cluster
+federation, object-storage state) has moved to [Beyond v1.0](#beyond-v10). It
+is optional infrastructure for deployments that have genuinely outgrown one
+machine — not the path to 1.0.
+
+| Version | Theme | User promise | Status | Scope | Full details |
+|---------|-------|--------------|--------|-------|--------------|
+| [v0.81.0](roadmap/v0.81.0.md) | Observability, Self-Tuning & Quick Wins: commit-to-visible latency metric using pg_xact_commit_timestamp (QW-1), configuration advisor function pgtrickle.tune_recommendations() (QW-2), preview/dry-run mode pgtrickle.preview_stream_table() (QW-3), OpenTelemetry trace spans on scheduler_tick/refresh_cycle/delta_execute/merge_apply with OTLP export (QW-4), bounded LRU eviction on thread-local L0/L1 template caches (QW-5), DeltaOperator trait for extensible operator dispatch (QW-6), split config.rs into config/scheduler.rs + config/cdc.rs + config/dvm.rs + config/monitoring.rs (QW-7), self-healing circuit breaker with auto-remediation for OOM/lock-timeout/sustained-lag (QW-8), chunked MERGE for large deltas with configurable merge_batch_size GUC (QW-9), stream table presets ('real-time'/'batch'/'cost-optimized') (QW-10) | — | ✅ Released | Large | [Full details](roadmap/v0.81.0.md) |
+| [v0.81.1](roadmap/v0.81.1.md) | Frontier & CDC Durability Gate: one safe frontier contract for manual/scheduled refresh, backend_xid/xmin/2PC holdback, database/tick-scoped immutable worker bounds, snapshot-aligned FULL refresh, no blind WAL slot fast-forward, atomic WAL-to-trigger cutover, missing-buffer fail-closed repair, common TopK/fused/fallback finalization, honest sync/UNLOGGED crash semantics | "Can I trust this table?" | Planned | Large | [Full details](roadmap/v0.81.1.md) |
+| [v0.81.2](roadmap/v0.81.2.md) | DVM Semantic Fidelity Gate: private set-operation state and exact ALL multiplicity, positional/NULL-safe branches, nullable SUM and statistical accumulator correctness, scalar cardinality errors, LATERAL identity/IMMEDIATE safety, fail-closed volatility and AST rewrites, sound circular monotonicity admission, collision-free composite row identity | "Can I trust this table?" | Planned | Large | [Full details](roadmap/v0.81.2.md) |
+| [v0.81.3](roadmap/v0.81.3.md) | Catalog, Privilege & Upgrade Integrity: fresh/upgrade catalog parity, explicit SQL ACL/ownership matrix, typed identifier and snapshot provenance safety, typed bulk lifecycle APIs and complete CDC cleanup, truthful logical restore, real old-binary upgrades, tag/runtime version equality, checked numeric contracts, generated SQL reference contracts | "Can I trust this table?" | Planned | Large | [Full details](roadmap/v0.81.3.md) |
+| [v0.81.4](roadmap/v0.81.4.md) | Scheduler & Resource Resilience Gate: authoritative worker limits and race-free tokens, database-scoped pause/health state, persistent drain, enforceable refresh deadlines, complete self-healing/error accounting, bounded queue/catalog maintenance, scheduler-safe metrics/alerts, API resource ceilings and real fuzz/property assurance | "Can I trust this table?" | Planned | Large | [Full details](roadmap/v0.81.4.md) |
+| [v0.82.0](roadmap/v0.82.0.md) | Product UX & Transparency: declarative CREATE/ALTER/DROP STREAM TABLE via ProcessUtility_hook (UX-1), pgtrickle.explain() reporting refresh mode, estimated changed rows, dominant cost, expected refresh time, current lag, next refresh and FULL fallback threshold in human terms (UX-2), machine-readable "why did AUTO choose FULL?" reason codes on every FULL path (UX-3), creation-time warnings with HINTs for always-FULL queries, cost exceeding the refresh interval, RLS, missing replica identity and excessive write overhead (UX-4), pg_stat_pgtrickle statistics view (UX-5), lag and refresh-mode annotations in EXPLAIN output (UX-6) | "I understand what pg_trickle is doing." | Planned | Large | [Full details](roadmap/v0.82.0.md) |
+| [v0.83.0](roadmap/v0.83.0.md) | Low-Impact Refresh: pipelined refresh execution streaming delta rows through a cursor with per-batch MERGE, bounding peak memory and lock hold time (LOW-1), cheaper capture via statement-level batching, capture-time column pruning and trigger short-circuit for paused consumers (LOW-2), shared-memory change buffer ring for sources above 10K writes/s with table-based overflow (LOW-3), load-aware deferral, refresh spike smoothing, bounded concurrency and lock etiquette (LOW-4), a single memory_budget_mb bounding every accumulation point (LOW-5), and a published pgbench overhead benchmark wired into CI as a blocking regression gate (LOW-6) | "Keeping views fresh won't hurt my application." | Planned | Large | [Full details](roadmap/v0.83.0.md) |
+| [v0.84.0](roadmap/v0.84.0.md) | Fast Incremental Engine: vectorized aggregate path using Arrow-compatible columnar batches with SIMD operations for pure-aggregate STs (MT-8), incremental window function computation replacing partition-based recomputation with proper incremental algorithms for ROW_NUMBER/RANK/DENSE_RANK/LAG/LEAD (LT-7), cost-based operator scheduling reordering operators within delta queries based on estimated cardinality (LT-9), parallel delta computation fan-out for multi-source joins (PERF-O4), DiffContext decomposition into CdcContext/CacheContext/OptimizationContext (ENG-1) | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.84.0.md) |
+| [v0.85.0](roadmap/v0.85.0.md) | Freshness SLAs & Self-Tuning: target_freshness as the primary user-facing control with every scheduler knob demoted to an optional override (SLA-1), a closed-loop controller choosing refresh timing, DIFFERENTIAL vs FULL, batch size, concurrency, priority and deferral from measured cost (SLA-2), adaptive worker pool sizing driven by CPU utilization, queue depth and SLA risk (SLA-3), pgtrickle.freshness() plus sla_status in pg_stat_pgtrickle, health_check() and Prometheus/OTel (SLA-4), infeasible-SLA detection at creation and continuously thereafter (SLA-5), and an audit that retires the knobs users should not need (SLA-6) | "Tell it how fresh I need data; it figures out the rest." | Planned | Large | [Full details](roadmap/v0.85.0.md) |
+| [v0.86.0](roadmap/v0.86.0.md) | Lifecycle & Schema Evolution: safe ALTER STREAM TABLE ... AS with compatible/rebuildable/rejected classification and shadow-table swap (LC-1), automatic handling of additive source DDL with loud, actionable suspension for destructive changes (LC-2), tested pg_dump/pg_restore, PITR, pg_basebackup and replica promotion behavior (LC-3), database cloning that never steals the original's replication slots (LC-4), pgtrickle.preflight_upgrade() plus quiesce/resume (LC-5), pg_upgrade and extension-upgrade coverage in CI with active workloads (LC-6), and automatic CDC repair as the default path (LC-7) | "Production changes don't break my stream tables." | Planned | Large | [Full details](roadmap/v0.86.0.md) |
+| [v0.87.0](roadmap/v0.87.0.md) | Production Polish: zero-config profile detection for laptop/managed/dedicated instances (PP-1), an enforced ceiling and alert for every resource including predictable disk usage (PP-2), pg_stat_progress-style progress reporting for long operations (PP-3), an audited error surface where every message carries SQLSTATE, DETAIL and an actionable HINT (PP-4), shipped Grafana dashboard, alert rules and collector-validated OTel spans (PP-5), a simple role-based privilege model (PP-6), 72-hour soak, upgrade compatibility matrix and performance regression gates (PP-7), one-command install verified by smoke tests on every package (PP-8), then **feature freeze** | "I can confidently run this for years." | Planned | Large | [Full details](roadmap/v0.87.0.md) |
 
 ### Toward v1.0
 
+After v0.87.0 the project stops adding features. No v0.88, v0.89 or v0.90 gets
+invented to fill the space before 1.0. The remaining pre-1.0 period is spent on
+**bugs → benchmarks → compatibility → upgrades → docs → real-world workloads →
+simplification**, and the real 1.0 gate is *no known correctness issues and
+boring upgrades*.
+
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
-| [v1.0.0](roadmap/v1.0.0.md-full.md) | Stable release — PostgreSQL 19, package registries, signed artifacts, SBOMs, zero breaking changes | Planned | Large | [Full details](roadmap/v1.0.0.md-full.md) |
+| [v1.0.0](roadmap/v1.0.0.md-full.md) | Stability contract — no known correctness issues, boring upgrades, stable API/catalog/GUC surface, PostgreSQL 19, package registries, signed artifacts, SBOMs | Planned | Large | [Full details](roadmap/v1.0.0.md-full.md) |
 
 ### Beyond v1.0
 
@@ -441,6 +457,10 @@ under adversarial concurrency. v0.82.0 is blocked until all four gates pass.
 | [v1.3.0](roadmap/v1.3.0.md-full.md) | Core extraction (`pg_trickle_core`) | Planned | Large | [Full details](roadmap/v1.3.0.md-full.md) |
 | [v1.4.0](roadmap/v1.4.0.md-full.md) | PGlite WASM extension | Planned | Medium | [Full details](roadmap/v1.4.0.md-full.md) |
 | [v1.5.0](roadmap/v1.5.0.md-full.md) | PGlite reactive integration | Planned | Medium | [Full details](roadmap/v1.5.0.md-full.md) |
+| [v1.6.0](roadmap/v1.6.0.md-full.md) | Automatic query acceleration: planner-hook rewriting of ordinary queries onto existing, sufficiently fresh stream tables (QA-1…QA-6), off by default, cost-based, staleness-bounded, and fully disclosed in EXPLAIN | Planned | Large | [Full details](roadmap/v1.6.0.md-full.md) |
+| [v1.7.0](roadmap/v1.7.0.md-full.md) | Decoupled compute (optional): standalone pg_trickle_worker binary with advisory-lock work claiming and heartbeat failover (DC-1…DC-3), external pg_trickle_cdc logical-replication consumer with cdc_mode='external' for zero write-path impact (DC-4, DC-5), zero-copy same-host transfer (DC-6) | Planned | Very Large | [Full details](roadmap/v1.7.0.md-full.md) |
+| [v1.8.0](roadmap/v1.8.0.md-full.md) | Distributed delta computation & Kubernetes-native deployment (optional): partitioned delta computation by source key range, read-replica execution, worker affinity, external change log backend (DD-1…DD-4), StreamTableCluster CRD and operator with freshness-driven HPA (K8-1…K8-4) | Planned | Very Large | [Full details](roadmap/v1.8.0.md-full.md) |
+| [v1.9.0](roadmap/v1.9.0.md-full.md) | Federation & state management (speculative): multi-cluster federation with a global DAG and cross-cluster frontier synchronization (FD-1…FD-4), object-storage state checkpointing and a global resource governor (ST-1, ST-2) — built only if real users ask for it | Planned | Very Large | [Full details](roadmap/v1.9.0.md-full.md) |
 
 ## How these versions fit together
 
@@ -567,19 +587,21 @@ v0.81.3  ─── Catalog, privilege & upgrade integrity: schema parity, ACL ma
     │
 v0.81.4  ─── Scheduler & resource resilience gate: worker caps, database scoping, drain/deadlines, self-healing, bounded maintenance, adversarial assurance
     │
-v0.82    ─── External worker foundation: pg_trickle_worker binary, advisory lock coordination, adaptive pool sizing, pg_stat_pgtrickle view, DiffContext split
+v0.82    ─── Product UX & transparency: declarative CREATE/ALTER STREAM TABLE, pgtrickle.explain(), FULL-reason codes, creation-time warnings, pg_stat_pgtrickle
     │
-v0.83    ─── Performance pipeline & CDC extraction: pipelined refresh, external CDC consumer, shared-memory ring buffers, auto-schema-evolution
+v0.83    ─── Low-impact refresh: pipelined execution, cheaper capture, shared-memory ring buffers, backpressure, memory budget, overhead benchmark gate
     │
-v0.84    ─── Vectorized compute & adaptive engine: Arrow columnar batches, incremental window functions, cost-based operator scheduling, parallel fan-out
+v0.84    ─── Fast incremental engine: Arrow columnar batches, incremental window functions, cost-based operator scheduling, parallel fan-out
     │
-v0.85    ─── Kubernetes-native deployment: K8s operator + CRD, external change log (Kafka/NATS), declarative SQL syntax, HPA metrics adapter
+v0.85    ─── Freshness SLAs & self-tuning: target_freshness as the primary control, closed-loop controller, adaptive workers, freshness() reporting
     │
-v0.86    ─── Distributed delta computation: partitioned deltas across workers, read-replica execution, zero-copy shared-memory protocol
+v0.86    ─── Lifecycle & schema evolution: safe ALTER ... AS, auto schema evolution, PITR/dump/clone, preflight_upgrade(), automatic CDC repair
     │
-v0.87    ─── Enterprise federation & state management: multi-cluster federation, S3/GCS state checkpointing, global resource governor, zero-config adaptive mode
+v0.87    ─── Production polish: zero-config profiles, bounded resources, progress reporting, error-message audit, soak + regression gates, then feature freeze
     │
-v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
+v1.0.0   ─── Stability contract: no known correctness issues, boring upgrades, PostgreSQL 19, package registries, signed artifacts, SBOMs
+    │
+v1.6+    ─── Beyond 1.0 (optional/speculative): automatic query acceleration, decoupled compute, distributed deltas + Kubernetes, federation
 ```
 
 v0.1.0 through v0.27.0 build the complete core engine and harden it for
@@ -876,14 +898,21 @@ Operational runbooks for upgrade rollback and the upgrade E2E cutoff policy,
 CI gate documentation for contributors, and cargo-deny advisory review-by
 dates complete the pre-v1.0 checklist.
 
-**v0.81.0 through v0.87.0 form the Assessment-16-Driven Scaling Arc**, driven
-by the findings in the v0.80.0 vision audit
-(plans/PLAN_OVERALL_ASSESSMENT_16.md). Prior assessments established a strong
-single-node architecture, but the post-v0.81.0 implementation audit found
-correctness and resilience gaps that require explicit closure before that
-architecture is distributed. The broader arc implements the "Blueprint for
-Infinite Scaling" — a backward-compatible transition from a world-class
-single-node extension to a distributed, auto-scaling IVM system.
+**v0.81.0 through v0.87.0 form the Product Arc.** The engine is sound after 16
+assessment arcs, though the post-v0.81.0 implementation audit found correctness
+and resilience gaps that require explicit closure first. What is missing beyond
+those gaps is not capability but product: the machinery is broad, and the
+experience of using it is not yet as good as the machinery deserves. This arc
+therefore stops broadening the feature surface and turns pg_trickle into
+something a DBA installs, points at a query, and trusts.
+
+The product thesis for the arc:
+
+> **pg_trickle should become the best way to make expensive PostgreSQL queries
+> continuously cheap and fresh — while still feeling like PostgreSQL.**
+
+Not Kafka. Not Flink. Not a Kubernetes platform. Not a distributed database.
+Just an unusually powerful PostgreSQL extension.
 
 v0.81.0 delivers immediate observability and ergonomic wins: OpenTelemetry
 trace spans across the refresh hot path, a commit-to-visible latency metric
@@ -893,7 +922,7 @@ deltas, self-healing circuit breakers, and stream table presets for progressive
 disclosure.
 
 The post-v0.81.0 implementation audit adds a mandatory four-release hardening
-gate before scaling work begins. v0.81.1 closes frontier, CDC durability, WAL
+gate before the product arc begins. v0.81.1 closes frontier, CDC durability, WAL
 cutover, crash-recovery, and refresh-finalization paths that could skip or hide
 committed changes. v0.81.2 enforces PostgreSQL semantics in the existing DVM
 surface, including set operations, NULL aggregates, scalar and LATERAL
@@ -902,27 +931,43 @@ fresh and upgraded catalogs identical, defines the privilege boundary, repairs
 lifecycle and restore contracts, and verifies real binary upgrades and release
 versions. v0.81.4 makes scheduler concurrency, database scoping, drain,
 deadlines, remediation, maintenance, metrics, and resource bounds reliable
-under stress. These releases add no major user-facing capability; they are the
-proof boundary that v0.82 must preserve.
+under stress. These releases add no user-facing capability; they are the proof
+boundary that everything after them must preserve.
 
-v0.82.0 introduces the external worker foundation: a standalone
-`pg_trickle_worker` binary that connects via tokio-postgres, claims work via
-advisory locks, and computes deltas outside the PostgreSQL process. The
-in-process scheduler becomes a coordinator that dispatches to external workers
-when available. v0.83.0 eliminates write-path impact with an external CDC
-consumer binary (`pg_trickle_cdc`) that subscribes to logical replication
-without triggers, plus shared-memory ring buffers for hot sources and pipelined
-refresh execution. v0.84.0 introduces vectorized compute using Arrow-compatible
-columnar batches and proper incremental window function algorithms. v0.85.0
-delivers Kubernetes-native deployment with a CRD-based operator, external
-change log backends (Kafka/NATS), and declarative SQL syntax. v0.86.0 enables
-distributed delta computation across workers with partition-aligned scheduling
-and read-replica execution. v0.87.0 completes the arc with multi-cluster
-federation, object-storage state checkpointing, and the zero-config adaptive
-mode that detects deployment context (laptop/server/kubernetes) and configures
-behavior accordingly.
+v0.82.0 makes the system legible: declarative `CREATE STREAM TABLE`
+DDL, a `pgtrickle.explain()` function that answers in plain language what a
+stream table costs and how stale it is, a reason code behind every FULL refresh,
+creation-time warnings for expensive queries, and a `pg_stat_pgtrickle` view
+that ordinary monitoring tools already know how to read. v0.83.0 makes
+pg_trickle nearly invisible to OLTP: pipelined refresh execution, cheaper
+capture on the write path, shared-memory ring buffers for hot sources,
+backpressure that yields to the application, a single memory budget, and a
+published write-overhead benchmark enforced as a CI gate. v0.84.0 is the one
+release where deep complexity is justified, because all of it is inside the
+engine — vectorized aggregates, proper incremental window algorithms,
+cost-based delta planning and selective parallelism, targeting a 5–10×
+throughput improvement with no change to deployment or API.
 
-Each phase is backward-compatible: a developer laptop continues running
-pg_trickle as a single in-process extension with zero additional infrastructure.
-A production Kubernetes cluster deploys the full distributed topology with
-auto-scaling workers.
+v0.85.0 elevates freshness to the primary user-facing control: users state a
+`target_freshness` and a closed-loop controller derives the schedule, the
+DIFFERENTIAL/FULL decision, batch sizes, concurrency and priority, reporting
+whether the SLA is being met. v0.86.0 makes lifecycle boring — safe query
+changes, automatic handling of compatible source-schema changes, tested PITR,
+dump/restore, cloning and major upgrades, and a `preflight_upgrade()` function
+that tells a DBA whether it is safe to proceed. v0.87.0 is the "would a DBA
+recommend this?" release: excellent defaults, bounded resources, progress
+reporting, error messages with remediation, monitoring integration, a simple
+privilege model, soak and regression gates, and one-command install — followed
+by a feature freeze.
+
+**The distributed work has moved past 1.0.** External workers, external CDC
+consumers, Kubernetes operators, distributed delta computation, cross-cluster
+federation and object-storage state coordination now live in v1.7.0–v1.9.0.
+They remain designed and recorded, but they are optional infrastructure for
+deployments that have genuinely outgrown one machine, not the road to a stable
+release. Automatic query acceleration — recognizing that an existing fresh
+stream table can answer an ordinary query — is deliberately placed at v1.6.0
+for the same reason: optimizer integration is complicated and potentially
+surprising, and surprising a DBA is exactly what the 1.0 contract promises not
+to do.
+

--- a/plans/PLAN_OVERALL_ASSESSMENT_16.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_16.md
@@ -455,6 +455,14 @@ These items require minimal architectural change and deliver immediate value:
 
 ## 6. Version Mapping
 
+> **Superseded.** The v0.82.x–v0.87.x mapping below records this assessment's
+> original recommendation. The roadmap was subsequently reshaped around a
+> product thesis rather than a scaling thesis: v0.82.x–v0.87.x now cover product
+> UX, low-impact refresh, engine performance, freshness SLAs, lifecycle and
+> production polish, and the distributed items (MT-1, MT-2, MT-4, LT-1 through
+> LT-5, LT-8, LT-10) moved to v1.7.0–v1.9.0. See
+> [ROADMAP.md](../ROADMAP.md) for the current plan.
+
 The action plan maps to the following release schedule:
 
 | Version | Theme | Items |

--- a/roadmap/v0.82.0.md
+++ b/roadmap/v0.82.0.md
@@ -1,121 +1,159 @@
-# v0.82.0 — External Worker Foundation
+# v0.82.0 — Product UX & Transparency
 
-> **Status:** Planned  
-> **Scope:** Large  
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"I understand what pg_trickle is doing."*
 > **Blocked by:** [v0.81.1](v0.81.1.md), [v0.81.2](v0.81.2.md), [v0.81.3](v0.81.3.md), and [v0.81.4](v0.81.4.md)
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — MT-1, MT-2, MT-7, MT-9, MT-10
 
 ## Theme
 
-Introduce the ability to run DVM computation outside the PostgreSQL backend
-process. A standalone `pg_trickle_worker` binary connects via tokio-postgres,
-claims work via advisory locks, and computes deltas externally. The in-process
-scheduler becomes a coordinator that dispatches to external workers when
-available, falling back to in-process execution when not.
+pg_trickle already has unusually broad SQL coverage, automatic FULL fallback,
+DAGs, repair tooling, observability, PgBouncer support and Citus support. The
+remaining gap is not capability — it is **legibility**. A user who runs
+`create_stream_table()` today cannot easily answer: will this be incremental or
+FULL? how expensive is each refresh? how stale is the table right now? what
+will this cost my write path?
 
-This is the foundational architectural change that enables horizontal scaling
-in later releases. The system remains fully backward-compatible: deployments
-without external workers continue operating exactly as before.
+This release turns the existing machinery into a product surface. Everything
+here is user-facing: declarative DDL, a standard statistics view, and an
+`explain()` function that answers the questions users actually ask, in plain
+language, before and after they commit to a query.
 
-External-worker implementation starts only after the v0.81.1-v0.81.4
-pre-scaling gates prove the current single-node frontier, DVM, catalog,
-privilege, upgrade, scheduler, and resource contracts. The worker protocol must
-preserve those proven invariants rather than creating parallel implementations
-of refresh finalization, error accounting, or frontier selection.
+Work starts only after the v0.81.1–v0.81.4 pre-scaling gates prove the current
+frontier, DVM, catalog, privilege, upgrade, scheduler and resource contracts.
+Everything below reports on those contracts; none of it may create a parallel
+implementation of refresh finalization, error accounting or frontier selection.
 
 ## Items
+### UX-1: Declarative DDL — `CREATE STREAM TABLE` / `ALTER STREAM TABLE`
 
-### MT-1: External Worker Binary (`pg_trickle_worker`)
+Replace parameter-heavy function calls as the primary interface with SQL that
+looks like SQL, implemented via `ProcessUtility_hook`:
 
-A standalone Rust binary (`pg_trickle_worker`) in a new `crates/worker/` workspace
-member:
-- Connects to PostgreSQL via `tokio-postgres` (connection string from env/config)
-- Reads stream table metadata from `pgtrickle.pgt_stream_tables`
-- Claims assigned work from `pgtrickle.pgt_worker_jobs` via advisory locks
-- Reads change buffers via `COPY ... TO STDOUT (FORMAT binary)` for efficient
-  transfer
-- Computes delta SQL using the extracted DVM engine
-- Applies MERGE back to the stream table
-- Advances frontier and records refresh history
-- Stateless: all state lives in PostgreSQL catalog tables
-
-The worker is a single static binary suitable for Docker/Kubernetes deployment.
-
-### MT-2: Worker Coordination Protocol
-
-Advisory-lock-based work assignment:
-- Coordinator (in-process scheduler) inserts jobs into `pgt_worker_jobs` table
-  with `(pgt_id, assigned_at, heartbeat_at, worker_id)`
-- Workers claim jobs via `pg_try_advisory_xact_lock(pgt_id)`
-- Heartbeat: workers UPDATE `heartbeat_at` every 5s while processing
-- Timeout: coordinator reclaims jobs where `heartbeat_at < now() - 30s`
-- Failover: unclaimed/expired jobs fall back to in-process execution
-
-New catalog table: `pgtrickle.pgt_worker_registry`:
 ```sql
-CREATE TABLE pgtrickle.pgt_worker_registry (
-    worker_id UUID PRIMARY KEY,
-    hostname TEXT NOT NULL,
-    pid INTEGER NOT NULL,
-    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now(),
-    status TEXT NOT NULL DEFAULT 'active',
-    capabilities JSONB DEFAULT '{}'
-);
+CREATE STREAM TABLE sales_by_region AS
+SELECT region, SUM(amount) AS total
+FROM orders JOIN customers USING (customer_id)
+GROUP BY region
+WITH (refresh_interval = '5s', mode = 'differential');
+
+ALTER STREAM TABLE sales_by_region SET (refresh_interval = '30s');
+ALTER STREAM TABLE sales_by_region PAUSE;
+DROP STREAM TABLE sales_by_region;
 ```
 
-### MT-7: DiffContext Decomposition
+The function API (`pgtrickle.create_stream_table(...)`) remains supported and
+becomes the documented escape hatch for programmatic use. DDL is captured by
+`pg_dump` via the existing catalog-based dump support, so declarative syntax
+does not regress backup/restore.
 
-Split the 15-field `DiffContext` struct into focused sub-contexts:
-- `CdcContext` — frontier LSNs, source OIDs, CDC columns, key columns
-- `CacheContext` — CTE delta cache, scan pushed predicates, bypass tables
-- `OptimizationContext` — depth tracking, CTE counters, max limits
+### UX-2: `pgtrickle.explain(stream_table)` — the flagship diagnostic
 
-The top-level `DiffContext` composes these via delegation. This reduces
-cognitive load when working on individual subsystems and enables the external
-worker to construct only the contexts it needs.
+A single function that answers "what is this thing doing, and is that
+reasonable?" in human terms:
 
-### MT-9: `pg_stat_pgtrickle` System View
+```
+SELECT * FROM pgtrickle.explain('sales_by_region');
+```
 
-A virtual system view (similar to `pg_stat_user_tables`) exposing per-ST
-cumulative statistics:
+```
+ Refresh mode:            DIFFERENTIAL
+ Estimated changed rows:  2,400
+ Dominant cost:           orders → customers join (est. 78% of refresh time)
+ Expected refresh time:   ~40 ms
+ Current lag:             620 ms
+ Next scheduled refresh:  in 4.4 s
+ FULL fallback threshold: 50% of base rows changed
+ Write-path overhead:     ~3.1 µs per INSERT on orders (trigger CDC)
+```
+
+Output is available as a readable text form and as a structured `jsonb` form
+(`pgtrickle.explain_json()`) for tooling. It is built from data that already
+exists — the cost model summary, refresh history, OpTree classifier and CDC
+metrics — rather than new instrumentation.
+
+### UX-3: "Why did AUTO choose FULL?"
+
+Every FULL refresh that occurred under `mode = 'auto'` records a machine-readable
+reason code plus a one-sentence explanation, surfaced by `explain()` and by
+`pgtrickle.refresh_history`:
+
+| Reason code | Explanation shown to the user |
+|-------------|-------------------------------|
+| `DELTA_RATIO_EXCEEDED` | 62% of base rows changed; recomputing is cheaper than diffing |
+| `CORRELATED_SUBQUERY_DELTA_QUADRATIC` | Correlated subquery would scan the base table once per changed row |
+| `CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK` | CASE/IN-list aggregate shape is not provably incremental |
+| `SOURCE_TRUNCATED` | A source table was truncated; the change buffer cannot describe the transition |
+| `SCHEMA_CHANGED` | A source column used by the query changed type |
+| `FIRST_REFRESH` | Initial population |
+
+The reason codes shipped in v0.80.0 are extended to cover every FULL path, and
+a CI test asserts that no code path can trigger FULL without a reason code.
+
+### UX-4: Creation-time warnings for expensive or problematic queries
+
+`CREATE STREAM TABLE` and `preview_stream_table()` emit `WARNING`s at creation
+time, before the user has invested in the object:
+
+- query will always run FULL (with the reason)
+- estimated refresh cost exceeds the requested refresh interval
+- a source table has RLS enabled (already shipped in v0.79.0; folded into the
+  unified warning surface)
+- a source table has no primary key or replica identity
+- estimated write-path overhead exceeds a configurable threshold
+- the stream table would join more than `warn_join_sources` (default 6) sources
+
+Each warning includes a `HINT` with the concrete remediation, and the full set
+is returned by `preview_stream_table()` so users can see them without creating
+anything.
+
+### UX-5: `pg_stat_pgtrickle` statistics view
+
+A virtual system view modelled on `pg_stat_user_tables`, exposing per-stream-table
+cumulative statistics that standard monitoring tools (pgwatch, Datadog,
+pg_stat_monitor, Prometheus exporters) can scrape without bespoke queries:
+
 ```sql
 CREATE VIEW pgtrickle.pg_stat_pgtrickle AS
 SELECT
-    pgt_id,
-    schema_name,
-    table_name,
-    total_refreshes,
-    total_full_refreshes,
-    total_diff_refreshes,
+    pgt_id, schema_name, table_name,
+    total_refreshes, total_full_refreshes, total_diff_refreshes,
     total_delta_rows_processed,
-    avg_refresh_duration_ms,
-    p95_refresh_duration_ms,
-    p99_refresh_duration_ms,
-    last_refresh_at,
-    current_lag_estimate_ms,
-    last_error,
-    last_error_at
+    avg_refresh_duration_ms, p95_refresh_duration_ms, p99_refresh_duration_ms,
+    last_refresh_at, current_lag_ms, target_freshness_ms,
+    last_full_reason, last_error, last_error_at
 FROM pgtrickle.pgt_cost_model_summary
 JOIN pgtrickle.pgt_stream_tables USING (pgt_id);
 ```
 
-Compatible with standard PostgreSQL monitoring tools (pgwatch, Datadog,
-pg_stat_monitor).
+Counters reset semantics follow PostgreSQL conventions
+(`pgtrickle.stat_reset(pgt_id)`, `pgtrickle.stat_reset_all()`).
 
-### MT-10: Adaptive Worker Pool Sizing
+### UX-6: Freshness and cost in `EXPLAIN`
 
-Automatically adjust the effective number of refresh workers based on
-real-time metrics:
-- **CPU utilization** > 70%: reduce workers by 1 (avoid starving OLTP)
-- **Refresh queue depth** > 2× workers: add 1 worker (reduce lag)
-- **All workers idle** for 3 consecutive ticks: reduce to `min_workers`
-- **CDC lag** > 5× schedule interval: add workers up to `max_workers`
+Extend PostgreSQL's own `EXPLAIN` output for queries that read a stream table
+with a pg_trickle annotation line:
 
-New GUCs:
-- `pg_trickle.adaptive_workers = true` (enable/disable)
-- `pg_trickle.min_workers = 1` (floor)
-- `pg_trickle.max_workers = 8` (ceiling, bounded by max_worker_processes)
+```
+Seq Scan on sales_by_region  (cost=0.00..18.50 rows=850 width=44)
+  pg_trickle: lag 620 ms, last refresh 2026-06-04 10:31:02, mode DIFFERENTIAL
+```
 
-The adaptive algorithm runs once per scheduler tick with hysteresis to
-prevent oscillation (changes require 3 consecutive measurements).
+Enabled by `pg_trickle.explain_annotations = on` (default on). This makes
+staleness visible exactly where a developer is already looking when a number
+looks wrong.
+
+## Exit criteria
+
+- [ ] `CREATE/ALTER/DROP STREAM TABLE` supported; round-trips through
+      `pg_dump`/`pg_restore`; function API unchanged and still tested
+- [ ] `pgtrickle.explain()` returns all seven fields for every supported query
+      shape in the DVM support matrix
+- [ ] Every FULL refresh in the test suite carries a reason code; CI test asserts
+      no reason-code-free FULL path exists
+- [ ] Creation-time warnings fire for all six conditions, each with a `HINT`
+- [ ] `pg_stat_pgtrickle` documented in `SQL_REFERENCE.md` and covered by the
+      `pg_extern` docs lint
+- [ ] `EXPLAIN` annotation appears for stream-table scans and can be disabled
+- [ ] Docs: a "Understanding your stream table" guide built entirely around
+      `explain()` output

--- a/roadmap/v0.83.0.md
+++ b/roadmap/v0.83.0.md
@@ -1,114 +1,138 @@
-# v0.83.0 — Performance Pipeline & CDC Extraction
+# v0.83.0 — Low-Impact Refresh
 
-> **Status:** Planned  
-> **Scope:** Large  
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — MT-3, MT-4, MT-5, MT-6
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"Keeping views fresh won't hurt my application."*
 
 ## Theme
 
-Eliminate the two largest performance bottlenecks: synchronous write-path
-impact from trigger-based CDC, and materialization overhead from the
-full-delta-then-MERGE refresh pattern. This release introduces an external
-CDC consumer that removes trigger overhead entirely, shared-memory ring
-buffers for high-throughput sources, and pipelined refresh execution that
-overlaps delta computation with MERGE application.
+The single most common reason a DBA rejects an IVM extension is fear of what it
+does to the primary workload. This release makes that fear measurable and then
+removes it: capture overhead on the write path, refresh spikes that steal CPU
+from OLTP, long lock holds during MERGE, and unbounded memory on large deltas.
+
+The goal is stated as a number, not a vibe:
+
+> **Installing pg_trickle should have very little impact on normal
+> INSERT/UPDATE/DELETE latency**, and that claim is enforced by a benchmark gate
+> in CI rather than asserted in the README.
 
 ## Items
 
-### MT-3: Pipelined Refresh Execution
+### LOW-1: Pipelined refresh execution
 
-Replace the current pattern (materialize full delta → MERGE entire set) with
-a streaming pipeline:
-1. Execute delta SQL with a cursor/portal (no full materialization)
+Replace the current pattern (materialize the full delta, then MERGE the entire
+set) with a streaming pipeline:
+
+1. Execute the delta SQL through a cursor/portal — no full materialization
 2. Stream result rows in batches of `pipeline_batch_size` (default 4096)
-3. For each batch, generate and execute a partial MERGE statement
+3. Generate and execute a partial MERGE per batch
 4. Commit incrementally (one sub-transaction per batch)
 
 Benefits:
-- Peak memory reduced from O(delta_size) to O(batch_size)
-- First rows visible sooner (progressive freshness)
-- Lock hold time reduced (sub-transaction per batch)
-- Long deltas don't block other ST refreshes
 
-New GUC: `pg_trickle.pipeline_batch_size = 4096`
+- peak memory drops from O(delta_size) to O(batch_size)
+- lock hold time drops to one batch instead of one refresh
+- first rows become visible sooner (progressive freshness)
+- a large delta on one stream table no longer blocks every other refresh
 
-Implementation uses PostgreSQL's extended query protocol with named portals
-when executed via external workers (tokio-postgres), or SPI cursors for
-in-process mode.
+New GUC: `pg_trickle.pipeline_batch_size = 4096`. Implemented with SPI cursors
+in-process; falls back to the existing single-MERGE path when the delta is
+smaller than one batch.
 
-### MT-4: External CDC Consumer Binary (`pg_trickle_cdc`)
+### LOW-2: Cheaper capture on the write path
 
-A standalone Rust binary in `crates/cdc-consumer/`:
-- Subscribes to PostgreSQL logical replication using `pgoutput` protocol
-- Decodes WAL events and writes to change buffer tables (same schema as
-  trigger-based CDC)
-- Runs as a separate process — zero overhead on the PostgreSQL write path
-- Supports multiple publication subscriptions (one per source table or
-  grouped)
-- Tracks consumed LSN via replication protocol feedback (no separate
-  frontier table needed)
+Reduce the per-row cost paid by the application's own transactions:
 
-Deployment modes:
-- **Sidecar:** Same host as PostgreSQL, writes to change buffers directly
-- **Remote:** Separate host, writes via `COPY ... FROM STDIN (FORMAT binary)`
-- **Log-based:** Writes to an intermediate log (Kafka/NATS) instead of
-  PostgreSQL tables (foundation for v0.85.0)
+- **Statement-level batching.** Row triggers accumulate into a per-statement
+  transition buffer and write to the change buffer once per statement instead
+  of once per row, using transition tables where available.
+- **Column pruning at capture time.** Only columns referenced by the defining
+  query (plus key and CDC columns) are written to the change buffer. Wide tables
+  stop paying for columns nobody reads.
+- **Unlogged and shrinking change buffers.** Change buffers become candidates
+  for reduced WAL volume where durability semantics allow, with the existing
+  frontier/replay path unchanged.
+- **Trigger short-circuit.** When every consumer of a source is paused or
+  suspended, the trigger becomes a cheap no-op instead of a full capture.
 
-New GUC: `pg_trickle.cdc_mode = 'external'` (vs 'trigger' / 'wal' / 'auto')
+### LOW-3: Shared-memory change buffer ring for hot sources
 
-When `cdc_mode='external'`, the extension:
-- Does not create triggers on source tables
-- Does not create logical replication slots
-- Expects the external consumer to populate change buffers
-- Monitors buffer freshness and alerts if the consumer falls behind
-
-### MT-5: Shared-Memory Change Buffer Ring
-
-For hot sources (>10K writes/s), replace the table-based change buffer with
-a fixed-size ring buffer in PostgreSQL shared memory:
+For sources exceeding `ring_buffer_threshold_writes_per_sec` (default 10,000),
+capture writes into a fixed-size lock-free ring in PostgreSQL shared memory
+instead of a heap table:
 
 ```
-┌─────────────────────────────────────────────┐
-│ Shared Memory Ring Buffer (per source OID) │
-│ [slot 0][slot 1][slot 2]...[slot N-1]     │
-│  ^write_head              ^read_head       │
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│ Shared Memory Ring Buffer (per source OID)   │
+│ [slot 0][slot 1][slot 2] ... [slot N-1]      │
+│  ^write_head                    ^read_head   │
+└──────────────────────────────────────────────┘
 ```
 
-Characteristics:
-- Fixed-size: `pg_trickle.ring_buffer_slots = 65536` (per source)
-- Lock-free SPSC (single producer = trigger/CDC, single consumer = scheduler)
-- Each slot: `{action: u8, lsn: u64, row_data: [u8; MAX_ROW_SIZE]}`
-- Overflow: when ring is full, spill to table-based path and log warning
-- Zero WAL overhead: shared memory is not WAL-logged
-- Cleared on crash recovery (change buffers are replayed from WAL position)
+- fixed size: `pg_trickle.ring_buffer_slots = 65536` per source
+- single-producer/single-consumer, lock-free
+- no WAL volume: shared memory is not WAL-logged
+- overflow spills to the table-based path and logs a warning
+- cleared on crash recovery; the change buffer is rebuilt from the recorded
+  WAL position, so correctness does not depend on the ring surviving
 
-New GUC: `pg_trickle.ring_buffer_sources` (comma-separated OIDs or `'auto'`)
+New GUC: `pg_trickle.ring_buffer_sources` (comma-separated OIDs or `'auto'`).
 
-When `'auto'`, sources exceeding `ring_buffer_threshold_writes_per_sec`
-(default 10000) are automatically promoted to ring-buffer mode.
+### LOW-4: Backpressure and yielding to the application
 
-### MT-6: Auto-Schema-Evolution
+pg_trickle must be a well-behaved tenant of the database it lives in:
 
-When `pg_trickle.auto_evolve = true` (default false), DDL event triggers
-detect schema changes on source tables and automatically propagate safe
-changes:
+- **Load-aware deferral.** The scheduler samples backend count, lock waits and
+  CPU pressure; when the instance is under load it lengthens intervals and
+  defers non-urgent refreshes rather than competing with OLTP.
+- **Refresh spike smoothing.** Stream tables due at the same instant are
+  jittered and rate-limited so a fleet of 5-second tables does not produce a
+  synchronized stampede every 5 seconds.
+- **Bounded concurrency.** A global cap on concurrently refreshing stream
+  tables, independent of worker count, with a fair queue so one expensive table
+  cannot starve the rest.
+- **Lock etiquette.** All refresh statements run with a bounded
+  `lock_timeout`/`statement_timeout` derived from the refresh interval; a
+  refresh that cannot acquire its locks yields and retries instead of blocking
+  application transactions.
 
-**Additive changes (automatic):**
-- `ALTER TABLE ... ADD COLUMN` → rewrite defining query if `SELECT *`,
-  ALTER stream table, mark for reinitialize
-- `ALTER TABLE ... ADD CONSTRAINT` → no-op (constraints don't affect ST)
+### LOW-5: Bounded memory, end to end
 
-**Destructive changes (alert + suspend):**
-- `ALTER TABLE ... DROP COLUMN` used in defining query → suspend ST,
-  alert via NOTIFY, log to health_check()
-- `ALTER TABLE ... ALTER COLUMN TYPE` on used column → suspend ST,
-  require manual intervention
+Every unbounded accumulation point gets an explicit ceiling and an observable
+counter: delta materialization (LOW-1), change buffer growth per source, the
+invalidation ring, template/plan caches (bounded in v0.81.0), and the DAG
+scheduling queue. A single GUC, `pg_trickle.memory_budget_mb`, sizes them
+together, and `health_check()` reports which component is closest to its bound.
 
-**Transparent changes (no action):**
-- `CREATE INDEX` / `DROP INDEX` on source → no-op
-- `ALTER TABLE ... SET STATISTICS` → no-op
-- `COMMENT ON COLUMN` → no-op
+### LOW-6: The overhead benchmark, as a CI gate
 
-All automated actions are logged to `pgt_refresh_history` with reason code
-`AUTO_SCHEMA_EVOLUTION` and the specific DDL that triggered the change.
+A `pgbench`-based harness measures p50/p95/p99 latency and TPS on a standard
+OLTP workload in three configurations: extension absent, extension installed
+with no stream tables, and extension installed with a realistic set of stream
+tables over the benchmarked tables.
+
+Published, versioned results plus a regression gate:
+
+| Metric | Gate |
+|--------|------|
+| TPS with extension installed, no stream tables | ≥ 99% of baseline |
+| p99 write latency with stream tables over hot tables | within a documented, enforced budget |
+| Refresh CPU share under sustained OLTP load | bounded and reported |
+
+The exact budgets are set from the first measured run and then defended; the
+release does not ship until the numbers are published in `docs/`.
+
+## Exit criteria
+
+- [ ] Pipelined refresh is the default path for deltas larger than one batch;
+      peak RSS during a 10M-row delta is bounded by `pipeline_batch_size`
+- [ ] Statement-level batching and column pruning are on by default; write-path
+      microbenchmark shows the improvement versus v0.82.0
+- [ ] Ring buffer auto-promotes hot sources and demotes them cleanly; crash
+      recovery test proves no lost changes
+- [ ] Scheduler defers under synthetic OLTP load and recovers when load drops
+- [ ] `pg_trickle.memory_budget_mb` bounds all five accumulation points;
+      `health_check()` names the closest one
+- [ ] Overhead benchmark published in `docs/`, wired into CI as a blocking
+      regression gate

--- a/roadmap/v0.84.0.md
+++ b/roadmap/v0.84.0.md
@@ -1,8 +1,8 @@
-# v0.84.0 — Vectorized Compute & Adaptive Engine
+# v0.84.0 — Fast Incremental Engine
 
-> **Status:** Planned  
-> **Scope:** Large  
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — MT-8, LT-7, LT-9, PERF-O4
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"One PostgreSQL instance can handle a lot."*
 
 ## Theme
 
@@ -11,6 +11,10 @@ proper incremental algorithms for window functions (replacing partition-based
 recomputation), and cost-based operator scheduling within delta queries. This
 release targets a 5–10× throughput improvement for aggregate-heavy and
 window-function-heavy workloads.
+
+This is the one place where deep complexity is justified, because all of it is
+**inside the engine**. Users get the same extension, the same PostgreSQL, the
+same SQL — just faster. Nothing here changes deployment, topology or the API.
 
 ## Items
 
@@ -103,3 +107,30 @@ Implementation:
   consistency group, (c) `pg_trickle.parallel_delta_fan_out = true`
 
 New GUC: `pg_trickle.parallel_delta_fan_out = false` (opt-in, requires testing)
+
+### ENG-1: `DiffContext` Decomposition
+
+Split the 15-field `DiffContext` struct into focused sub-contexts so the engine
+work above lands in code that can be reasoned about:
+
+- `CdcContext` — frontier LSNs, source OIDs, CDC columns, key columns
+- `CacheContext` — CTE delta cache, scan-pushed predicates, bypass tables
+- `OptimizationContext` — depth tracking, CTE counters, max limits
+
+The top-level `DiffContext` composes these via delegation, so no call sites
+change semantics. This is a prerequisite for the vectorized and parallel paths,
+which each need only a subset of the context.
+
+## Exit criteria
+
+- [ ] Vectorized aggregate path active for pure-aggregate stream tables; ≥5×
+      throughput on the aggregate benchmark versus v0.83.0, with identical
+      results verified against the FULL oracle
+- [ ] Incremental algorithms shipped for every window function in the table
+      above; unsupported frames fall back with a reason code
+- [ ] Cost-based operator scheduling on by default; `explain_delta_plan()` shows
+      the chosen order; no plan regression on the TPC-H suite
+- [ ] Parallel fan-out validated for multi-source joins and correct under the
+      DVM delta-invariant validator
+- [ ] `DiffContext` decomposed; no behavioural change in the E2E suite
+

--- a/roadmap/v0.85.0.md
+++ b/roadmap/v0.85.0.md
@@ -1,160 +1,134 @@
-# v0.85.0 — Kubernetes-Native Deployment
+# v0.85.0 — Freshness SLAs & Self-Tuning
 
-> **Status:** Planned  
-> **Scope:** Very Large  
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — LT-1, LT-2, LT-6
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"Tell it how fresh I need data; it figures out the rest."*
 
 ## Theme
 
-Enable pg_trickle to run as a fully managed, auto-scaling system on
-Kubernetes. A custom operator manages worker deployments, CDC consumers,
-and HPA policies via Custom Resource Definitions. An external change log
-backend (Kafka, NATS JetStream, or local WAL files) provides durable,
-distributed change event storage. Declarative SQL syntax makes stream table
-creation feel native to PostgreSQL.
+Users do not want to reason about scheduler intervals, batch sizes, worker
+counts and fallback thresholds. They want to say how stale the answer is
+allowed to be. This release elevates **freshness** to the primary user-facing
+control and demotes every other knob to an override.
+
+> **"Tell pg_trickle how fresh you need the answer, not how to schedule it."**
+
+This mirrors where the surrounding ecosystem has landed — PostgreSQL's own
+materialized views still require explicit `REFRESH MATERIALIZED VIEW`, while
+Timescale exposes continuous-aggregate refresh policies and Materialize exposes
+freshness and lag as first-class concepts. Freshness is the concept users
+already have; pg_trickle should accept it directly.
 
 ## Items
 
-### LT-1: Kubernetes Operator
-
-A Kubernetes operator (Rust, using `kube-rs` controller-runtime) that manages
-pg_trickle infrastructure:
-
-**Custom Resource Definitions:**
-
-```yaml
-apiVersion: trickle-labs.io/v1alpha1
-kind: StreamTableCluster
-metadata:
-  name: production
-spec:
-  postgresql:
-    host: pg-primary.default.svc
-    port: 5432
-    database: myapp
-    secretRef:
-      name: pg-credentials
-  workers:
-    min: 2
-    max: 32
-    targetCdcLagMs: 100
-    targetCpuPercent: 70
-    image: ghcr.io/trickle-labs/pg-trickle-worker:0.85.0
-  cdc:
-    mode: external
-    replicas: 1
-    logBackend: nats
-    nats:
-      url: nats://nats.default.svc:4222
-      stream: pgtrickle-changes
-  monitoring:
-    prometheus: true
-    serviceMonitor: true
-    otlp:
-      endpoint: otel-collector.monitoring.svc:4317
-```
-
-**Operator responsibilities:**
-- Deploys worker pods as a Deployment (stateless, horizontally scalable)
-- Deploys CDC consumer as a StatefulSet (one pod per replication slot)
-- Configures HPA based on CDC lag custom metric
-- Watches PostgreSQL catalog for new/dropped stream tables
-- Manages NATS/Kafka stream lifecycle
-- Health checks and automatic restart on failure
-- Graceful draining on pod termination (finish in-progress refresh)
-
-**Helm chart:** `charts/pg-trickle/` with values for common configurations.
-
-### LT-2: External Change Log Backend
-
-Support pluggable change log backends between CDC consumers and DVM workers:
-
-| Backend | Durability | Ordering | Deployment |
-|---------|-----------|----------|------------|
-| **PostgreSQL tables** (default) | WAL-logged | Per-source total order | Zero infrastructure |
-| **Local WAL files** | fsync'd | Per-source total order | Single-node, no external deps |
-| **NATS JetStream** | Replicated | Per-subject (source) order | Lightweight, K8s-native |
-| **Apache Kafka** | Replicated | Per-partition order | Enterprise, existing infra |
-
-**Change event format** (common across all backends):
-```json
-{
-  "source_oid": 16384,
-  "lsn": "0/1A3B4C0",
-  "xid": 12345,
-  "action": "INSERT",
-  "columns": {"id": 1, "name": "Alice", "amount": 100.00},
-  "old_columns": null,
-  "timestamp": "2026-05-30T12:00:00Z"
-}
-```
-
-**Backend interface trait** (in `crates/change-log/`):
-```rust
-#[async_trait]
-pub trait ChangeLogBackend: Send + Sync {
-    async fn publish(&self, source_oid: u32, events: &[ChangeEvent]) -> Result<()>;
-    async fn consume(&self, source_oid: u32, from_lsn: Lsn) -> Result<Vec<ChangeEvent>>;
-    async fn acknowledge(&self, source_oid: u32, up_to_lsn: Lsn) -> Result<()>;
-    async fn lag(&self, source_oid: u32) -> Result<Duration>;
-}
-```
-
-### LT-6: Declarative SQL Syntax
-
-Implement `CREATE STREAM TABLE` syntax via `ProcessUtility_hook`:
+### SLA-1: `target_freshness` as the primary control
 
 ```sql
--- Basic usage (mirrors CREATE MATERIALIZED VIEW)
-CREATE STREAM TABLE my_aggregates AS
-SELECT category, SUM(amount) as total
-FROM orders
-GROUP BY category
-WITH (schedule = '5s', refresh_mode = 'differential');
+CREATE STREAM TABLE sales_by_region AS
+SELECT region, SUM(amount) FROM orders GROUP BY region
+WITH (target_freshness = '2 seconds');
 
--- With explicit options
-CREATE STREAM TABLE IF NOT EXISTS realtime_dashboard AS
-SELECT ...
-WITH (
-    schedule = '1s',
-    refresh_mode = 'auto',
-    preset = 'real-time',
-    cdc_mode = 'external'
-);
-
--- ALTER syntax
-ALTER STREAM TABLE my_aggregates SET (schedule = '10s');
-ALTER STREAM TABLE my_aggregates SET QUERY AS SELECT ...;
-
--- DROP syntax
-DROP STREAM TABLE my_aggregates;
-DROP STREAM TABLE IF EXISTS my_aggregates CASCADE;
+ALTER STREAM TABLE sales_by_region SET (target_freshness = '1 minute');
 ```
 
-Implementation:
-- `ProcessUtility_hook` intercepts unrecognized utility statements
-- Parses `CREATE STREAM TABLE` / `ALTER STREAM TABLE` / `DROP STREAM TABLE`
-- Translates to corresponding `pgtrickle.*` function calls
-- Reports errors with standard PostgreSQL error formatting
-- `pg_dump` support via custom `COMMENT` tags (same as current approach)
-- Tab-completion in psql via `CREATE STREAM` prefix
+`target_freshness` is defined as the p95 age of the data visible in the stream
+table, measured commit-to-visible using the metric shipped in v0.81.0. When set,
+the scheduler owns every derived parameter and the explicit knobs
+(`refresh_interval`, batch sizes, concurrency) become optional overrides that
+are reported as such by `explain()`.
 
-### Metrics Adapter for HPA
+Special values: `'on_commit'` (existing IMMEDIATE mode) and `'manual'`
+(refresh only when asked).
 
-A lightweight sidecar (`pg_trickle_metrics_adapter`) that:
-- Queries `pgtrickle.pg_stat_pgtrickle` and Prometheus metrics
-- Exposes them as Kubernetes custom metrics via the Custom Metrics API
-- Enables HPA to scale workers based on:
-  - `pg_trickle_cdc_lag_p95_ms` (target: 100ms)
-  - `pg_trickle_parallel_queue_depth` (target: 0)
-  - `pg_trickle_worker_cpu_percent` (target: 70%)
+### SLA-2: The controller
 
-### CDC Consumer StatefulSet
+A closed-loop controller per stream table decides, once per scheduler tick:
 
-The `pg_trickle_cdc` binary deployed as a Kubernetes StatefulSet:
-- One pod per logical replication slot (stable network identity for slot)
-- Exactly-once delivery to the change log via two-phase acknowledgment
-- Automatic slot creation/drop on pod start/stop
-- Graceful handling of PostgreSQL failover (reconnect to new primary)
-- Liveness probe: slot lag not exceeding threshold
-- Readiness probe: consuming events (not blocked)
+- **when** to refresh (interval derived from observed refresh cost and inflow
+  rate, not a fixed timer)
+- **DIFFERENTIAL vs FULL**, using measured cost rather than a static delta-ratio
+  threshold
+- **batch size** for pipelined refresh, from observed row width and memory
+  budget
+- **concurrency**, within the global bound from v0.83.0
+- **priority**, so a 1-second SLA outranks a 1-hour SLA under contention
+- **whether to defer**, when the instance is overloaded (v0.83.0 backpressure)
+
+The controller uses hysteresis — a decision changes only after three consecutive
+consistent measurements — and its inputs and last decision are exposed in
+`explain()` so behaviour is never mysterious.
+
+### SLA-3: Adaptive worker pool sizing
+
+Replace the static worker count with automatic sizing driven by real signals:
+
+- CPU utilisation > 70% → reduce workers by one (do not starve OLTP)
+- refresh queue depth > 2× workers → add one worker
+- all workers idle for three consecutive ticks → shrink to `min_workers`
+- an SLA at risk of breach → add workers up to `max_workers`
+
+New GUCs: `pg_trickle.adaptive_workers = true`, `pg_trickle.min_workers = 1`,
+`pg_trickle.max_workers = 8` (bounded by `max_worker_processes`).
+
+### SLA-4: SLA reporting and alerting
+
+Freshness becomes a reported, checkable status rather than something users infer
+from timestamps:
+
+```
+SELECT * FROM pgtrickle.freshness();
+```
+
+```
+ stream_table      | target | p50    | p95    | p99    | status
+-------------------+--------+--------+--------+--------+---------------
+ sales_by_region   | 2s     | 310ms  | 730ms  | 1.4s   | meeting SLA
+ customer_360      | 5s     | 4.1s   | 9.8s   | 21s    | BREACHING
+```
+
+- `pg_stat_pgtrickle` gains `target_freshness_ms`, `p95_freshness_ms` and
+  `sla_status`
+- `health_check()` reports sustained breaches with the controller's diagnosis
+  (for example: *"refresh cost 8.2s exceeds 5s target; consider a coarser
+  target or reducing join breadth"*)
+- Prometheus/OTel metrics expose target, actual and breach duration
+
+### SLA-5: Infeasible SLA detection
+
+If a target can never be met — the cheapest possible refresh already costs more
+than the target — pg_trickle says so immediately at creation time rather than
+silently thrashing:
+
+```
+WARNING:  target_freshness '500 ms' is not achievable for this query
+DETAIL:   Minimum observed refresh cost is 3.4 s (dominated by orders → line_items join).
+HINT:     Use target_freshness >= '5 s', or narrow the defining query.
+```
+
+The same check runs continuously; a stream table whose workload has grown past
+feasibility is flagged in `health_check()` instead of consuming resources in a
+losing race.
+
+### SLA-6: Retire the knobs users should not need
+
+Every GUC and per-stream-table option is audited and classified as *user-facing*,
+*advanced override*, or *internal*. Internal knobs are removed or hidden;
+advanced overrides are documented as "only if the controller is wrong, and please
+tell us why". The documented configuration surface shrinks measurably, and the
+config advisor from v0.81.0 becomes a translator from workload description to
+`target_freshness` rather than a list of settings to hand-tune.
+
+## Exit criteria
+
+- [ ] `target_freshness` supported in `CREATE`/`ALTER STREAM TABLE`; explicit
+      knobs become optional overrides and are reported as such
+- [ ] Controller meets p95 targets for a mixed workload of 100 stream tables
+      across 1s/10s/1m targets in a soak test
+- [ ] Adaptive worker sizing demonstrated to shrink under OLTP load and grow
+      under SLA pressure, without oscillation
+- [ ] `pgtrickle.freshness()` and `sla_status` shipped, documented and exported
+      to Prometheus/OTel
+- [ ] Infeasible targets rejected with a warning at creation and flagged
+      continuously thereafter
+- [ ] Documented configuration surface reduced; every remaining user-facing GUC
+      justified in `docs/CONFIGURATION.md`

--- a/roadmap/v0.86.0.md
+++ b/roadmap/v0.86.0.md
@@ -1,140 +1,134 @@
-# v0.86.0 — Distributed Delta Computation
+# v0.86.0 — Lifecycle & Schema Evolution
 
-> **Status:** Planned  
-> **Scope:** Very Large  
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — LT-3, LT-4, LT-10
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"Production changes don't break my stream tables."*
 
 ## Theme
 
-Enable delta computation to be distributed across multiple worker processes,
-potentially on different hosts. Partitioned delta computation divides work by
-source key ranges; read-replica execution offloads compute entirely from the
-primary; and zero-copy shared-memory protocols minimize transfer overhead for
-co-located workers.
+An extension that works perfectly until the first PostgreSQL major upgrade is
+not production-ready. Neither is one that breaks when someone adds a column,
+restores a backup, clones a database into staging, or renames a schema.
+
+This release is dedicated entirely to making the boring, unavoidable operations
+of a real production database boring for pg_trickle too. Nothing here is a
+feature users will brag about; all of it is the reason they will still be
+running pg_trickle in three years.
 
 ## Items
 
-### LT-3: Partitioned Delta Computation
+### LC-1: Safe `ALTER STREAM TABLE ... AS <new query>`
 
-For large stream tables with high delta volume, partition the delta
-computation across multiple workers by source key ranges:
+Changing the defining query today means dropping and recreating. Instead:
 
-**Architecture:**
-```
-Source Table (partitioned by hash(id) into 8 ranges)
-    │
-    ├─ Range [0, 1B)   → Worker A (computes partial delta)
-    ├─ Range [1B, 2B)  → Worker B (computes partial delta)
-    ├─ Range [2B, 3B)  → Worker C (computes partial delta)
-    └─ ...
-         │
-         ▼
-    Coordinator merges partial deltas → final MERGE
-```
+1. Classify the change: **compatible** (same output schema and provably
+   compatible incremental plan), **rebuildable** (output schema changes, or the
+   plan changes such that existing state is invalid), or **rejected**
+2. Compatible changes swap the plan atomically, keeping existing state and
+   frontier — no repopulation, no visible gap
+3. Rebuildable changes populate a shadow table, then swap under a brief lock,
+   so readers never see a partially populated result
+4. `pgtrickle.explain_alter('st', $$new query$$)` reports the classification and
+   the estimated rebuild cost *before* the user runs it
 
-**Implementation:**
-1. **Partition assignment:** Coordinator divides change buffer rows by
-   hash(primary_key) % num_workers
-2. **Partial delta queries:** Each worker executes the delta SQL with a
-   `WHERE __pgt_pk_hash BETWEEN $1 AND $2` predicate pushed into the scan
-3. **Result assembly:** Workers write partial results to temp tables;
-   coordinator executes final MERGE from UNION ALL of partials
-4. **Consistency:** All workers see the same frontier (read from coordinator)
+### LC-2: Automatic handling of compatible source-schema changes
 
-**Requirements:**
-- Source table must have a primary key (for hash partitioning)
-- Stream table query must be partition-safe (no cross-partition dependencies
-  in aggregates — i.e., GROUP BY key must be a superset of partition key)
-- Worker count configurable per-ST: `ALTER STREAM TABLE ... SET (partitions = 4)`
+DDL event triggers detect source changes and act, controlled by
+`pg_trickle.auto_evolve` (default `true` for additive changes only):
 
-**Non-partition-safe fallback:** STs with cross-partition aggregates (e.g.,
-global SUM) use a two-phase approach: local partial aggregates → global
-combine step.
+**Automatic:**
+- `ADD COLUMN` — propagate when the defining query uses `SELECT *`; otherwise
+  no-op
+- `ADD CONSTRAINT`, `CREATE INDEX`, `DROP INDEX`, `SET STATISTICS`, `COMMENT` —
+  no-op
+- source table rename, schema move, ownership change — catalog references
+  updated in place
 
-### LT-4: Read-Replica DVM Execution
+**Suspend with a clear diagnosis:**
+- `DROP COLUMN` used by the defining query
+- `ALTER COLUMN TYPE` on a column used by the defining query
+- replica identity or primary key removal on a source
 
-Run delta computation on read replicas (streaming replication), applying
-only the final MERGE results to the primary:
+Suspension is loud and actionable: `NOTIFY`, `health_check()` entry, an entry in
+refresh history with reason `SCHEMA_INCOMPATIBLE`, and a `HINT` naming the exact
+`ALTER STREAM TABLE` that would resolve it. A suspended stream table stops
+refreshing but never serves silently wrong data.
 
-**Architecture:**
-```
-┌─────────────────────────┐
-│ Primary (writes only)   │
-│ • Source tables         │
-│ • Stream tables         │
-│ • Change buffers        │
-│ • Receives MERGE from   │
-│   replica workers       │
-└────────────┬────────────┘
-             │ streaming replication
-             ▼
-┌─────────────────────────┐
-│ Read Replica            │
-│ • Source tables (RO)    │
-│ • Change buffers (RO)   │
-│ • DVM Workers read here │
-│ • Delta computation     │
-│   (no writes to PG)     │
-└────────────┬────────────┘
-             │ delta results (via tokio-postgres to primary)
-             ▼
-┌─────────────────────────┐
-│ Primary                 │
-│ • MERGE delta into ST   │
-│ • Advance frontier      │
-└─────────────────────────┘
+### LC-3: Backup, restore and PITR
+
+- `pg_dump`/`pg_restore` round-trip for every catalog object, including
+  declarative DDL from v0.82.0, with a restore-time consistency check
+- documented and tested PITR behaviour: after a point-in-time restore, frontiers
+  are validated against the restored WAL position, and stream tables whose
+  frontier is ahead of the restored database are automatically marked for
+  reinitialisation rather than diverging silently
+- `pg_basebackup` and physical replica promotion covered by E2E tests
+- restoring a dump into a database without the extension yields ordinary tables
+  and a clear message, never a broken restore
+
+### LC-4: Database cloning and environment copies
+
+`CREATE DATABASE ... TEMPLATE`, dump/restore into staging, and logical copies
+are first-class: cloned stream tables detect that they are a clone (database
+identity changed), drop stale replication-slot bindings, and either resume with
+fresh CDC or suspend with an explicit message. No clone ever consumes the
+original's replication slots.
+
+### LC-5: `pgtrickle.preflight_upgrade()`
+
+One function a DBA runs before a PostgreSQL major upgrade or an extension
+upgrade, which answers "is this safe?":
+
+```sql
+SELECT * FROM pgtrickle.preflight_upgrade();
 ```
 
-**Benefits:**
-- Zero compute load on primary for delta SQL execution
-- Primary only handles the final MERGE (typically much smaller than delta)
-- Leverages existing streaming replication infrastructure
-- Change buffers are available on replica (WAL-replicated tables)
-
-**Challenges and solutions:**
-- **Replication lag:** Workers must wait for change buffer rows to be visible
-  on replica. Use `pg_last_wal_replay_lsn()` to detect readiness.
-- **Frontier coordination:** Frontiers are read from primary (via dedicated
-  connection), not from replica (which may be behind).
-- **Write conflict:** MERGE on primary must handle the case where source data
-  changed between replica read and primary write. Use SAVEPOINT + retry.
-
-### LT-10: Zero-Copy Change Buffer Protocol
-
-For workers co-located with PostgreSQL (same host, sidecar deployment), use
-shared memory and UNIX domain sockets for zero-copy transfer of change events:
-
-**Protocol:**
-1. CDC trigger/consumer writes change events to a memory-mapped file
-   (`/dev/shm/pgtrickle/changes_<oid>`)
-2. Worker maps the same file and reads events directly (no serialization)
-3. Coordination via futex-based signaling (producer signals consumer on write)
-4. Cleanup via reference counting (events freed when all consumers advance past)
-
-**Memory layout:**
 ```
-┌─────────────────────────────────────────────┐
-│ Header: magic, version, write_pos, read_pos │
-├─────────────────────────────────────────────┤
-│ Event[0]: lsn, action, data_offset, data_len│
-│ Event[1]: ...                                │
-│ ...                                          │
-├─────────────────────────────────────────────┤
-│ Data region (variable-length row payloads)  │
-└─────────────────────────────────────────────┘
+ check                            | status | detail
+----------------------------------+--------+-------------------------------------------
+ extension version supported      | OK     | 0.86.0 → 1.0.0 upgrade path exists
+ stream tables suspended          | WARN   | 1 suspended (customer_360) — resolve first
+ in-flight refreshes              | OK     | none
+ replication slots                | OK     | 3 slots, all active, max lag 1.2 MB
+ change buffer backlog            | WARN   | orders backlog 2.1M rows — drain recommended
+ catalog integrity                | OK     | 0 orphaned entries
+ disk headroom for rebuild        | OK     | 41 GB free, 3.2 GB estimated
 ```
 
-**Fallback:** When shared memory is unavailable (remote workers, different
-hosts), falls back to COPY BINARY protocol over TCP.
+Backed by a documented drain-and-quiesce procedure
+(`pgtrickle.quiesce()` / `pgtrickle.resume_all()`) so an upgrade window can be
+entered cleanly.
 
-### Worker Affinity & Data Locality
+### LC-6: PostgreSQL major upgrades and extension upgrades
 
-Optimize worker assignment based on data locality:
-- **Partition-aligned scheduling:** Assign workers to ST partitions that match
-  the source table's physical partition layout
-- **NUMA-aware:** On multi-socket systems, prefer workers on the same NUMA
-  node as the PostgreSQL shared buffers containing the relevant pages
-- **Sticky assignment:** Workers that previously processed an ST retain affinity
-  (warm caches, prepared statements) unless load balancing requires reassignment
-- **Cost-based rebalancing:** Periodically (every 60s) evaluate worker
-  utilization and rebalance assignments to equalize load
+- `pg_upgrade` across major versions covered end to end in CI, including a run
+  with active stream tables and a non-empty change buffer
+- extension upgrade E2E extended to cover every supported source version to the
+  release under test, with the existing cutoff policy documented in place
+- downgrade remains unsupported and is enforced with a clear error plus the
+  rollback runbook shipped in v0.80.0
+
+### LC-7: Automatic CDC repair
+
+When capture breaks — dropped replication slot, dropped trigger, a source
+restored out from under a stream table, WAL removed before it was consumed —
+pg_trickle detects it, reports it precisely, and where safe repairs it
+automatically by rebuilding capture and reinitialising affected stream tables.
+Where automatic repair is unsafe, it suspends and names the manual step. The
+existing repair tooling becomes the automatic path rather than a documented
+procedure the user has to find.
+
+## Exit criteria
+
+- [ ] `ALTER STREAM TABLE ... AS` supported for compatible and rebuildable
+      changes; `explain_alter()` classifies correctly for every DVM support
+      matrix entry
+- [ ] Additive source DDL flows through with no user action; destructive DDL
+      suspends with a named remediation; no path produces silently wrong data
+- [ ] PITR, `pg_basebackup`, replica promotion, `pg_dump`/`pg_restore` and
+      database cloning each covered by an E2E test
+- [ ] `preflight_upgrade()` shipped and referenced from the upgrade runbook
+- [ ] `pg_upgrade` major-version test green with active stream tables and a
+      non-empty change buffer
+- [ ] CDC break-and-repair chaos test: every injected failure is either
+      auto-repaired or suspended with an actionable message

--- a/roadmap/v0.87.0.md
+++ b/roadmap/v0.87.0.md
@@ -1,149 +1,129 @@
-# v0.87.0 — Enterprise Federation & State Management
+# v0.87.0 — Production Polish
 
-> **Status:** Planned  
-> **Scope:** Very Large  
-> **Driven by:** [Assessment 16](../plans/PLAN_OVERALL_ASSESSMENT_16.md) — LT-5, LT-8
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"I can confidently run this for years."*
 
 ## Theme
 
-Complete the distributed scaling arc with multi-cluster federation (stream
-tables spanning multiple PostgreSQL clusters), object-storage state
-checkpointing for disaster recovery, and the zero-config adaptive mode that
-detects deployment context and configures behavior automatically. This release
-establishes pg_trickle as a true enterprise-grade distributed IVM platform.
+The last feature release before 1.0. The question this release answers is not
+"what else can pg_trickle do?" but **"would a DBA recommend this to another
+DBA?"**
+
+Everything here is about defaults, bounds, diagnosis and packaging. No new
+capability, no new architecture, no distributed anything. After this release the
+project stops adding features and spends the remaining pre-1.0 period on bugs,
+benchmarks, compatibility, upgrades, docs, real-world workloads and
+simplification.
 
 ## Items
 
-### LT-5: Multi-Cluster Federation
+### PP-1: Defaults that are right without being tuned
 
-Coordinate stream tables across multiple PostgreSQL clusters with a global
-DAG and cross-cluster frontier synchronization:
+Ship a zero-config adaptive mode that detects the environment on first start —
+available memory, `max_worker_processes`, CPU count, whether the instance looks
+like a laptop, a modest managed instance, or a large dedicated server — and
+selects a coherent configuration profile rather than a set of independent
+defaults.
 
-**Architecture:**
-```
-┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
-│ Cluster A        │     │ Cluster B        │     │ Cluster C        │
-│ • Source: orders │     │ • Source: users  │     │ • ST: dashboard  │
-│ • ST: order_agg  │────▶│ • ST: user_stats │────▶│   (joins A + B)  │
-│   (local)        │     │   (local)        │     │   (federated)    │
-└──────────────────┘     └──────────────────┘     └──────────────────┘
-         │                        │                        │
-         └────────────────────────┴────────────────────────┘
-                          │
-                  ┌───────────────┐
-                  │ Federation    │
-                  │ Coordinator   │
-                  │ (global DAG)  │
-                  └───────────────┘
-```
+The chosen profile is reported (`pgtrickle.active_profile()`), explained in
+`explain()`, and fully overridable. The design constraint: **the out-of-the-box
+configuration should be the right answer for the large majority of installs**,
+and the config advisor should usually have nothing to suggest.
 
-**Components:**
-1. **Federation Coordinator:** A standalone service that maintains the global
-   DAG across clusters. Runs as a Kubernetes Deployment or standalone binary.
-2. **Cross-cluster change forwarding:** When Cluster A's `order_agg` ST is
-   refreshed, its change buffer events are forwarded to Cluster C via the
-   change log backend (Kafka/NATS).
-3. **Global frontier synchronization:** The coordinator tracks per-cluster
-   frontiers and ensures downstream clusters only process events up to the
-   consistent frontier of all upstream clusters.
-4. **Cluster discovery:** Clusters register with the coordinator via
-   `pgtrickle.register_federation(coordinator_url)`.
+### PP-2: Bounded resource consumption, proven
 
-**SQL API:**
-```sql
--- On Cluster C (consumer):
-SELECT pgtrickle.create_federated_stream_table(
-    'dashboard',
-    $$SELECT o.category, u.region, SUM(o.amount)
-      FROM cluster_a.order_agg o
-      JOIN cluster_b.user_stats u ON o.user_id = u.id
-      GROUP BY 1, 2$$,
-    sources => ARRAY[
-        'nats://coordinator/cluster_a/order_agg',
-        'nats://coordinator/cluster_b/user_stats'
-    ]
-);
-```
+Every resource pg_trickle consumes has a documented, enforced ceiling:
 
-**Consistency model:**
-- **Eventual consistency** (default): Each cluster refreshes independently;
-  cross-cluster joins may see temporarily inconsistent snapshots.
-- **Causal consistency** (opt-in): The coordinator enforces that downstream
-  clusters only see events that are causally consistent across all upstream
-  clusters. Adds latency equal to the slowest upstream cluster.
+| Resource | Bound |
+|----------|-------|
+| Memory | `pg_trickle.memory_budget_mb` (v0.83.0), enforced per component |
+| Background workers | `min_workers`..`max_workers` (v0.85.0) |
+| Disk (change buffers, history, state) | quota with retention policy and alert |
+| WAL generated | reported per source; capture-side reduction measured |
+| CPU share under load | bounded by the backpressure controller (v0.83.0) |
+| Connections | bounded, documented, PgBouncer-compatible |
 
-### LT-8: State Checkpointing to Object Storage
+Disk in particular becomes predictable: `pgtrickle.disk_usage()` reports current
+and projected usage per stream table, retention is enforced automatically, and
+`health_check()` warns before the trend crosses available headroom.
 
-Periodically checkpoint DVM state to S3/GCS for disaster recovery
-independent of pg_basebackup:
+### PP-3: Progress reporting
 
-**What is checkpointed:**
-- Stream table metadata (defining queries, schedules, configurations)
-- Frontier positions (per-source, per-ST)
-- Template cache (delta SQL templates, Aho-Corasick automata serialized)
-- DAG topology (edges, SCC groupings, diamond consistency groups)
-- Cost model summaries (refresh history aggregates)
-- Worker registry state
+Long operations report progress the way PostgreSQL does, via a
+`pg_stat_progress_pgtrickle`-style view: initial population, FULL refresh,
+rebuild after `ALTER`, reinitialisation after repair. Each reports phase, rows
+processed, rows estimated, and elapsed time. No more staring at a query that
+might be five seconds or five hours from finishing.
 
-**Checkpoint format:** A single JSONL file per checkpoint:
-```
-s3://my-bucket/pgtrickle/checkpoints/2026-05-30T12:00:00Z.jsonl.zst
-```
+### PP-4: Error messages that tell you what to do
 
-**Checkpoint lifecycle:**
-- Triggered every `pg_trickle.checkpoint_interval` (default 1h)
-- Also triggered before extension upgrade (`ALTER EXTENSION ... UPDATE`)
-- Retained for `pg_trickle.checkpoint_retention_days` (default 7)
-- Compressed with Zstandard (typically <1MB for 1000-ST deployments)
+An audit of every user-visible error and warning, held to a standard:
 
-**Recovery from checkpoint:**
-```sql
-SELECT pgtrickle.restore_from_checkpoint(
-    's3://my-bucket/pgtrickle/checkpoints/2026-05-30T12:00:00Z.jsonl.zst'
-);
-```
+- correct SQLSTATE (the rollout begun in earlier releases is completed)
+- `MESSAGE` states what failed, in the user's vocabulary
+- `DETAIL` gives the specific object, value or limit involved
+- `HINT` gives a concrete next action, and where possible the exact SQL
 
-This recreates all stream tables, dependencies, and configurations but marks
-all STs for `REINITIALIZE` (since the actual data may have diverged since the
-checkpoint). Useful for:
-- Restoring pg_trickle configuration after a database restore from a backup
-  that doesn't include the `pgtrickle` schema
-- Migrating pg_trickle state to a new PostgreSQL cluster
-- Disaster recovery when the primary is lost and only a replica (without
-  pg_trickle extension) is available
+Enforced by a CI lint over `ereport!` sites, and by a documented error-code
+reference generated from the source.
 
-### Global Priority Queue & Resource Governor
+### PP-5: Monitoring integration that works out of the box
 
-For multi-database PostgreSQL clusters (multi-tenant SaaS), implement a
-global resource governor:
+- Prometheus exposition covering the full metric set, with a shipped, tested
+  Grafana dashboard and alerting rules for the conditions that actually matter
+  (SLA breach, suspended stream table, CDC lag growth, disk trend, repeated FULL
+  fallback, backlog growth)
+- OpenTelemetry traces (v0.81.0) validated end to end against a real collector
+  in CI, with documented span names and attributes treated as a stable contract
+- `health_check()` as the single "is everything fine?" entry point, with a
+  documented, stable output schema suitable for automation
 
-**Architecture:**
-- Shared-memory priority queue across all per-database schedulers
-- Priority based on: (1) SLA tier, (2) current lag, (3) last refresh age
-- Global worker budget: `pg_trickle.global_max_workers` across all databases
-- Per-database quotas: `pg_trickle.per_db_max_workers` (default unlimited)
-- Priority preemption: HIGH-SLA STs can preempt LOW-SLA refreshes in progress
+### PP-6: A simple, auditable privilege model
 
-**GUCs:**
-- `pg_trickle.global_max_workers = 16`
-- `pg_trickle.per_db_max_workers = -1` (unlimited)
-- `pg_trickle.priority_preemption = false`
+One documented model for who can create, alter, refresh, pause and inspect
+stream tables, expressed with predefined roles (`pg_trickle_admin`,
+`pg_trickle_operator`, `pg_trickle_reader`) rather than a matrix of function
+grants. Includes the RLS interaction, `SECURITY DEFINER` boundaries, and what a
+non-superuser can and cannot do — with tests asserting each boundary.
 
-### Zero-Config Adaptive Mode
+### PP-7: Soak, compatibility and regression gates
 
-The system detects its deployment context and configures behavior
-automatically without any GUC changes:
+The testing that turns "it works" into "it keeps working":
 
-| Context | Detection Method | Auto-Configuration |
-|---------|-----------------|-------------------|
-| **Developer laptop** | `max_connections < 20` AND no `pgt_worker_registry` entries | 1 worker, trigger CDC, 5s interval, 32MB memory |
-| **Small server** | `max_connections < 100` AND no external workers | 4 workers, trigger CDC, 1s interval, 64MB memory |
-| **Production server** | External workers in `pgt_worker_registry` | Coordinator mode, dispatch to external workers |
-| **Kubernetes** | `PG_TRICKLE_K8S_MODE=true` env var OR operator CRD detected | Full distributed: external CDC, external workers, log backend |
+- **Long-running soak:** 72-hour multi-database run with schema changes,
+  restarts, failure injection and mixed SLAs; zero correctness deviations, no
+  unbounded growth in memory, disk or catalog size
+- **Upgrade compatibility matrix:** every supported source version upgraded to
+  the release under test, on every supported PostgreSQL version, with active
+  workloads
+- **Performance regression gates:** refresh throughput, write-path overhead
+  (v0.83.0) and TPC-H/Nexmark latencies gate PRs against published baselines
+- **Real-world workload suite:** a small set of realistic application schemas
+  and query shapes, run continuously, as the final sanity check that the
+  synthetic benchmarks are not lying
 
-**Override:** Any GUC explicitly set by the user takes precedence over
-adaptive detection. The adaptive mode only sets defaults for GUCs that are
-at their compile-time default values.
+### PP-8: Packaging and install experience
 
-**Reporting:** `SELECT pgtrickle.detected_mode()` returns the current adaptive
-mode and the reasoning for the detection.
+Install should be one command on every supported platform, and the extension
+should work immediately afterwards with no configuration:
+PGXN, apt/rpm via PGDG, Docker/GHCR images, CloudNativePG extension image, and a
+documented build-from-source path. Every package is verified by an install-smoke
+test in CI that creates a stream table and asserts it refreshes.
+
+## Exit criteria
+
+- [ ] Zero-config profile selection ships; the config advisor has no suggestions
+      for the standard benchmark environments
+- [ ] Every resource in the bounds table has an enforced ceiling and an alert
+- [ ] Progress view covers all four long operations
+- [ ] Error-message audit complete; CI lint blocks regressions; generated error
+      reference published
+- [ ] Grafana dashboard and alert rules shipped and tested; OTel spans validated
+      against a real collector in CI
+- [ ] Predefined roles shipped, documented, and boundary-tested
+- [ ] 72-hour soak green; upgrade matrix green; performance gates active
+- [ ] Install-smoke test green for every published package
+- [ ] **Feature freeze declared.** From this point to v1.0 the project accepts
+      bug fixes, documentation, tests, compatibility work and simplification
+      only.

--- a/roadmap/v1.0.0.md-full.md
+++ b/roadmap/v1.0.0.md-full.md
@@ -1,12 +1,37 @@
 > **See also:** [ROADMAP.md](../ROADMAP.md)
 
-## v1.0.0 — Stable Release
+## v1.0.0 — Stability Contract
+
+**User promise:** *"The product is now boring and dependable."*
 
 **Goal:** First officially supported release. Semantic versioning locks in.
 API, catalog schema, and GUC names are considered stable. Focus is
 distribution and trust: getting pg_trickle onto package registries, shipping
 signed artifacts and SBOMs with provenance, and proving PostgreSQL 19
 forward-compatibility.
+
+### The real 1.0 gate
+
+Packaging and signing are necessary but not sufficient. The gate that actually
+decides whether 1.0 ships is:
+
+> **No known correctness issues, and boring upgrades.**
+
+After the v0.87.0 feature freeze, the project accepts only bug fixes,
+documentation, tests, compatibility work and simplification. The pre-1.0 period
+is spent on **bugs → benchmarks → compatibility → upgrades → docs → real-world
+workloads → simplification** — deliberately not on inventing v0.88, v0.89 and
+v0.90 to fill the space.
+
+| Gate | Condition |
+|------|-----------|
+| G1 | Zero open correctness defects. Every known DVM limitation is either fixed or documented in `docs/DVM_SUPPORT_MATRIX.md` with a proven FULL fallback and a reason code. |
+| G2 | Upgrade from every supported prior version, on every supported PostgreSQL version, with an active workload — green, unattended, and documented. |
+| G3 | `pg_upgrade` across a PostgreSQL major version with active stream tables and a non-empty change buffer — green. |
+| G4 | 72-hour soak with schema changes, restarts and failure injection — zero correctness deviations, no unbounded growth. |
+| G5 | Published benchmarks (write-path overhead, refresh throughput, TPC-H/Nexmark) enforced as blocking regression gates. |
+| G6 | Documentation matches reality: every `#[pg_extern]` documented, every user-facing GUC justified, every claim in the README reproducible from a shipped test. |
+| G7 | API, catalog schema and GUC surface frozen; a compatibility test asserts no breaking change versus v0.87.0. |
 
 ### PostgreSQL 19 Forward-Compatibility (A3)
 
@@ -55,6 +80,7 @@ forward-compatibility.
 > **v1.0.0 total: ~46–86 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h + OTel/signing/SBOM/provenance/MDB ~12–20h)
 
 **Exit criteria:**
+- [ ] G1–G7: the stability-contract gates above are all met
 - [ ] A3: PG 19 builds and passes full E2E suite
 - [ ] CI matrix includes PG 19
 - [ ] Published on PGXN (stable) and apt/rpm via PGDG

--- a/roadmap/v1.6.0.md-full.md
+++ b/roadmap/v1.6.0.md-full.md
@@ -1,0 +1,51 @@
+> **See also:** [ROADMAP.md](../ROADMAP.md)
+
+## v1.6.0 — Automatic Query Acceleration
+
+> **Release Theme**
+> Today an application has to know that a stream table exists and query it by
+> name. This release lets the planner do that instead: when an ordinary query
+> can be answered by an existing, sufficiently fresh stream table, pg_trickle
+> rewrites it to read the stream table.
+>
+> Materialized-view query rewriting is a well-understood and widely requested
+> capability in other query engines, but it is deliberately placed **after
+> 1.0**: optimizer integration is both complicated and potentially surprising,
+> and surprising a DBA is exactly what the 1.0 contract promises not to do.
+
+### Concept
+
+```sql
+-- The user writes this:
+SELECT region, SUM(amount) FROM orders GROUP BY region;
+
+-- pg_trickle recognizes that sales_by_region already answers it,
+-- and (if fresh enough) rewrites the scan to read the stream table.
+```
+
+| Item | Description |
+|------|-------------|
+| QA-1 | **Subsumption matching.** Match an incoming query's parsed tree against the OpTree of every eligible stream table: exact match first, then containment (stream table computes a superset that can be filtered/re-aggregated). Reuse the existing OpTree classifier rather than a second query representation. |
+| QA-2 | **Planner hook integration.** Rewrite via `planner_hook`/`set_rel_pathlist_hook`, producing a *candidate path* costed against the original plan so the rewrite is only chosen when the planner agrees it is cheaper. |
+| QA-3 | **Freshness as a correctness precondition.** A rewrite is only legal when the stream table's current lag is within the session's tolerance: `pg_trickle.acceleration_max_staleness` (default `'0'` = only if provably up to date). Never trade correctness for speed silently. |
+| QA-4 | **Opt-in by default, per scope.** `pg_trickle.query_acceleration = off` globally at first; enable per database, per role, or per session. A stream table can opt out with `WITH (acceleration = false)`. |
+| QA-5 | **Explainability.** `EXPLAIN` states plainly when a rewrite happened and why: which stream table, what lag, what the alternative cost was. `pgtrickle.explain_acceleration(query)` answers "why was my query *not* accelerated?" for the cases where a user expected it. |
+| QA-6 | **Safety boundaries.** No rewrite when the query is inside a transaction that has already written to a source table, when RLS applies to the source but not the stream table, when the stream table is suspended, or when the query targets a source under an incompatible snapshot. Each boundary is a test. |
+
+### Why after 1.0
+
+- It changes plans for queries the user did not write against pg_trickle, which
+  is the highest-surprise thing an extension can do.
+- It requires the freshness contract from v0.85.0 to be mature and trusted.
+- It benefits from a stable OpTree representation, which the 1.0 API contract
+  provides.
+
+**Exit criteria:**
+- [ ] Exact and containment matching implemented over the OpTree classifier
+- [ ] Rewrite is cost-based; never applied when the original plan is cheaper
+- [ ] Staleness tolerance enforced; default configuration accelerates only
+      provably fresh reads
+- [ ] Off by default; opt-in per database/role/session and per stream table
+- [ ] `EXPLAIN` discloses every rewrite; `explain_acceleration()` explains
+      non-rewrites
+- [ ] Every safety boundary covered by a negative test

--- a/roadmap/v1.7.0.md-full.md
+++ b/roadmap/v1.7.0.md-full.md
@@ -1,0 +1,40 @@
+> **See also:** [ROADMAP.md](../ROADMAP.md)
+
+## v1.7.0 — Decoupled Compute
+
+> **Release Theme**
+> Move delta computation and change capture out of the PostgreSQL backend
+> process, so that a deployment which has genuinely outgrown one machine's CPU
+> can add compute without changing its SQL.
+>
+> This was originally planned for v0.82.0–v0.83.0 and has been moved past 1.0
+> deliberately. Pre-1.0 effort is better spent making a single PostgreSQL
+> instance go surprisingly far (v0.84.0) and making the product trustworthy
+> (v0.82.0, v0.83.0, v0.85.0–v0.87.0) than on a second process most users will
+> never deploy. Everything here remains **strictly optional**: a deployment
+> without external processes continues to work exactly as it does today.
+
+### External worker
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| DC-1 | **`pg_trickle_worker` binary.** A standalone Rust binary in `crates/worker/` that connects via `tokio-postgres`, reads stream table metadata from the catalog, reads change buffers via `COPY ... TO STDOUT (FORMAT binary)`, computes delta SQL with the extracted DVM engine, applies the MERGE, advances the frontier and records refresh history. Stateless — all state stays in PostgreSQL. Ships as a single static binary. | MT-1 |
+| DC-2 | **Coordination protocol.** The in-process scheduler becomes a coordinator: it inserts jobs into `pgtrickle.pgt_worker_jobs`; workers claim them with `pg_try_advisory_xact_lock(pgt_id)` and heartbeat every 5s; the coordinator reclaims jobs whose heartbeat is older than 30s; unclaimed or expired jobs fall back to in-process execution. New catalog table `pgtrickle.pgt_worker_registry` (`worker_id`, `hostname`, `pid`, `started_at`, `last_heartbeat`, `status`, `capabilities`). | MT-2 |
+| DC-3 | **Failover and fallback parity.** Every code path proven identical between in-process and external execution: same delta SQL, same MERGE, same reason codes, same freshness accounting. A property test runs the same workload both ways and asserts identical results. | — |
+
+### External change capture
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| DC-4 | **`pg_trickle_cdc` binary.** A standalone consumer in `crates/cdc-consumer/` that subscribes to logical replication using the `pgoutput` protocol, decodes WAL events and writes change buffers in the same schema as trigger-based capture. Zero work on the application's write path. Tracks the consumed LSN through replication feedback. Deployment modes: sidecar (same host) and remote (`COPY ... FROM STDIN (FORMAT binary)`). | MT-4 |
+| DC-5 | **`pg_trickle.cdc_mode = 'external'`.** When set, the extension creates no triggers and no slots of its own, expects the external consumer to populate change buffers, and monitors buffer freshness — alerting through `health_check()` if the consumer falls behind. | MT-4 |
+| DC-6 | **Zero-copy same-host transfer.** For a sidecar worker on the same host, move change buffer pages over shared memory and a UNIX domain socket instead of the PostgreSQL protocol. | LT-10 |
+
+**Exit criteria:**
+- [ ] External worker computes and applies deltas with results identical to
+      in-process execution across the full E2E suite
+- [ ] Worker crash mid-refresh is reclaimed and completed with no lost or
+      duplicated changes
+- [ ] `cdc_mode = 'external'` removes all trigger overhead, measured against the
+      v0.83.0 write-path benchmark
+- [ ] Deployments with no external processes are byte-for-byte unaffected

--- a/roadmap/v1.8.0.md-full.md
+++ b/roadmap/v1.8.0.md-full.md
@@ -1,0 +1,40 @@
+> **See also:** [ROADMAP.md](../ROADMAP.md)
+
+## v1.8.0 — Distributed Delta Computation & Kubernetes-Native Deployment
+
+> **Release Theme**
+> For the deployments that have outgrown a single worker process, distribute
+> delta computation across workers and make the resulting topology
+> operable on Kubernetes.
+>
+> Builds directly on v1.7.0. Like that release, everything here is optional
+> infrastructure: pg_trickle on a laptop remains a single extension with no
+> additional moving parts.
+
+### Distributed delta computation
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| DD-1 | **Partitioned delta computation.** Split a stream table's delta by source key ranges and compute each range on a different worker, merging the partial deltas before MERGE. Requires a partitionable key and an OpTree whose operators are provably decomposable over that key; falls back to single-worker computation otherwise, with a reason code. | LT-3 |
+| DD-2 | **Read-replica execution.** Run delta computation against a streaming replica and apply only the resulting MERGE to the primary, moving read-heavy delta SQL off the primary entirely. Correctness rests on comparing the replica's replay LSN against the stream table frontier and refusing to compute ahead of it. | LT-4 |
+| DD-3 | **Worker affinity and data locality.** Schedule partition-aligned work to the worker that already holds the relevant change buffer pages or replica connection, so distribution does not turn into a shuffle. | — |
+| DD-4 | **External change log backend.** Support Kafka, NATS JetStream or local WAL files as the intermediate transport between capture and compute, instead of change buffer tables — the durable substrate that makes multi-worker and cross-host topologies practical. | LT-2 |
+
+### Kubernetes-native deployment
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| K8-1 | **`StreamTableCluster` CRD and operator.** A Kubernetes operator that manages worker `Deployment`s, the CDC consumer `StatefulSet`, and their configuration from a single declarative resource. | LT-1 |
+| K8-2 | **Autoscaling on the right signal.** A metrics adapter exposing CDC lag and freshness-SLA headroom as Kubernetes custom metrics, so HPA scales workers on the thing users actually care about rather than CPU. | LT-1 |
+| K8-3 | **Exactly-once CDC delivery in the StatefulSet.** Consumer identity, slot ownership and restart semantics defined so that rescheduling a pod never duplicates or drops changes. | LT-2 |
+| K8-4 | **Operational surface.** Readiness/liveness semantics, rolling upgrades of workers without a freshness gap, and a documented failure matrix (pod evicted, node lost, network partition, PostgreSQL failover). | — |
+
+**Exit criteria:**
+- [ ] Partitioned computation produces results identical to single-worker
+      computation under the DVM delta-invariant validator
+- [ ] Read-replica execution never computes ahead of the replica's replay LSN;
+      proven by an injected-lag test
+- [ ] Operator manages the full topology from one CRD; chaos tests cover the
+      documented failure matrix
+- [ ] HPA scales on freshness headroom in a demonstrated load test
+- [ ] Single-node deployments remain unaffected and require none of this

--- a/roadmap/v1.9.0.md-full.md
+++ b/roadmap/v1.9.0.md-full.md
@@ -1,0 +1,55 @@
+> **See also:** [ROADMAP.md](../ROADMAP.md)
+
+## v1.9.0 — Federation & State Management
+
+> **Release Theme**
+> The furthest point on the distributed axis: stream tables that span multiple
+> PostgreSQL clusters, and state that can be checkpointed and recovered
+> independently of PostgreSQL's own backup machinery.
+>
+> This is explicitly the least certain item on the roadmap. It is recorded here
+> because the design work exists, not because it is committed. It will only be
+> built if real users ask for it — a single PostgreSQL instance, made fast
+> (v0.84.0) and trustworthy (v0.82.0–v0.87.0), covers the overwhelming majority
+> of the problem pg_trickle exists to solve.
+
+### Multi-cluster federation
+
+```
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│ Cluster A        │     │ Cluster B        │     │ Cluster C        │
+│ • Source: orders │     │ • Source: users  │     │ • ST: dashboard  │
+│ • ST: order_agg  │────▶│ • ST: user_stats │────▶│   (joins A + B)  │
+└──────────────────┘     └──────────────────┘     └──────────────────┘
+         │                        │                        │
+         └────────────────────────┴────────────────────────┘
+                                  │
+                        ┌───────────────────┐
+                        │ Federation        │
+                        │ Coordinator       │
+                        │ (global DAG)      │
+                        └───────────────────┘
+```
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| FD-1 | **Federation coordinator.** A standalone service maintaining the global DAG across clusters, deployable as a Kubernetes `Deployment` or a plain binary. Clusters register via `pgtrickle.register_federation(coordinator_url)`. | LT-5 |
+| FD-2 | **Cross-cluster change forwarding.** When an upstream cluster refreshes a stream table, its change events are forwarded downstream through the change log backend from v1.8.0. | LT-5 |
+| FD-3 | **Global frontier synchronization.** The coordinator tracks per-cluster frontiers so a downstream cluster only processes events up to the consistent frontier of all its upstreams — the existing single-cluster consistency guarantee, extended. | LT-5 |
+| FD-4 | **`create_federated_stream_table()`.** SQL API for defining a stream table whose sources live in other registered clusters. | LT-5 |
+
+### State management
+
+| Item | Description | Ref |
+|------|-------------|-----|
+| ST-1 | **Object-storage checkpointing.** Checkpoint stream table state and frontiers to S3/GCS for disaster recovery independent of `pg_basebackup`, with a documented restore path and a recovery-time objective measured in the test suite. | LT-8 |
+| ST-2 | **Global priority queue and resource governor.** Cross-database and cross-cluster scheduling that respects freshness SLAs (v0.85.0) globally rather than per database. | — |
+
+**Exit criteria:**
+- [ ] Federated stream tables produce results identical to the equivalent
+      single-cluster computation
+- [ ] Global frontier synchronization proven under injected cross-cluster lag
+      and partition
+- [ ] Object-storage checkpoint restore validated end to end with a measured RTO
+- [ ] Nothing in this release is required by, or affects, a single-cluster
+      deployment


### PR DESCRIPTION
## Summary

Reshapes the v0.82–v1.0 roadmap around a product thesis instead of a scaling thesis.

The old arc was built around external workers, external CDC consumers, Kubernetes operators, distributed delta computation and cross-cluster federation. That is not what the core user is buying. The core user is buying:

> "I have an expensive PostgreSQL query. Keep its result fresh automatically, without hammering my database, and make it safe enough that I can forget about it."

pg_trickle already has unusually broad SQL coverage, automatic FULL fallback, DAGs, repair tooling, observability, PgBouncer and Citus support. The arc now stops broadening the feature surface and turns that machinery into a polished product.

The v0.81.1–v0.81.4 hardening gates from #904 are unchanged and still block v0.82.0.

## New arc

| Release | Theme | User promise |
|---------|-------|--------------|
| v0.82.0 | Product UX & transparency | "I understand what pg_trickle is doing." |
| v0.83.0 | Low-impact refresh | "Keeping views fresh won't hurt my application." |
| v0.84.0 | Fast incremental engine | "One PostgreSQL instance can handle a lot." |
| v0.85.0 | Freshness SLAs & self-tuning | "Tell it how fresh I need data; it figures out the rest." |
| v0.86.0 | Lifecycle & schema evolution | "Production changes don't break my stream tables." |
| v0.87.0 | Production polish | "I can confidently run this for years." |
| v1.0.0 | Stability contract | "The product is now boring and dependable." |

Highlights:

- **v0.82.0** replaces the external-worker release entirely: declarative `CREATE`/`ALTER STREAM TABLE`, `pgtrickle.explain()` answering refresh mode, estimated changed rows, dominant cost, expected refresh time, lag, next refresh and FULL threshold in plain language, a reason code behind every FULL refresh, creation-time warnings with HINTs, `pg_stat_pgtrickle`, and lag annotations in `EXPLAIN`.
- **v0.83.0** keeps pipelined refresh execution and builds a whole release around low OLTP impact: cheaper capture, shared-memory ring buffers, backpressure, one memory budget, and a published pgbench overhead benchmark enforced as a blocking CI gate.
- **v0.84.0** is kept as planned and retitled. Vectorized aggregates, incremental window algorithms, cost-based delta planning and selective parallelism, plus the `DiffContext` decomposition and exit criteria.
- **v0.85.0** elevates freshness to the primary control: `target_freshness` with a closed-loop controller deriving schedule, DIFFERENTIAL/FULL, batch size, concurrency and priority; `pgtrickle.freshness()` reporting; infeasible-SLA detection; knob retirement.
- **v0.86.0** makes lifecycle boring: safe `ALTER ... AS`, auto schema evolution, PITR/dump/clone coverage, `pgtrickle.preflight_upgrade()`, automatic CDC repair.
- **v0.87.0** is the "would a DBA recommend this?" release, ending in a feature freeze.
- **v1.0.0** gains the real gate: no known correctness issues and boring upgrades (G1–G7).

## Moved to Beyond 1.0

| Release | Content |
|---------|---------|
| v1.6.0 | Automatic query acceleration (planner-hook rewrite onto fresh stream tables) |
| v1.7.0 | Decoupled compute: `pg_trickle_worker`, `pg_trickle_cdc`, zero-copy transfer |
| v1.8.0 | Distributed delta computation & Kubernetes-native deployment |
| v1.9.0 | Federation & state management (explicitly speculative) |

Nothing is deleted. All the distributed design work is preserved verbatim in the v1.7.0–v1.9.0 files, marked optional and clearly scoped to deployments that have genuinely outgrown one machine.

Query acceleration is placed after 1.0 deliberately: optimizer integration is complicated and potentially surprising, and surprising a DBA is what the 1.0 contract promises not to do.

## No filler releases

There is no v0.88, v0.89 or v0.90 invented to fill space. After the v0.87.0 freeze the remaining pre-1.0 period is bugs, benchmarks, compatibility, upgrades, docs, real-world workloads and simplification.

## Files

- `ROADMAP.md` — arc section, release tables, flow diagram, narrative
- `roadmap/v0.82.0.md`, `v0.83.0.md`, `v0.85.0.md`, `v0.86.0.md`, `v0.87.0.md` — rewritten
- `roadmap/v0.84.0.md` — retitled, `ENG-1` and exit criteria added
- `roadmap/v1.0.0.md-full.md` — stability-contract gates G1–G7
- `roadmap/v1.6.0.md-full.md`, `v1.7.0.md-full.md`, `v1.8.0.md-full.md`, `v1.9.0.md-full.md` — new
- `plans/PLAN_OVERALL_ASSESSMENT_16.md` — version mapping marked superseded, pointing at the current roadmap

Docs only. No code changes.
