### PR TITLE
fix(refresh): repair v0.85 release coverage

### DIFF
--- a/src/refresh/merge/mod.rs
+++ b/src/refresh/merge/mod.rs
@@ -360,7 +360,29 @@ pub fn execute_differential_refresh(
     prev_frontier: &Frontier,
     new_frontier: &Frontier,
 ) -> Result<(i64, i64), PgTrickleError> {
+    validate_differential_refresh_inputs(st, prev_frontier)?;
     execute_differential_refresh_with_tuning(st, prev_frontier, new_frontier, &st.runtime_tuning())
+}
+
+fn validate_differential_refresh_inputs(
+    st: &StreamTableMeta,
+    prev_frontier: &Frontier,
+) -> Result<(), PgTrickleError> {
+    if !st.is_populated {
+        return Err(PgTrickleError::InvalidArgument(format!(
+            "Cannot run DIFFERENTIAL refresh on unpopulated stream table {}.{}; a FULL refresh is required first.",
+            st.pgt_schema, st.pgt_name
+        )));
+    }
+
+    if prev_frontier.is_empty() {
+        return Err(PgTrickleError::InvalidArgument(format!(
+            "Cannot run DIFFERENTIAL refresh on {}.{}; no previous frontier exists.",
+            st.pgt_schema, st.pgt_name
+        )));
+    }
+
+    Ok(())
 }
 
 pub fn execute_differential_refresh_with_tuning(
@@ -369,24 +391,12 @@ pub fn execute_differential_refresh_with_tuning(
     new_frontier: &Frontier,
     tuning: &crate::catalog::RefreshRuntimeTuning,
 ) -> Result<(i64, i64), PgTrickleError> {
+    validate_differential_refresh_inputs(st, prev_frontier)?;
+
     let schema = &st.pgt_schema;
     let name = &st.pgt_name;
     // F10: record start time for OTLP span (nanoseconds since Unix epoch).
     let start_ns = crate::otel::now_ns();
-
-    if !st.is_populated {
-        return Err(PgTrickleError::InvalidArgument(format!(
-            "Cannot run DIFFERENTIAL refresh on unpopulated stream table {}.{}; a FULL refresh is required first.",
-            schema, name
-        )));
-    }
-
-    if prev_frontier.is_empty() {
-        return Err(PgTrickleError::InvalidArgument(format!(
-            "Cannot run DIFFERENTIAL refresh on {}.{}; no previous frontier exists.",
-            schema, name
-        )));
-    }
 
     let dependencies = StDependency::get_for_st(st.pgt_id)?;
     let _validated_buffers = crate::cdc::validate_required_change_buffers(st, &dependencies)?;


### PR DESCRIPTION
## Summary

Fixes the v0.85.0 coverage regression by validating differential-refresh preconditions before accessing PostgreSQL-backed GUC state.

## Changes

- Extract pure differential-refresh input validation.
- Run validation before runtime tuning and timing initialization.

## Testing

- `just lint` — passes.
- `just fmt` — passes.
- Focused unit test reaches the intended validation path; local macOS execution is blocked by the pgrx linker environment.

## Notes

The v0.85.0 release tag currently points to the prior v0.84.0 commit; it should be retargeted to the merged v0.85.0 commit after this fix lands.
