### PR TITLE
fix(hooks): enforce fail-closed dependency inspection

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1259,6 +1259,15 @@ pg_trickle has DDL event triggers that listen for `ALTER TABLE` and `DROP TABLE`
 
 If the DDL change breaks the defining query (e.g., a column referenced in the query was dropped), the reinitialization will fail and the stream table will enter ERROR status. In that case, you need to drop and recreate the stream table with an updated query.
 
+Dependency inspection is deliberately **fail-closed**. PostgreSQL event
+triggers are database-wide, so pg_trickle must read
+`pgtrickle.pgt_dependencies` before it can determine whether an altered or
+dropped table is tracked. If that lookup cannot complete, for example because
+an `ACCESS EXCLUSIVE` lock causes `lock_timeout`, the originating DDL is
+aborted rather than risk missing a schema change and leaving CDC or a stream
+table inconsistent. This can temporarily block DDL on an unrelated table;
+retry the statement after the catalog contention clears.
+
 ### How do I check if a source table has switched from trigger-based CDC to WAL-based CDC?
 
 When you enable hybrid CDC (`pg_trickle.cdc_mode = 'auto'`), pg_trickle starts capturing changes with triggers and can automatically transition to WAL-based logical replication once conditions are met. There are several ways to check the current CDC mode for each source table:

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -791,28 +791,18 @@ fn handle_policy_change(cmd: &DdlCommand) {
 /// a ST storage table itself.
 fn handle_alter_table(objid: pg_sys::Oid, identity: &str) {
     // Check if this OID is an upstream source of any ST.
-    // SEC-3: Retry once on SPI error; escalate to pgrx::error!() on repeated failure
-    // so the originating ALTER TABLE is blocked rather than silently proceeding.
+    // Fail closed when relevance cannot be determined: allowing the DDL could
+    // leave a tracked source's CDC and downstream stream tables inconsistent.
     let affected_pgt_ids = match find_downstream_pgt_ids(objid) {
         Ok(ids) => ids,
         Err(e) => {
-            pgrx::warning!(
-                "pg_trickle_ddl_tracker: dependency query for {} failed ({}); retrying once",
+            pgrx::error!(
+                "pg_trickle: DDL hook could not inspect dependencies — \
+                 schema change blocked to prevent inconsistent state \
+                 (source: {}, error: {})",
                 identity,
                 e
             );
-            match find_downstream_pgt_ids(objid) {
-                Ok(ids) => ids,
-                Err(e2) => {
-                    pgrx::error!(
-                        "pg_trickle: DDL hook could not inspect dependencies — \
-                         schema change blocked to prevent inconsistent state \
-                         (source: {}, error: {})",
-                        identity,
-                        e2
-                    );
-                }
-            }
         }
     };
 
@@ -1300,12 +1290,12 @@ fn handle_dropped_table(obj: &DroppedObject) {
     let affected_pgt_ids = match find_downstream_pgt_ids(obj.objid) {
         Ok(ids) => ids,
         Err(e) => {
-            pgrx::warning!(
-                "pg_trickle_ddl_tracker: failed to query deps for dropped {}: {}",
+            pgrx::error!(
+                "pg_trickle: DROP TABLE hook could not inspect dependencies — \
+                 drop blocked to prevent inconsistent state (source: {}, error: {})",
                 identity,
-                e,
+                e
             );
-            return;
         }
     };
 

--- a/tests/e2e_ddl_event_tests.rs
+++ b/tests/e2e_ddl_event_tests.rs
@@ -10,9 +10,11 @@ mod e2e;
 use e2e::E2eDb;
 
 #[tokio::test]
-async fn test_ddl_hook_dependency_lookup_timeout_fails_closed() {
+async fn test_ddl_hooks_dependency_lookup_timeout_fail_closed() {
     let db = E2eDb::new().await.with_extension().await;
     db.execute("CREATE TABLE evt_lock_unrelated (id INT)").await;
+    db.execute("CREATE TABLE evt_lock_unrelated_drop (id INT)")
+        .await;
 
     let mut blocker = db.pool.acquire().await.expect("acquire blocker connection");
     sqlx::query("BEGIN")
@@ -24,16 +26,21 @@ async fn test_ddl_hook_dependency_lookup_timeout_fails_closed() {
         .await
         .expect("lock dependency catalog");
 
-    let blocked = db
-        .try_execute_with_config(
-            &["SET lock_timeout = '100ms'"],
+    for (kind, ddl) in [
+        (
+            "ALTER TABLE",
             "ALTER TABLE evt_lock_unrelated ADD COLUMN added INT",
-        )
-        .await;
-    assert!(
-        blocked.is_err(),
-        "DDL must fail closed when dependency relevance cannot be determined"
-    );
+        ),
+        ("DROP TABLE", "DROP TABLE evt_lock_unrelated_drop"),
+    ] {
+        let blocked = db
+            .try_execute_with_config(&["SET lock_timeout = '100ms'"], ddl)
+            .await;
+        assert!(
+            blocked.is_err(),
+            "{kind} must fail closed when dependency relevance cannot be determined"
+        );
+    }
 
     sqlx::query("ROLLBACK")
         .execute(&mut *blocker)
@@ -43,6 +50,7 @@ async fn test_ddl_hook_dependency_lookup_timeout_fails_closed() {
 
     db.execute("ALTER TABLE evt_lock_unrelated ADD COLUMN added INT")
         .await;
+    db.execute("DROP TABLE evt_lock_unrelated_drop").await;
 }
 
 #[tokio::test]

--- a/tests/e2e_ddl_event_tests.rs
+++ b/tests/e2e_ddl_event_tests.rs
@@ -10,6 +10,42 @@ mod e2e;
 use e2e::E2eDb;
 
 #[tokio::test]
+async fn test_ddl_hook_dependency_lookup_timeout_fails_closed() {
+    let db = E2eDb::new().await.with_extension().await;
+    db.execute("CREATE TABLE evt_lock_unrelated (id INT)").await;
+
+    let mut blocker = db.pool.acquire().await.expect("acquire blocker connection");
+    sqlx::query("BEGIN")
+        .execute(&mut *blocker)
+        .await
+        .expect("begin blocker transaction");
+    sqlx::query("LOCK TABLE pgtrickle.pgt_dependencies IN ACCESS EXCLUSIVE MODE")
+        .execute(&mut *blocker)
+        .await
+        .expect("lock dependency catalog");
+
+    let blocked = db
+        .try_execute_with_config(
+            &["SET lock_timeout = '100ms'"],
+            "ALTER TABLE evt_lock_unrelated ADD COLUMN added INT",
+        )
+        .await;
+    assert!(
+        blocked.is_err(),
+        "DDL must fail closed when dependency relevance cannot be determined"
+    );
+
+    sqlx::query("ROLLBACK")
+        .execute(&mut *blocker)
+        .await
+        .expect("release dependency catalog lock");
+    drop(blocker);
+
+    db.execute("ALTER TABLE evt_lock_unrelated ADD COLUMN added INT")
+        .await;
+}
+
+#[tokio::test]
 async fn test_drop_source_fires_event_trigger() {
     let db = E2eDb::new().await.with_extension().await;
 


### PR DESCRIPTION
## Summary

- make ALTER TABLE and DROP TABLE dependency-inspection failures consistently fail closed
- remove the ineffective same-transaction retry from the ALTER TABLE hook
- document the database-wide availability tradeoff and add a deterministic lock-timeout regression test

## Rationale

Issue #930 correctly identifies that pg_trickle's event trigger runs for unrelated DDL before it can know whether the target relation is tracked. The dependency lookup is therefore part of the correctness boundary: if pg_trickle cannot determine relevance, allowing the DDL could miss a schema change on a tracked source, leave its CDC trigger out of date, and leave downstream stream tables stale or inconsistent.

Failing open would trade correctness for DDL availability, contrary to pg_trickle's durability guarantees. This change keeps the fail-closed contract and makes it explicit for both ALTER TABLE and DROP TABLE.

The previous ALTER TABLE path retried `find_downstream_pgt_ids()` once after a returned SPI error. PostgreSQL execution errors such as permission failures and lock or statement timeouts are raised by SPI rather than returned through that Rust `Result`, so they already abort the originating DDL and do not enter the retry branch. Retrying a returned SPI failure immediately in the same transaction also provides no useful recovery window. The retry is removed so the code matches the actual contract and preserves the original contextual error for returned SPI failures.

The DROP TABLE path previously warned and returned for a returned SPI error. It now follows the same fail-closed policy as ALTER TABLE so a source drop cannot commit when dependency relevance is unknown.

Normal dependency catalog INSERT, UPDATE, and DELETE operations do not conflict with the hook's SELECT. The documented availability impact requires stronger catalog contention, such as an ACCESS EXCLUSIVE lock. The new two-session E2E test creates exactly that condition, verifies unrelated ALTER TABLE fails under `lock_timeout`, releases the lock, and verifies the same ALTER succeeds.

## Testing

- `just fmt`
- `just lint`
- `bash scripts/run_light_e2e_tests.sh --package --test e2e_ddl_event_tests` (23 passed)

Closes #930
