### PR TITLE
fix(ci): repair upgrade migration compatibility

### DIFF
--- a/sql/archive/pg_trickle--0.81.0.sql
+++ b/sql/archive/pg_trickle--0.81.0.sql
@@ -2651,7 +2651,6 @@ CREATE  FUNCTION pgtrickle."commit_latency_stats"() RETURNS TABLE (
         "min_ms" double precision,  /* f64 */
         "p50_ms" double precision,  /* f64 */
         "p95_ms" double precision,  /* f64 */
-        "p95_ms" double precision,  /* f64 */
         "max_ms" double precision,  /* f64 */
         "tracking_mode" TEXT  /* String */
 )

--- a/sql/archive/pg_trickle--0.81.1.sql
+++ b/sql/archive/pg_trickle--0.81.1.sql
@@ -2665,7 +2665,6 @@ CREATE  FUNCTION pgtrickle."commit_latency_stats"() RETURNS TABLE (
         "min_ms" double precision,  /* f64 */
         "p50_ms" double precision,  /* f64 */
         "p95_ms" double precision,  /* f64 */
-        "p95_ms" double precision,  /* f64 */
         "max_ms" double precision,  /* f64 */
         "tracking_mode" TEXT  /* String */
 )

--- a/sql/archive/pg_trickle--0.82.0.sql
+++ b/sql/archive/pg_trickle--0.82.0.sql
@@ -2687,7 +2687,6 @@ CREATE  FUNCTION pgtrickle."commit_latency_stats"() RETURNS TABLE (
         "min_ms" double precision,  /* f64 */
         "p50_ms" double precision,  /* f64 */
         "p95_ms" double precision,  /* f64 */
-        "p95_ms" double precision,  /* f64 */
         "max_ms" double precision,  /* f64 */
         "tracking_mode" TEXT  /* String */
 )

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1272,11 +1272,17 @@ fn handle_dropped_table(obj: &DroppedObject) {
             e,
         );
     }
-    if let Err(e) = Spi::run_with_args(
-        "DELETE FROM pgtrickle.pgt_change_buffers \
-         WHERE source_kind = 'BASE' AND source_id = $1",
-        &[i64::from(obj.objid.to_u32()).into()],
-    ) {
+    let registry_exists =
+        Spi::get_one::<bool>("SELECT to_regclass('pgtrickle.pgt_change_buffers') IS NOT NULL")
+            .unwrap_or(Some(false))
+            .unwrap_or(false);
+    if registry_exists
+        && let Err(e) = Spi::run_with_args(
+            "DELETE FROM pgtrickle.pgt_change_buffers \
+             WHERE source_kind = 'BASE' AND source_id = $1",
+            &[i64::from(obj.objid.to_u32()).into()],
+        )
+    {
         pgrx::warning!(
             "pg_trickle_ddl_tracker: failed to remove CDC registry row for {}: {}",
             identity,


### PR DESCRIPTION
## Summary

Fixes the upgrade E2E failures reported by CI run 31861919243. Historical install SQL had an invalid duplicate output parameter, and the current DDL hook queried a catalog table that does not exist when testing older extension targets.

## Changes

- Remove the duplicate `p95_ms` output from the 0.81.0, 0.81.1, and 0.82.0 archived install scripts.
- Guard the change-buffer registry cleanup in the DDL drop hook until the v0.82 catalog exists.

## Testing

- `just fmt && just lint` — passes
- `just test-unit` — 2,323 tests pass
- Archived SQL signature validation — passes

## Notes

The fixes are targeted at the two distinct failure signatures in the referenced workflow: duplicate `p95_ms` parameters and missing `pgtrickle.pgt_change_buffers`.
