### PR TITLE
fix(ci): repair v0.85 workflow failures

### DIFF
--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -737,11 +737,11 @@ pub fn parse_test_decoding_action_for_fuzz(data: &str) -> Option<char> {
 fn parse_pgoutput_columns(data: &str) -> std::collections::HashMap<String, String> {
     let mut cols = std::collections::HashMap::new();
     let payload = if let Some(pos) = data.find("INSERT:") {
-        &data[pos + 8..]
+        data.get(pos + "INSERT:".len()..).unwrap_or("")
     } else if let Some(pos) = data.find("UPDATE:") {
-        &data[pos + 8..]
+        data.get(pos + "UPDATE:".len()..).unwrap_or("")
     } else if let Some(pos) = data.find("DELETE:") {
-        &data[pos + 8..]
+        data.get(pos + "DELETE:".len()..).unwrap_or("")
     } else {
         return cols;
     };
@@ -2618,6 +2618,13 @@ mod tests {
         let data = "BEGIN 12345";
         let cols = parse_pgoutput_columns(data);
         assert!(cols.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pgoutput_columns_truncated_action_marker() {
+        let data = format!("{}DELETE:", "x".repeat(24));
+        assert_eq!(data.len(), 31);
+        assert!(parse_pgoutput_columns(&data).is_empty());
     }
 
     // ── build_pk_hash_from_values tests ────────────────────────────

--- a/tests/e2e_bootstrap_gating_tests.rs
+++ b/tests/e2e_bootstrap_gating_tests.rs
@@ -598,9 +598,16 @@ async fn test_scheduler_logs_skip_when_source_gated() {
     db.execute("INSERT INTO sched_gate_src VALUES (2, 'trigger')")
         .await;
 
-    // Wait for at least one COMPLETED scheduler refresh.
+    // Wait for the scheduler to apply the CDC change. Checking the materialized
+    // row count avoids relying on data_timestamp precision when fast refreshes
+    // happen within the same timestamp value.
     let refreshed = db
-        .wait_for_auto_refresh("sched_gate_st", Duration::from_secs(60))
+        .wait_for_condition(
+            "sched_gate_st contains the CDC row",
+            "SELECT count(*) >= 2 FROM public.sched_gate_st",
+            Duration::from_secs(60),
+            Duration::from_millis(200),
+        )
         .await;
     assert!(
         refreshed,

--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -67,10 +67,11 @@ fn rf_count() -> usize {
 // signalling a DVM regression where a previously-passing query no longer
 // creates or runs correctly.
 //
-// DIFFERENTIAL: all 22 queries pass at SF<10. At SF≥10, queries with correlated
-//               scalar subqueries in WHERE clauses become quadratic in the DVM delta
-//               SQL and exceed the 90-minute nextest slow-timeout. Those queries are
-//               in LARGE_SCALE_DIFFERENTIAL_SKIP below and are skipped automatically.
+// DIFFERENTIAL: all 22 queries previously passed at SF<10. The v0.83+ fail-closed
+//               volatility admission currently makes q07/q08/q09 FULL-only, and
+//               queries with correlated scalar subqueries in WHERE clauses become
+//               quadratic in the DVM delta SQL at SF≥10. The latter are in
+//               LARGE_SCALE_DIFFERENTIAL_SKIP below and are skipped automatically.
 // IMMEDIATE:    a subset cannot be created (IVM restriction). Populate by
 //               running with the guard disabled, then hardening the set.
 //
@@ -82,7 +83,12 @@ fn rf_count() -> usize {
 const DIFFERENTIAL_SKIP_ALLOWLIST: &[&str] = &[
     // DI-11 deep-join planner hints (disable nestloop, raise work_mem,
     // bump join_collapse_limit, temp_file_limit=-1) resolved Q05/Q09.
-    // All 22 TPC-H queries pass DIFFERENTIAL mode at SF<10.
+    // v0.83+ fail-closed volatility admission: q07/q08/q09 use EXTRACT(YEAR
+    // FROM date), which resolves to immutable date_part(text,date), but the
+    // name-only overload check also sees the stable timestamptz overload.
+    // They remain intentionally FULL-only until overload-aware function
+    // volatility resolution is implemented.
+    "q07", "q08", "q09",
     // v0.77.0: q12 uses CASE aggregate + IN-list predicate and is currently
     // forced to FULL refresh by CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK.
     "q12",
@@ -1474,7 +1480,7 @@ async fn test_tpch_full_vs_differential() {
     );
 
     // P0.2: Minimum threshold — must pass at least as many as the non-skipped set.
-    // With 5 known DIFFERENTIAL skips, at least 15/22 should pass.
+    // Allow two additional skips beyond the known DIFFERENTIAL limitations.
     let min_passing = queries.len() - DIFFERENTIAL_SKIP_ALLOWLIST.len() - 2; // -2 tolerance
     assert!(
         passed >= min_passing,
@@ -1878,7 +1884,7 @@ async fn test_tpch_performance_comparison() {
     );
 
     // P0.2: Minimum threshold — at least 15 queries must be benchmarked
-    // (22 queries minus the 5 known DIFFERENTIAL skips minus 2 tolerance).
+    // (22 queries minus the known DIFFERENTIAL skips minus 2 tolerance).
     let min_benchmarked = queries.len() - DIFFERENTIAL_SKIP_ALLOWLIST.len() - 2;
     assert!(
         results.len() >= min_benchmarked,


### PR DESCRIPTION
## Summary

Fixes the three failing v0.85.0 workflows on `main`: WAL fuzz parsing, TPC-H differential skip drift, and the bootstrap-gating scheduler E2E test.

## Changes

- Make truncated pgoutput action markers safe and add a regression test.
- Allowlist q07, q08, and q09 as intentional FULL-only volatility cases with the root cause documented.
- Wait for the scheduler materialized row count instead of timestamp changes in the gating test.

## Testing

- `just fmt` — passes.
- `just lint` — passes.
- Affected E2E targets compile successfully.
- WAL fuzz smoke and minimized-input replay pass.
