### PR TITLE
chore(ci): extend benchmark timeout to 45 minutes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
   benchmark:
     name: Criterion benchmarks
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

Increase the Criterion benchmark job timeout from 20 to 45 minutes. The full benchmark suite repeatedly reached the previous hard limit before completing.

## Changes

- Set the benchmark job timeout to 45 minutes.

## Testing

- `git diff --check` — passes

## Notes

- This is a CI-only change; no application or extension code is modified.
