### PR TITLE
fix(security): resolve Semgrep code-scanning findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1460,6 +1460,25 @@ jobs:
             docker save postgres:18.3 --output /tmp/docker-images/postgres-18.3.tar
           fi
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image from GHCR
+        run: |
+          # Pull the pre-built builder image to avoid a ~30–60 min local build.
+          # Falls back to building locally if the GHCR image is unavailable.
+          if docker pull ghcr.io/trickle-labs/pg-trickle/builder:pg18 2>/dev/null; then
+            docker tag ghcr.io/trickle-labs/pg-trickle/builder:pg18 pg_trickle_builder:pg18
+            echo "Builder image pulled from GHCR — skipping local build"
+          else
+            echo "::warning::Builder image not in GHCR (first run?). Will build locally."
+          fi
+
       - name: Build E2E Docker image (security gate)
         run: ./tests/build_e2e_image.sh
 

--- a/.semgrep/pg_trickle.yml
+++ b/.semgrep/pg_trickle.yml
@@ -46,7 +46,8 @@ rules:
         - "**/*.md"
         - /plans/**
         - /docs/**
-    pattern-regex: SECURITY\s+DEFINER
+        - /sql/archive/**
+    pattern-regex: '(?m)^[ \t]*SECURITY\s+DEFINER\b'
 
   # ── Phase 2: Extension-specific privilege-context rules ─────────────────────
 
@@ -204,4 +205,3 @@ rules:
           - pattern: $CLIENT.select(&format!($FMT, ...), ...)
           - pattern: $CLIENT.update(&format!($FMT, ...), ...)
           - pattern: $CLIENT.execute(&format!($FMT, ...), ...)
-

--- a/sql/pg_trickle--0.81.0--0.81.1.sql
+++ b/sql/pg_trickle--0.81.0--0.81.1.sql
@@ -9,7 +9,7 @@
 ALTER FUNCTION pgtrickle.create_stream_table(
     TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT, INT,
     double precision, TEXT, bool, TEXT, INT
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table(
     TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT, INT,
     double precision, TEXT, bool, TEXT, INT
@@ -18,50 +18,50 @@ ALTER FUNCTION pgtrickle.create_stream_table(
 ALTER FUNCTION pgtrickle.create_stream_table_if_not_exists(
     TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT, INT,
     double precision, TEXT, bool, TEXT, INT
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table_if_not_exists(
     TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT, INT,
     double precision, TEXT, bool, TEXT, INT
 ) SET search_path = pgtrickle, pg_catalog, pg_temp;
 
-ALTER FUNCTION pgtrickle.bulk_create(jsonb) SECURITY DEFINER;
+ALTER FUNCTION pgtrickle.bulk_create(jsonb) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.bulk_create(jsonb)
     SET search_path = pgtrickle, pg_catalog, pg_temp;
 
 ALTER FUNCTION pgtrickle.create_stream_table_fast_append_only(
     TEXT, TEXT, TEXT, TEXT, TEXT, INT, double precision
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table_fast_append_only(
     TEXT, TEXT, TEXT, TEXT, TEXT, INT, double precision
 ) SET search_path = pgtrickle, pg_catalog, pg_temp;
 
 ALTER FUNCTION pgtrickle.create_stream_table_realtime(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table_realtime(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
 ) SET search_path = pgtrickle, pg_catalog, pg_temp;
 
 ALTER FUNCTION pgtrickle.create_stream_table_batch(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table_batch(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
 ) SET search_path = pgtrickle, pg_catalog, pg_temp;
 
 ALTER FUNCTION pgtrickle.create_stream_table_cost_optimized(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
-) SECURITY DEFINER;
+) SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle.create_stream_table_cost_optimized(
     TEXT, TEXT, TEXT, bool, TEXT, INT, double precision
 ) SET search_path = pgtrickle, pg_catalog, pg_temp;
 
-ALTER FUNCTION pgtrickle._on_ddl_end() SECURITY DEFINER;
+ALTER FUNCTION pgtrickle._on_ddl_end() SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle._on_ddl_end()
     SET search_path = pgtrickle, pg_catalog, pg_temp;
 REVOKE EXECUTE ON FUNCTION pgtrickle._on_ddl_end() FROM PUBLIC;
 
-ALTER FUNCTION pgtrickle._on_sql_drop() SECURITY DEFINER;
+ALTER FUNCTION pgtrickle._on_sql_drop() SECURITY DEFINER; -- nosemgrep: sql.security-definer.present — search_path is pinned by the following ALTER FUNCTION.
 ALTER FUNCTION pgtrickle._on_sql_drop()
     SET search_path = pgtrickle, pg_catalog, pg_temp;
 REVOKE EXECUTE ON FUNCTION pgtrickle._on_sql_drop() FROM PUBLIC;

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -2209,6 +2209,7 @@ pub(crate) fn normalize_full_set_operation_storage(
         } else {
             String::new()
         };
+        // nosemgrep: rust.spi.run.dynamic-format — table and column names are quote_identifier()-escaped catalog identifiers.
         Spi::run(&format!(
             "CREATE INDEX ON {quoted_table} (__pgt_row_id){include_clause}"
         ))

--- a/src/api/refresh_ops.rs
+++ b/src/api/refresh_ops.rs
@@ -730,6 +730,7 @@ fn execute_manual_differential_refresh(
     let mut safe_bound = cdc::get_current_wal_lsn()?;
     for source_oid in source_oids {
         let buffer_name = cdc::buffer_base_name_for_oid(*source_oid);
+        // nosemgrep: rust.spi.get_one_with_args.dynamic-format — change_schema is a quoted config identifier and buffer_name is OID-derived.
         safe_bound = Spi::get_one_with_args::<String>(
             &format!(
                 "SELECT GREATEST($1::pg_lsn, COALESCE(MAX(lsn), '0/0'::pg_lsn))::text \

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1873,19 +1873,11 @@ impl StDependency {
         slot_name: Option<&str>,
         decoder_confirmed_lsn: Option<&str>,
     ) -> Result<(), PgTrickleError> {
-        let transition_started = if cdc_mode == CdcMode::Transitioning {
-            "now()"
-        } else {
-            "NULL"
-        };
         Spi::run_with_args(
-            &format!(
-                "UPDATE pgtrickle.pgt_dependencies \
-                 SET cdc_mode = $1, slot_name = $2, decoder_confirmed_lsn = $3::pg_lsn, \
-                     transition_started_at = {} \
-                 WHERE pgt_id = $4 AND source_relid = $5",
-                transition_started
-            ),
+            "UPDATE pgtrickle.pgt_dependencies \
+             SET cdc_mode = $1, slot_name = $2, decoder_confirmed_lsn = $3::pg_lsn, \
+                 transition_started_at = CASE WHEN $1 = 'TRANSITIONING' THEN now() ELSE NULL END \
+             WHERE pgt_id = $4 AND source_relid = $5",
             &[
                 cdc_mode.as_str().into(),
                 slot_name.into(),
@@ -1904,19 +1896,11 @@ impl StDependency {
         slot_name: Option<&str>,
         decoder_confirmed_lsn: Option<&str>,
     ) -> Result<(), PgTrickleError> {
-        let transition_started = if cdc_mode == CdcMode::Transitioning {
-            "now()"
-        } else {
-            "NULL"
-        };
         Spi::run_with_args(
-            &format!(
-                "UPDATE pgtrickle.pgt_dependencies \
-                 SET cdc_mode = $1, slot_name = $2, decoder_confirmed_lsn = $3::pg_lsn, \
-                     transition_started_at = {} \
-                 WHERE source_relid = $4",
-                transition_started
-            ),
+            "UPDATE pgtrickle.pgt_dependencies \
+             SET cdc_mode = $1, slot_name = $2, decoder_confirmed_lsn = $3::pg_lsn, \
+                 transition_started_at = CASE WHEN $1 = 'TRANSITIONING' THEN now() ELSE NULL END \
+             WHERE source_relid = $4",
             &[
                 cdc_mode.as_str().into(),
                 slot_name.into(),

--- a/src/cdc/mod.rs
+++ b/src/cdc/mod.rs
@@ -203,9 +203,10 @@ pub fn lock_source_relations(source_oids: &[pg_sys::Oid]) -> Result<(), PgTrickl
         let Some(table) = resolve_relation_name(pg_sys::Oid::from(oid))? else {
             continue;
         };
-        Spi::run(&format!("LOCK TABLE {table} IN SHARE MODE")).map_err(|e| {
-            PgTrickleError::LockTimeout(format!("could not lock source {table}: {e}"))
-        })?;
+        Spi::run(&format!("LOCK TABLE {table} IN SHARE MODE")) // nosemgrep: rust.spi.run.dynamic-format — table is returned by PostgreSQL format('%I.%I') from a catalog OID.
+            .map_err(|e| {
+                PgTrickleError::LockTimeout(format!("could not lock source {table}: {e}"))
+            })?;
     }
     Ok(())
 }
@@ -521,6 +522,7 @@ fn validate_one_change_buffer(
     if !columns_ok {
         return Err(invalid("required control columns are missing".into()));
     }
+    // nosemgrep: rust.spi.get_one_with_args.dynamic-format — change_schema is quote-escaped config and buffer_name is OID-derived.
     let sentinel_ok = Spi::get_one_with_args::<bool>(
         &format!(
             "SELECT COUNT(*) = 1 AND MIN(pk_hash) = $1 FROM {change_schema}.{buffer_name} \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,14 +790,14 @@ extension_sql!(
 -- event triggers. We create them manually here with the correct return type.
 CREATE FUNCTION pgtrickle."_on_ddl_end"()
     RETURNS event_trigger
-    SECURITY DEFINER
+    SECURITY DEFINER -- nosemgrep: sql.security-definer.present — event trigger runs with pinned pgtrickle catalog search_path below.
     SET search_path TO pgtrickle, pg_catalog, pg_temp
     LANGUAGE c
     AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
 
 CREATE FUNCTION pgtrickle."_on_sql_drop"()
     RETURNS event_trigger
-    SECURITY DEFINER
+    SECURITY DEFINER -- nosemgrep: sql.security-definer.present — event trigger runs with pinned pgtrickle catalog search_path below.
     SET search_path TO pgtrickle, pg_catalog, pg_temp
     LANGUAGE c
     AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';

--- a/src/monitor/health.rs
+++ b/src/monitor/health.rs
@@ -251,15 +251,12 @@ fn health_check() -> TableIterator<
         let threshold_bytes = config::pg_trickle_slot_lag_warning_threshold_bytes();
         let lagging: Vec<String> = client
             .select(
-                &format!(
-                    "SELECT slot_name || ' (' || pg_size_pretty(retained_wal_bytes) || ')' \
-                     FROM pgtrickle.slot_health() \
-                     WHERE retained_wal_bytes > {} \
-                     ORDER BY retained_wal_bytes DESC",
-                    threshold_bytes
-                ),
+                "SELECT slot_name || ' (' || pg_size_pretty(retained_wal_bytes) || ')' \
+                 FROM pgtrickle.slot_health() \
+                 WHERE retained_wal_bytes > $1 \
+                 ORDER BY retained_wal_bytes DESC",
                 None,
-                &[],
+                &[threshold_bytes.into()],
             )
             .map(|r| {
                 r.filter_map(|row| row.get::<String>(1).unwrap_or(None))

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -534,7 +534,11 @@ pub(crate) fn collect_metrics_text_with_deadline(
             "metrics request deadline elapsed".to_string(),
         ));
     }
-    Spi::run(&format!("SET LOCAL statement_timeout = '{millis}ms'")).map_err(|e| {
+    Spi::run_with_args(
+        "SELECT pg_catalog.set_config('statement_timeout', $1, true)",
+        &[format!("{millis}ms").into()],
+    )
+    .map_err(|e| {
         crate::metrics_server::MetricsServerError::Io(format!("set metrics statement_timeout: {e}"))
     })?;
     Ok(collect_metrics_text())

--- a/src/refresh/merge/delete.rs
+++ b/src/refresh/merge/delete.rs
@@ -18,6 +18,7 @@ pub(crate) fn execute_incremental_truncate_delete(
     );
 
     let rows_deleted = Spi::connect_mut(|client| {
+        // nosemgrep: rust.spi.connect_mut.dynamic-format — quoted_table is built from double-quote-escaped relation identifiers.
         let result = client
             .update(&format!("DELETE FROM {quoted_table}"), None, &[])
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;

--- a/src/refresh/merge/insert.rs
+++ b/src/refresh/merge/insert.rs
@@ -48,6 +48,7 @@ pub fn execute_topk_refresh(st: &StreamTableMeta) -> Result<(i64, i64), PgTrickl
         name.replace('"', "\"\""),
     );
     let pre_table = format!("__pgt_topk_state_{}", st.pgt_id);
+    // nosemgrep: rust.spi.run.dynamic-format — pre_table is OID-derived and quoted_table is double-quote-escaped.
     Spi::run(&format!(
         "DROP TABLE IF EXISTS {pre_table}; \
          CREATE TEMP TABLE {pre_table} ON COMMIT DROP AS SELECT * FROM {quoted_table}"

--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -1236,11 +1236,8 @@ pub fn check_and_complete_transition(
         // Check if we've exceeded the final deadline (3× base timeout)
         let final_deadline = base_timeout * 3;
         let exceeded_final = Spi::get_one_with_args::<bool>(
-            &format!(
-                "SELECT (now() - $1::timestamptz) > interval '{} seconds'",
-                final_deadline
-            ),
-            &[started_at.as_str().into()],
+            "SELECT (now() - $1::timestamptz) > ($2 * interval '1 second')",
+            &[started_at.as_str().into(), final_deadline.into()],
         )
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
         .unwrap_or(false);
@@ -1260,22 +1257,16 @@ pub fn check_and_complete_transition(
 
         // Emit warnings at intermediate checkpoints (1× and 2× base timeout)
         let exceeded_first = Spi::get_one_with_args::<bool>(
-            &format!(
-                "SELECT (now() - $1::timestamptz) > interval '{} seconds'",
-                base_timeout
-            ),
-            &[started_at.as_str().into()],
+            "SELECT (now() - $1::timestamptz) > ($2 * interval '1 second')",
+            &[started_at.as_str().into(), base_timeout.into()],
         )
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
         .unwrap_or(false);
 
         if exceeded_first {
             let exceeded_second = Spi::get_one_with_args::<bool>(
-                &format!(
-                    "SELECT (now() - $1::timestamptz) > interval '{} seconds'",
-                    base_timeout * 2
-                ),
-                &[started_at.as_str().into()],
+                "SELECT (now() - $1::timestamptz) > ($2 * interval '1 second')",
+                &[started_at.as_str().into(), (base_timeout * 2).into()],
             )
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
             .unwrap_or(false);
@@ -1334,14 +1325,13 @@ fn complete_wal_transition(
     Spi::run_with_args("SELECT pg_advisory_lock($1)", &[lock_key.into()])
         .map_err(|e| PgTrickleError::SpiError(format!("advisory lock for COR-003: {}", e)))?;
     let source_table = cdc::get_qualified_table_name(source_oid)?;
-    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")).map_err(|e| {
-        PgTrickleError::CdcCutoverUnproven {
+    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")) // nosemgrep: rust.spi.run.dynamic-format — source_table is PostgreSQL format('%I.%I') output from a catalog OID.
+        .map_err(|e| PgTrickleError::CdcCutoverUnproven {
             source_oid: oid_u32,
             target: "WAL".to_string(),
             required_lsn: "source lock".to_string(),
             confirmed_lsn: Some(e.to_string()),
-        }
-    })?;
+        })?;
 
     // Step 1: Update catalog to WAL mode FIRST.
     // After this point the scheduler knows the source is in WAL mode.  Any
@@ -1403,14 +1393,13 @@ pub fn abort_wal_transition(
     })?;
 
     let source_table = cdc::get_qualified_table_name(source_oid)?;
-    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")).map_err(|e| {
-        PgTrickleError::CdcCutoverUnproven {
+    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")) // nosemgrep: rust.spi.run.dynamic-format — source_table is PostgreSQL format('%I.%I') output from a catalog OID.
+        .map_err(|e| PgTrickleError::CdcCutoverUnproven {
             source_oid: oid_u32,
             target: "TRIGGER".to_string(),
             required_lsn: "source lock".to_string(),
             confirmed_lsn: Some(e.to_string()),
-        }
-    })?;
+        })?;
 
     // Future writes must be captured before WAL resources are released.
     ensure_trigger_for_source(source_oid, change_schema)?;
@@ -1573,14 +1562,13 @@ pub fn force_source_to_trigger(
     };
 
     let source_table = cdc::get_qualified_table_name(source_oid)?;
-    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")).map_err(|e| {
-        PgTrickleError::CdcCutoverUnproven {
+    Spi::run(&format!("LOCK TABLE {source_table} IN SHARE MODE")) // nosemgrep: rust.spi.run.dynamic-format — source_table is PostgreSQL format('%I.%I') output from a catalog OID.
+        .map_err(|e| PgTrickleError::CdcCutoverUnproven {
             source_oid: source_oid.to_u32(),
             target: "TRIGGER".to_string(),
             required_lsn: "source lock".to_string(),
             confirmed_lsn: Some(e.to_string()),
-        }
-    })?;
+        })?;
     ensure_trigger_for_source(source_oid, change_schema)?;
 
     let slot_name = slot_name_for_source(source_oid);


### PR DESCRIPTION
## Summary

- Resolve the repository's Semgrep code-scanning findings.
- Exclude archived migrations from the active scan and match only executable `SECURITY DEFINER` clauses.
- Parameterize dynamic SQL values for catalog updates, metrics, and WAL transition deadlines.
- Document the remaining catalog-quoted identifier SQL with focused `nosemgrep` comments.

## Tests

- `just lint`
- `just test-unit` (2,372 passed)
- `just test-integration` (161 passed)
- Semgrep scan with `.semgrep/pg_trickle.yml` (0 findings)
