### PR TITLE
fix(dvm): harden aggregate CTE rescan and join deltas

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -974,12 +974,12 @@ impl StDag {
 
                 // Merge other overlapping groups into target.
                 for &other in overlapping.iter().skip(1) {
-                    let other_members: HashSet<NodeId> = groups[other].drain().collect();
+                    let other_members = std::mem::take(&mut groups[other]);
                     for m in &other_members {
                         node_to_group.insert(*m, target);
                     }
                     groups[target].extend(other_members);
-                    let other_cp: HashSet<NodeId> = convergence_map[other].drain().collect();
+                    let other_cp = std::mem::take(&mut convergence_map[other]);
                     convergence_map[target].extend(other_cp);
                 }
             }

--- a/src/dvm/operators/aggregate.rs
+++ b/src/dvm/operators/aggregate.rs
@@ -123,6 +123,39 @@ fn resolve_expr_for_child(expr: &Expr, child_cols: &[String]) -> String {
 
 // ── Group-rescan helpers ────────────────────────────────────────────
 
+/// Build a NULL-safe affected-group filter without shadowing source columns.
+///
+/// The delta columns are renamed inside the subquery so an unqualified source
+/// expression such as `c_custkey` cannot resolve to the inner delta row.
+fn build_group_filter(delta_cte: &str, group_output: &[String]) -> String {
+    let delta_cols = group_output
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{} AS {}",
+                quote_ident(column),
+                quote_ident(&format!("__pgt_group_{index}")),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let conditions = group_output
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{column} IS NOT DISTINCT FROM __pgt_d2.{}",
+                quote_ident(&format!("__pgt_group_{index}")),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    format!(
+        "EXISTS (SELECT 1 FROM (SELECT {delta_cols} FROM {delta_cte}) __pgt_d2 WHERE {conditions})"
+    )
+}
+
 /// Reconstruct the FROM clause SQL from a child OpTree.
 ///
 /// Returns the SQL fragment for `FROM ...` suitable for the rescan CTE.
@@ -589,21 +622,8 @@ fn build_intermediate_agg_delta(
     // Group filter: only rescan affected groups
     let group_filter = if group_output.is_empty() {
         String::new()
-    } else if group_output.len() == 1 {
-        let col = &group_output[0];
-        format!(
-            "EXISTS (SELECT 1 FROM {delta_cte} __pgt_d2 WHERE {col} IS NOT DISTINCT FROM __pgt_d2.{})",
-            quote_ident(col),
-        )
     } else {
-        let corr: Vec<String> = group_output
-            .iter()
-            .map(|c| format!("{c} IS NOT DISTINCT FROM __pgt_d2.{}", quote_ident(c)))
-            .collect();
-        format!(
-            "EXISTS (SELECT 1 FROM {delta_cte} __pgt_d2 WHERE {})",
-            corr.join(" AND "),
-        )
+        build_group_filter(delta_cte, group_output)
     };
 
     // Determine WHERE/AND connector based on existing WHERE in from_sql.
@@ -1044,25 +1064,8 @@ fn build_rescan_cte(
         // the group filter into the WHERE clause before aggregation.
         let group_filter = if group_output.is_empty() {
             String::new()
-        } else if group_output.len() == 1 {
-            // Use EXISTS with IS NOT DISTINCT FROM instead of IN to
-            // correctly match NULL group-key values (NULL IN (...) → NULL).
-            let col = &group_output[0];
-            format!(
-                "EXISTS (SELECT 1 FROM {delta_cte} __pgt_d2 WHERE {col} IS NOT DISTINCT FROM __pgt_d2.{})",
-                quote_ident(col),
-            )
         } else {
-            // Multi-column group key: use EXISTS with IS NOT DISTINCT FROM
-            // to correctly handle NULL group-key values.
-            let corr: Vec<String> = group_output
-                .iter()
-                .map(|c| format!("{c} IS NOT DISTINCT FROM __pgt_d2.{}", quote_ident(c),))
-                .collect();
-            format!(
-                "EXISTS (SELECT 1 FROM {delta_cte} __pgt_d2 WHERE {})",
-                corr.join(" AND "),
-            )
+            build_group_filter(delta_cte, group_output)
         };
 
         // If the child is a Filter, the FROM already includes WHERE.
@@ -5531,6 +5534,52 @@ mod tests {
             sql,
             "(SELECT \"id\", \"group_id\", \"created_at\" FROM \"public\".\"events\") AS \"e\""
         );
+    }
+
+    #[test]
+    fn test_q13_shaped_nested_left_join_aggregate_sql() {
+        let customer = scan_with_pk(
+            1,
+            "customer",
+            "public",
+            "customer",
+            &["c_custkey"],
+            &["c_custkey"],
+        );
+        let orders = scan_with_pk(
+            2,
+            "orders",
+            "public",
+            "orders",
+            &["o_orderkey", "o_custkey", "o_comment"],
+            &["o_orderkey"],
+        );
+        let join = left_join(
+            Expr::Raw("c_custkey = o_custkey AND o_comment NOT LIKE '%special%requests%'".into()),
+            customer,
+            orders,
+        );
+        let inner = aggregate(
+            vec![colref("c_custkey")],
+            vec![count_col("o_orderkey", "c_count")],
+            join,
+        );
+        let outer = aggregate(
+            vec![colref("c_count")],
+            vec![count_star("custdist")],
+            subquery("c_orders", vec![], inner),
+        );
+
+        let mut ctx = test_ctx_with_st("public", "q13");
+        ctx.st_user_columns = Some(vec!["c_count".into(), "custdist".into()]);
+        ctx.st_has_pgt_count = true;
+        let result = diff_aggregate(&mut ctx, &outer).unwrap();
+        let sql = ctx.build_with_query(&result.cte_name);
+
+        assert!(sql.contains("LEFT JOIN"), "{sql}");
+        assert!(sql.contains("agg_new"), "{sql}");
+        assert!(sql.contains("\"__ins_c_count\""), "{sql}");
+        assert!(sql.contains("\"__pgt_group_0\""), "{sql}");
     }
 
     #[test]

--- a/src/dvm/operators/aggregate.rs
+++ b/src/dvm/operators/aggregate.rs
@@ -214,15 +214,47 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
                 inner,
             ))
         }
-        OpTree::CteScan { cte_id, .. } => {
+        OpTree::CteScan {
+            cte_id,
+            alias,
+            cte_def_aliases,
+            column_aliases,
+            ..
+        } => {
             // Resolve the CTE body via the registry and recursively determine
             // the FROM clause. This handles chained CTEs where the aggregate's
             // child is a CTE alias (e.g., `FROM raw`) that is not a real
             // relation — using the alias directly would cause a PostgreSQL
             // "relation does not exist" error in the rescan CTE.
-            registry
-                .get(*cte_id)
-                .and_then(|(_, body)| child_to_from_sql(body, registry))
+            let (_, body) = registry.get(*cte_id)?;
+            let inner = child_to_from_sql(body, registry)?;
+            let source_cols = body.output_columns();
+            let output_cols = if !column_aliases.is_empty() {
+                column_aliases
+            } else if !cte_def_aliases.is_empty() {
+                cte_def_aliases
+            } else {
+                &source_cols
+            };
+            if source_cols.len() != output_cols.len() {
+                return None;
+            }
+            let selects = source_cols
+                .iter()
+                .zip(output_cols)
+                .map(|(source, output)| {
+                    if source == output {
+                        quote_ident(source)
+                    } else {
+                        format!("{} AS {}", quote_ident(source), quote_ident(output))
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!(
+                "(SELECT {selects} FROM {inner}) AS {}",
+                quote_ident(alias)
+            ))
         }
         OpTree::Subquery {
             child,
@@ -544,7 +576,10 @@ fn build_intermediate_agg_delta(
         String::new()
     } else if group_output.len() == 1 {
         let col = &group_output[0];
-        format!("{col} IN (SELECT {} FROM {delta_cte})", quote_ident(col),)
+        format!(
+            "EXISTS (SELECT 1 FROM {delta_cte} __pgt_d2 WHERE {col} IS NOT DISTINCT FROM __pgt_d2.{})",
+            quote_ident(col),
+        )
     } else {
         let corr: Vec<String> = group_output
             .iter()
@@ -5583,9 +5618,32 @@ mod tests {
             "Should resolve to the underlying table, not the CTE alias: {sql}"
         );
         assert!(
-            !sql.contains("\"raw\""),
-            "Should NOT emit the CTE alias as a bare table reference: {sql}"
+            sql.ends_with("AS \"raw\""),
+            "Should preserve the CTE reference alias: {sql}"
         );
+    }
+
+    #[test]
+    fn test_child_to_from_sql_cte_scan_applies_definition_aliases() {
+        let body = scan(1, "metrics", "public", "m", &["grp", "val"]);
+        let registry = CteRegistry {
+            entries: vec![("raw".to_string(), body)],
+        };
+        let child = OpTree::CteScan {
+            cte_id: 0,
+            cte_name: "raw".to_string(),
+            alias: "r".to_string(),
+            columns: vec!["grp".to_string(), "val".to_string()],
+            cte_def_aliases: vec!["g".to_string(), "v".to_string()],
+            column_aliases: vec![],
+            body: None,
+        };
+
+        let sql = child_to_from_sql(&child, &registry).unwrap();
+
+        assert!(sql.contains("\"grp\" AS \"g\""), "{sql}");
+        assert!(sql.contains("\"val\" AS \"v\""), "{sql}");
+        assert!(sql.ends_with("AS \"r\""), "{sql}");
     }
 
     #[test]

--- a/src/dvm/operators/aggregate.rs
+++ b/src/dvm/operators/aggregate.rs
@@ -133,7 +133,11 @@ fn resolve_expr_for_child(expr: &Expr, child_cols: &[String]) -> String {
 /// emitting the CTE alias as a bare table reference (which would fail at
 /// SQL execution time for chained CTEs that are not real relations), we
 /// recursively resolve the CTE body and emit its underlying source.
-fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
+fn child_to_from_sql(
+    child: &OpTree,
+    registry: &CteRegistry,
+    project_scan_columns: bool,
+) -> Option<String> {
     match child {
         OpTree::Scan {
             schema,
@@ -141,7 +145,7 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             alias,
             columns,
             ..
-        } => {
+        } if project_scan_columns => {
             let columns = columns
                 .iter()
                 .map(|column| quote_ident(&column.name))
@@ -154,8 +158,19 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
                 quote_ident(alias),
             ))
         }
+        OpTree::Scan {
+            schema,
+            table_name,
+            alias,
+            ..
+        } => Some(format!(
+            "{}.{} AS {}",
+            quote_ident(schema),
+            quote_ident(table_name),
+            quote_ident(alias),
+        )),
         OpTree::Filter { predicate, child } => {
-            let inner = child_to_from_sql(child, registry)?;
+            let inner = child_to_from_sql(child, registry, project_scan_columns)?;
             Some(format!("{inner} WHERE {}", predicate.to_sql()))
         }
         OpTree::InnerJoin {
@@ -163,8 +178,8 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             left,
             right,
         } => {
-            let l = child_to_from_sql(left, registry)?;
-            let r = child_to_from_sql(right, registry)?;
+            let l = child_to_from_sql(left, registry, project_scan_columns)?;
+            let r = child_to_from_sql(right, registry, project_scan_columns)?;
             Some(format!("{l} INNER JOIN {r} ON {}", condition.to_sql()))
         }
         OpTree::LeftJoin {
@@ -172,8 +187,8 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             left,
             right,
         } => {
-            let l = child_to_from_sql(left, registry)?;
-            let r = child_to_from_sql(right, registry)?;
+            let l = child_to_from_sql(left, registry, project_scan_columns)?;
+            let r = child_to_from_sql(right, registry, project_scan_columns)?;
             Some(format!("{l} LEFT JOIN {r} ON {}", condition.to_sql()))
         }
         OpTree::FullJoin {
@@ -181,8 +196,8 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             left,
             right,
         } => {
-            let l = child_to_from_sql(left, registry)?;
-            let r = child_to_from_sql(right, registry)?;
+            let l = child_to_from_sql(left, registry, project_scan_columns)?;
+            let r = child_to_from_sql(right, registry, project_scan_columns)?;
             Some(format!("{l} FULL JOIN {r} ON {}", condition.to_sql()))
         }
         OpTree::Project {
@@ -195,7 +210,7 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             // that reference the Project's output aliases (e.g., `o_year`
             // from `EXTRACT(year FROM o_orderdate) AS o_year`) resolve
             // correctly in the rescan CTE.
-            let inner = child_to_from_sql(child, registry)?;
+            let inner = child_to_from_sql(child, registry, project_scan_columns)?;
             let select_items: Vec<String> = expressions
                 .iter()
                 .zip(aliases.iter())
@@ -227,7 +242,7 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             // relation — using the alias directly would cause a PostgreSQL
             // "relation does not exist" error in the rescan CTE.
             let (_, body) = registry.get(*cte_id)?;
-            let inner = child_to_from_sql(body, registry)?;
+            let inner = child_to_from_sql(body, registry, project_scan_columns)?;
             let source_cols = body.output_columns();
             let output_cols = if !column_aliases.is_empty() {
                 column_aliases
@@ -272,7 +287,7 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             // that are lost when child_to_from_sql recurses through them.
             match child.as_ref() {
                 OpTree::Aggregate { .. } => {
-                    let inner = child_to_from_sql(child, registry)?;
+                    let inner = child_to_from_sql(child, registry, project_scan_columns)?;
                     if column_aliases.is_empty() {
                         Some(format!("{inner} AS {}", quote_ident(alias)))
                     } else {
@@ -297,7 +312,7 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             child,
             ..
         } => {
-            let inner_from = child_to_from_sql(child, registry)?;
+            let inner_from = child_to_from_sql(child, registry, project_scan_columns)?;
             let mut selects = Vec::new();
             for expr in group_by {
                 selects.push(expr.to_sql());
@@ -526,7 +541,7 @@ fn build_intermediate_agg_delta(
     aggregates: &[AggExpr],
     delta_cte: &str,
 ) -> Result<DiffResult, PgTrickleError> {
-    let source_from = child_to_from_sql(child, &ctx.cte_registry);
+    let source_from = child_to_from_sql(child, &ctx.cte_registry, true);
 
     // We need the child's source SQL for rescanning. If we can't reconstruct
     // it, fall back to the defining query approach.
@@ -969,7 +984,7 @@ fn build_rescan_cte(
     }
 
     let rescan_cte = ctx.next_cte_name("agg_rescan");
-    let source_from = child_to_from_sql(child, &ctx.cte_registry);
+    let source_from = child_to_from_sql(child, &ctx.cte_registry, false);
     let can_rescan_sum_nonnull = source_from.is_some();
 
     // Build SELECT list: group columns + rescan aggregate calls
@@ -5510,7 +5525,7 @@ mod tests {
             &["id", "group_id", "created_at"],
         );
 
-        let sql = child_to_from_sql(&child, &CteRegistry::default()).unwrap();
+        let sql = child_to_from_sql(&child, &CteRegistry::default(), true).unwrap();
 
         assert_eq!(
             sql,
@@ -5540,7 +5555,7 @@ mod tests {
             ),
         );
 
-        let result = child_to_from_sql(&child, &CteRegistry::default());
+        let result = child_to_from_sql(&child, &CteRegistry::default(), true);
         assert!(result.is_some(), "Project over Scan should return Some");
         let sql = result.unwrap();
         // Should be a subquery wrapping the scan
@@ -5576,7 +5591,7 @@ mod tests {
             },
         );
 
-        let result = child_to_from_sql(&child, &CteRegistry::default());
+        let result = child_to_from_sql(&child, &CteRegistry::default(), true);
         assert!(
             result.is_none(),
             "Project over non-Aggregate Subquery should return None"
@@ -5609,7 +5624,7 @@ mod tests {
             vec![],
             vec![],
         );
-        let result = child_to_from_sql(&cte_child, &registry);
+        let result = child_to_from_sql(&cte_child, &registry, true);
 
         assert!(result.is_some(), "CteScan over Scan should resolve to Some");
         let sql = result.unwrap();
@@ -5639,7 +5654,7 @@ mod tests {
             body: None,
         };
 
-        let sql = child_to_from_sql(&child, &registry).unwrap();
+        let sql = child_to_from_sql(&child, &registry, true).unwrap();
 
         assert!(sql.contains("\"grp\" AS \"g\""), "{sql}");
         assert!(sql.contains("\"val\" AS \"v\""), "{sql}");
@@ -5652,7 +5667,7 @@ mod tests {
         // so callers fall back to the defining-query approach.
         let registry = CteRegistry::default(); // empty
         let cte_child = cte_scan(0, "missing", "missing", vec!["id"], vec![], vec![]);
-        let result = child_to_from_sql(&cte_child, &registry);
+        let result = child_to_from_sql(&cte_child, &registry, true);
         assert!(
             result.is_none(),
             "CteScan with missing registry entry should return None"

--- a/src/dvm/operators/aggregate.rs
+++ b/src/dvm/operators/aggregate.rs
@@ -139,13 +139,21 @@ fn child_to_from_sql(child: &OpTree, registry: &CteRegistry) -> Option<String> {
             schema,
             table_name,
             alias,
+            columns,
             ..
-        } => Some(format!(
-            "\"{}\".\"{}\" AS \"{}\"",
-            schema.replace('"', "\"\""),
-            table_name.replace('"', "\"\""),
-            alias.replace('"', "\"\""),
-        )),
+        } => {
+            let columns = columns
+                .iter()
+                .map(|column| quote_ident(&column.name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!(
+                "(SELECT {columns} FROM {}.{}) AS {}",
+                quote_ident(schema),
+                quote_ident(table_name),
+                quote_ident(alias),
+            ))
+        }
         OpTree::Filter { predicate, child } => {
             let inner = child_to_from_sql(child, registry)?;
             Some(format!("{inner} WHERE {}", predicate.to_sql()))
@@ -5456,6 +5464,24 @@ mod tests {
     }
 
     // ── child_to_from_sql tests (SF-4) ──────────────────────────────
+
+    #[test]
+    fn test_child_to_from_sql_scan_projects_pruned_columns() {
+        let child = scan(
+            1,
+            "events",
+            "public",
+            "e",
+            &["id", "group_id", "created_at"],
+        );
+
+        let sql = child_to_from_sql(&child, &CteRegistry::default()).unwrap();
+
+        assert_eq!(
+            sql,
+            "(SELECT \"id\", \"group_id\", \"created_at\" FROM \"public\".\"events\") AS \"e\""
+        );
+    }
 
     #[test]
     fn test_child_to_from_sql_project_over_scan() {

--- a/src/dvm/operators/cte_scan.rs
+++ b/src/dvm/operators/cte_scan.rs
@@ -68,10 +68,12 @@ pub fn diff_cte_scan(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, P
         base_result.columns.clone()
     };
 
-    // CteScan rows use the CTE's visible output columns as their content-hash
-    // row identity, even when the body delta uses a different row_id strategy.
+    // Hash the source expressions before their positional aliases are applied.
+    // The values are identical to the CTE's visible columns, while referring
+    // to select-list aliases here would make the generated SQL invalid.
     let row_id_expr = build_hash_expr(
-        &effective_cols
+        &base_result
+            .columns
             .iter()
             .map(|col| format!("{}::TEXT", quote_ident(col)))
             .collect::<Vec<_>>(),
@@ -166,6 +168,7 @@ mod tests {
         // Columns should be renamed
         assert_eq!(result.columns, vec!["a", "b"]);
         let sql = ctx.build_with_query(&result.cte_name);
+        assert_sql_contains(&sql, "ARRAY[(\"id\"::TEXT)::TEXT, (\"name\"::TEXT)::TEXT]");
         assert_sql_contains(&sql, "\"id\" AS \"a\"");
         assert_sql_contains(&sql, "\"name\" AS \"b\"");
     }

--- a/src/dvm/operators/full_join.rs
+++ b/src/dvm/operators/full_join.rs
@@ -57,7 +57,8 @@
 use crate::dvm::diff::{DiffContext, DiffResult, quote_ident};
 use crate::dvm::operators::join::mark_leaf_delta_ctes_not_materialized;
 use crate::dvm::operators::join_common::{
-    build_leaf_snapshot_sql, build_snapshot_sql, is_join_child, rewrite_join_condition,
+    build_leaf_snapshot_sql, build_snapshot_sql, contains_semijoin, extract_equijoin_keys_aliased,
+    is_join_child, rewrite_join_condition, supports_pre_change_join_snapshot,
     use_pre_change_snapshot,
 };
 use crate::dvm::parser::OpTree;
@@ -182,7 +183,12 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     //
     // L₀ and EC-01 R₀ are mutually exclusive: when L₀ is available,
     // Part 1 is unsplit (no EC-01), and the standard formula is exact.
-    let use_l0 = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
+    let use_per_leaf_l0 = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
+    let use_combined_l0 = is_join_child(left)
+        && !supports_pre_change_join_snapshot(left)
+        && !contains_semijoin(left)
+        && !ctx.inside_semijoin;
+    let use_l0 = use_per_leaf_l0 || use_combined_l0;
 
     // ── EC-01: Pre-change right snapshot for Parts 1b / 3b ─────────
     //
@@ -220,7 +226,7 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
 
     // ── L₀ snapshot for Part 2 (when use_l0=true) ──────────────────
     let left_part2_source = if use_l0 {
-        if is_join_child(left) {
+        if is_join_child(left) && !use_combined_l0 {
             let pre_change = ctx.get_or_register_snapshot_cte(left);
             mark_leaf_delta_ctes_not_materialized(left, ctx);
             pre_change
@@ -250,7 +256,7 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
         .filter(|c| *c != "__pgt_count")
         .cloned()
         .collect();
-    let r_old_snapshot = if is_join_child(right) {
+    let r_old_snapshot = if is_join_child(right) && supports_pre_change_join_snapshot(right) {
         ctx.get_or_register_snapshot_cte(right)
     } else {
         build_leaf_snapshot_sql(
@@ -269,7 +275,7 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
         .filter(|c| *c != "__pgt_count")
         .cloned()
         .collect();
-    let l_old_snapshot = if is_join_child(left) {
+    let l_old_snapshot = if is_join_child(left) && supports_pre_change_join_snapshot(left) {
         ctx.get_or_register_snapshot_cte(left)
     } else {
         build_leaf_snapshot_sql(
@@ -297,14 +303,37 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // Guard: AND NOT EXISTS (SELECT 1 FROM delta_left dl2
     //                        WHERE dl2.__pgt_action = 'I'
     //                          AND join_cond(l, dl2))
-    // NOTE: This uses right→dl2 substitution in the join condition, which
-    // is correct for symmetric join conditions (ON l.k = r.k). For
-    // asymmetric conditions, the guard may be imprecise but errs on the
-    // side of allowing Part 5 to fire (duplicates are less harmful than
-    // missed insertions for most queries).
-    let part5_excl_cond = rewrite_join_condition(condition, left, "l", right, "dl2");
-    // Symmetric for Part 7b: AND NOT EXISTS ΔR_I with same join key as r.
-    let part7b_excl_cond = rewrite_join_condition(condition, left, "dr2", right, "r");
+    let current_keys = extract_equijoin_keys_aliased(condition, left, "l", right, "r");
+    let delta_left_keys = extract_equijoin_keys_aliased(condition, left, "dl2", right, "r");
+    let delta_right_keys = extract_equijoin_keys_aliased(condition, left, "l", right, "dr2");
+    let same_side_condition = |current: &[(String, String)],
+                               delta: &[(String, String)],
+                               current_alias: &str,
+                               delta_alias: &str| {
+        let current_prefix = format!("\"{current_alias}\".");
+        let delta_prefix = format!("\"{delta_alias}\".");
+        let comparisons = current
+            .iter()
+            .zip(delta)
+            .filter_map(|(current_pair, delta_pair)| {
+                let current_expr = [&current_pair.0, &current_pair.1]
+                    .into_iter()
+                    .find(|expr| expr.contains(&current_prefix))?;
+                let delta_expr = [&delta_pair.0, &delta_pair.1]
+                    .into_iter()
+                    .find(|expr| expr.contains(&delta_prefix))?;
+                Some(format!("{current_expr} IS NOT DISTINCT FROM {delta_expr}"))
+            })
+            .collect::<Vec<_>>();
+        if comparisons.is_empty() {
+            "FALSE".to_string()
+        } else {
+            comparisons.join(" AND ")
+        }
+    };
+    let part5_excl_cond = same_side_condition(&current_keys, &delta_left_keys, "l", "dl2");
+    // Symmetric for Part 7b: AND NOT EXISTS ΔR_I with the same right-side key.
+    let part7b_excl_cond = same_side_condition(&current_keys, &delta_right_keys, "r", "dr2");
 
     // ── Part 4 exclusion guard ───────────────────────────────────────
     //
@@ -424,9 +453,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_part2} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {right_flags_cte})
+WHERE (SELECT has_ins FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'I' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {r_old_snapshot} __pgt_r_old WHERE {r_old_cond}
   )
@@ -445,9 +476,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'D'
-  AND (SELECT has_del FROM {right_flags_cte})
+WHERE (SELECT has_del FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'D' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {right_table} r WHERE {not_exists_cond_lr}
   )
@@ -494,9 +527,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {r_old_snapshot} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {left_flags_cte})
+WHERE (SELECT has_ins FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'I' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {l_old_snapshot} __pgt_l_old WHERE {l_old_cond}
   )
@@ -512,9 +547,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {right_table} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'D'
-  AND (SELECT has_del FROM {left_flags_cte})
+WHERE (SELECT has_del FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'D' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {left_table} l WHERE {not_exists_cond_lr}
   )
@@ -595,9 +632,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {right_flags_cte})
+WHERE (SELECT has_ins FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'I' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {r_old_snapshot} __pgt_r_old WHERE {r_old_cond}
   )
@@ -613,9 +652,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'D'
-  AND (SELECT has_del FROM {right_flags_cte})
+WHERE (SELECT has_del FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'D' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {right_table} r WHERE {not_exists_cond_lr}
   )
@@ -659,9 +700,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {r0_snapshot} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {left_flags_cte})
+WHERE (SELECT has_ins FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'I' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {l_old_snapshot} __pgt_l_old WHERE {l_old_cond}
   )
@@ -674,9 +717,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {right_table} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'D'
-  AND (SELECT has_del FROM {left_flags_cte})
+WHERE (SELECT has_del FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'D' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {left_table} l WHERE {not_exists_cond_lr}
   )
@@ -736,9 +781,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {right_flags_cte})
+WHERE (SELECT has_ins FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'I' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {r_old_snapshot} __pgt_r_old WHERE {r_old_cond}
   )
@@ -754,9 +801,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {l_null_right_padded}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'D'
-  AND (SELECT has_del FROM {right_flags_cte})
+WHERE (SELECT has_del FROM {right_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'D' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {right_table} r WHERE {not_exists_cond_lr}
   )
@@ -786,9 +835,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {right_table} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {left_flags_cte})
+WHERE (SELECT has_ins FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'I' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {l_old_snapshot} __pgt_l_old WHERE {l_old_cond}
   )
@@ -801,9 +852,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {null_left_r_padded}
 FROM {right_table} r
-JOIN {delta_left} dl ON {join_cond_antijoin_l}
-WHERE dl.__pgt_action = 'D'
-  AND (SELECT has_del FROM {left_flags_cte})
+WHERE (SELECT has_del FROM {left_flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_left} dl
+    WHERE dl.__pgt_action = 'D' AND {join_cond_antijoin_l}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {left_table} l WHERE {not_exists_cond_lr}
   )
@@ -888,6 +941,11 @@ mod tests {
         // R_old and L_old guards present
         assert_sql_contains(&sql, "__pgt_r_old");
         assert_sql_contains(&sql, "__pgt_l_old");
+        assert_sql_contains(
+            &sql,
+            "\"l\".\"cust_id\" IS NOT DISTINCT FROM \"dl2\".\"cust_id\"",
+        );
+        assert_sql_contains(&sql, "\"r\".\"id\" IS NOT DISTINCT FROM \"dr2\".\"id\"");
     }
 
     #[test]

--- a/src/dvm/operators/join.rs
+++ b/src/dvm/operators/join.rs
@@ -84,8 +84,9 @@
 use crate::config;
 use crate::dvm::diff::{DiffContext, DiffResult, quote_ident};
 use crate::dvm::operators::join_common::{
-    build_base_table_key_exprs, build_leaf_snapshot_sql, build_snapshot_sql, is_join_child,
-    is_simple_child, join_scan_count, rewrite_join_condition, use_pre_change_snapshot,
+    build_base_table_key_exprs, build_leaf_snapshot_sql, build_snapshot_sql, contains_semijoin,
+    is_join_child, is_simple_child, join_scan_count, rewrite_join_condition,
+    supports_pre_change_join_snapshot, use_pre_change_snapshot,
 };
 use crate::dvm::parser::{Expr, OpTree};
 use crate::error::PgTrickleError;
@@ -328,10 +329,16 @@ pub fn diff_inner_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult,
     // interacts with the SemiJoin's R_old computation.
     // A44-1: Read L0 scan threshold from GUC (default 4, previously hardcoded).
     let deep_join_l0_threshold = config::pg_trickle_deep_join_l0_scan_threshold();
-    let use_l0 = use_pre_change_snapshot(left, ctx.inside_semijoin, deep_join_l0_threshold);
+    let use_per_leaf_l0 =
+        use_pre_change_snapshot(left, ctx.inside_semijoin, deep_join_l0_threshold);
+    let use_combined_l0 = is_join_child(left)
+        && !supports_pre_change_join_snapshot(left)
+        && !contains_semijoin(left)
+        && !ctx.inside_semijoin;
+    let use_l0 = use_per_leaf_l0 || use_combined_l0;
 
     let left_part2_source = if use_l0 {
-        if is_join_child(left) {
+        if is_join_child(left) && !use_combined_l0 {
             // DI-1: Register per-leaf pre-change snapshot as a named CTE.
             // Subsequent references to the same subtree reuse the CTE,
             // eliminating redundant EXCEPT ALL evaluations.

--- a/src/dvm/operators/join_common.rs
+++ b/src/dvm/operators/join_common.rs
@@ -1673,12 +1673,29 @@ pub fn tree_contains_join(op: &OpTree) -> bool {
     }
 }
 
+/// Returns whether every leaf in a join subtree can be reconstructed from
+/// its pre-change state.
+pub(crate) fn supports_pre_change_join_snapshot(op: &OpTree) -> bool {
+    match op {
+        OpTree::Scan { .. } => true,
+        OpTree::InnerJoin { left, right, .. }
+        | OpTree::LeftJoin { left, right, .. }
+        | OpTree::FullJoin { left, right, .. } => {
+            supports_pre_change_join_snapshot(left) && supports_pre_change_join_snapshot(right)
+        }
+        OpTree::Filter { child, .. }
+        | OpTree::Project { child, .. }
+        | OpTree::Subquery { child, .. } => supports_pre_change_join_snapshot(child),
+        _ => false,
+    }
+}
+
 /// Returns true when the pre-change snapshot (via per-leaf CTE-based
 /// reconstruction) should be used for the given child node.  This is
 /// safe when:
 /// - The child is a simple Scan (cheap single-table EXCEPT ALL)
-/// - The child is NOT a join (Subquery/Aggregate — safe for EXCEPT ALL)
-/// - The child is a join without SemiJoin/AntiJoin (any depth)
+/// - The child is NOT a join (safe for leaf EXCEPT ALL reconstruction)
+/// - Every leaf in a join can be reconstructed, without SemiJoin/AntiJoin
 ///
 /// When false, the post-change snapshot should be used (with a correction
 /// term for shallow join children).
@@ -1706,6 +1723,9 @@ pub fn use_pre_change_snapshot(
 ) -> bool {
     if is_simple_child(child) || !is_join_child(child) {
         return true;
+    }
+    if !supports_pre_change_join_snapshot(child) {
+        return false;
     }
     if contains_semijoin(child) || inside_semijoin {
         return false;
@@ -2029,6 +2049,18 @@ mod tests {
         assert!(
             use_pre_change_snapshot(&child, false, 999),
             "Non-join child (Aggregate) should use pre-change snapshot"
+        );
+    }
+
+    #[test]
+    fn test_pre_change_snapshot_join_with_cte_scan_falls_back() {
+        let parent = scan(1, "parent", "public", "p", &["id"]);
+        let aggregate_cte = cte_scan(0, "agg", "a", vec!["parent_id", "count"], vec![], vec![]);
+        let child = left_join(eq_cond("p", "id", "a", "parent_id"), parent, aggregate_cte);
+
+        assert!(
+            !use_pre_change_snapshot(&child, false, 999),
+            "A join containing a CTE scan cannot reconstruct an exact pre-change snapshot"
         );
     }
 

--- a/src/dvm/operators/outer_join.rs
+++ b/src/dvm/operators/outer_join.rs
@@ -156,7 +156,7 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // the current cycle's changes, preventing spurious NULL-padded D/I.
     let right_user_cols: Vec<&String> = right_cols.iter().filter(|c| *c != "__pgt_count").collect();
 
-    let r_old_snapshot = if is_join_child(right) {
+    let r_old_snapshot = if is_join_child(right) && supports_pre_change_join_snapshot(right) {
         // DI-1: Named CTE snapshot for right pre-change state.
         ctx.get_or_register_snapshot_cte(right)
     } else {
@@ -426,9 +426,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_padded_cols}
 FROM {left_part2} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {flags_cte})
+WHERE (SELECT has_ins FROM {flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'I' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {r_old_snapshot} __pgt_r_old WHERE {r_old_cond}
   )
@@ -444,9 +446,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {l_null_padded_cols}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'D'
-  AND (SELECT has_del FROM {flags_cte})
+WHERE (SELECT has_del FROM {flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'D' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {right_table} r WHERE {not_exists_cond}
   )
@@ -498,9 +502,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_padded_cols}
 FROM {left_part2} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'I'
-  AND (SELECT has_ins FROM {flags_cte})
+WHERE (SELECT has_ins FROM {flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'I' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {r_old_snapshot} __pgt_r_old WHERE {r_old_cond}
   )
@@ -512,9 +518,11 @@ SELECT 0::BIGINT AS __pgt_row_id,
        'I'::TEXT AS __pgt_action,
        {l_null_padded_cols}
 FROM {left_table} l
-JOIN {delta_right} dr ON {join_cond_part2}
-WHERE dr.__pgt_action = 'D'
-  AND (SELECT has_del FROM {flags_cte})
+WHERE (SELECT has_del FROM {flags_cte})
+  AND EXISTS (
+    SELECT 1 FROM {delta_right} dr
+    WHERE dr.__pgt_action = 'D' AND {join_cond_part2}
+  )
   AND NOT EXISTS (
     SELECT 1 FROM {right_table} r WHERE {not_exists_cond}
   )

--- a/src/dvm/operators/outer_join.rs
+++ b/src/dvm/operators/outer_join.rs
@@ -38,8 +38,8 @@
 use crate::dvm::diff::{DiffContext, DiffResult, quote_ident};
 use crate::dvm::operators::join::mark_leaf_delta_ctes_not_materialized;
 use crate::dvm::operators::join_common::{
-    build_leaf_snapshot_sql, build_snapshot_sql, is_join_child, is_simple_child,
-    rewrite_join_condition, use_pre_change_snapshot,
+    build_leaf_snapshot_sql, build_snapshot_sql, contains_semijoin, is_join_child, is_simple_child,
+    rewrite_join_condition, supports_pre_change_join_snapshot, use_pre_change_snapshot,
 };
 use crate::dvm::parser::OpTree;
 use crate::error::PgTrickleError;
@@ -189,8 +189,13 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // When use_l0 is true (Part 2 uses L₀), the standard DBSP formula
     // is already exact — no EC-01 split needed. See diff_inner_join
     // for the full derivation.
-    let l0_available = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
-    let use_r0 = if l0_available {
+    let use_per_leaf_l0 = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
+    let use_combined_l0 = is_join_child(left)
+        && !supports_pre_change_join_snapshot(left)
+        && !contains_semijoin(left)
+        && !ctx.inside_semijoin;
+    let use_exact_l0 = use_per_leaf_l0 || use_combined_l0;
+    let use_r0 = if use_exact_l0 {
         false
     } else {
         use_pre_change_snapshot(right, ctx.inside_semijoin, 4)
@@ -238,9 +243,7 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // Same logic as diff_inner_join: use L₀ for simple/Scan children,
     // fall back to L₁ for SemiJoin-containing deep chains where
     // EXCEPT ALL interacts badly.
-    let use_l0 = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
-
-    let left_part2_source = if use_l0 {
+    let left_part2_source = if use_per_leaf_l0 {
         if is_join_child(left) {
             let pre_change = ctx.get_or_register_snapshot_cte(left);
             mark_leaf_delta_ctes_not_materialized(left, ctx);
@@ -253,6 +256,13 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
                 &ctx.fallback_leaf_oids,
             )
         }
+    } else if use_combined_l0 {
+        build_leaf_snapshot_sql(
+            left,
+            &left_result.cte_name,
+            left_cols,
+            &ctx.fallback_leaf_oids,
+        )
     } else {
         left_table.clone()
     };
@@ -260,7 +270,7 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // When use_l0 is true and left is a Scan, the left delta CTE is
     // referenced in both Part 1 and the L₀ EXCEPT ALL sub-selects.
     // Mark NOT MATERIALIZED to prevent spilling.
-    if use_l0 {
+    if use_exact_l0 {
         ctx.mark_cte_not_materialized(&left_result.cte_name);
     }
 
@@ -289,7 +299,7 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
         "dr.__pgt_row_id::TEXT".to_string(),
     ]);
 
-    let correction_sql = if !use_l0 && is_join_child(left) && !is_simple_child(left) {
+    let correction_sql = if !use_exact_l0 && is_join_child(left) && !is_simple_child(left) {
         // Part 2 uses L₁: correction for (L₁ − L₀) ⋈ ΔR error.
         // Same as inner join Part 3: ΔL_I ⋈ ΔR flipped, ΔL_D ⋈ ΔR kept.
         format!(
@@ -407,6 +417,7 @@ UNION ALL
 -- Part 4: Delete stale NULL-padded rows when a left row gains its FIRST right match.
 -- When a right INSERT creates a new match for a left row that previously had NO
 -- matching right rows (was NULL-padded), the NULL-padded ST row must be removed.
+-- Use L₀ so simultaneous left changes delete the row that actually existed.
 -- We check R_old (pre-change right) to verify the left row truly had no matches
 -- before. Without this check, left rows that ALREADY had matches would get
 -- spurious D(NULL-padded) rows that corrupt intermediate aggregate old-state
@@ -414,7 +425,7 @@ UNION ALL
 SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_padded_cols}
-FROM {left_table} l
+FROM {left_part2} l
 JOIN {delta_right} dr ON {join_cond_part2}
 WHERE dr.__pgt_action = 'I'
   AND (SELECT has_ins FROM {flags_cte})
@@ -482,10 +493,11 @@ WHERE NOT EXISTS (
 UNION ALL
 
 -- Part 4: Delete stale NULL-padded rows when a left row gains its FIRST right match.
+-- Use L₀ so simultaneous left changes delete the row that actually existed.
 SELECT 0::BIGINT AS __pgt_row_id,
        'D'::TEXT AS __pgt_action,
        {l_null_padded_cols}
-FROM {left_table} l
+FROM {left_part2} l
 JOIN {delta_right} dr ON {join_cond_part2}
 WHERE dr.__pgt_action = 'I'
   AND (SELECT has_ins FROM {flags_cte})

--- a/tests/e2e_cte_tests.rs
+++ b/tests/e2e_cte_tests.rs
@@ -548,6 +548,97 @@ async fn test_chained_ctes_differential_refresh() {
     );
 }
 
+#[tokio::test]
+async fn test_cte_chained_left_join_rescans_with_pruned_columns_stay_correct() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute_seq(&[
+        "CREATE TABLE rescan_parent (id INT PRIMARY KEY, created_at INT NOT NULL)",
+        "CREATE TABLE rescan_d (\
+             id INT PRIMARY KEY, parent_id INT NOT NULL REFERENCES rescan_parent(id), \
+             unused TEXT, flag INT NOT NULL, created_at INT NOT NULL\
+         )",
+        "CREATE TABLE rescan_e (\
+             id INT PRIMARY KEY, parent_id INT NOT NULL REFERENCES rescan_parent(id), \
+             unused TEXT, label TEXT NOT NULL, created_at INT NOT NULL\
+         )",
+        "INSERT INTO rescan_parent VALUES (1, 10), (2, 20)",
+    ])
+    .await;
+
+    let query = "WITH agg_d AS (\
+                     SELECT d.parent_id, \
+                            count(*) FILTER (WHERE d.flag = 1) AS cnt_pos, \
+                            count(*) FILTER (WHERE d.flag = 0) AS cnt_zero, \
+                            max(d.created_at) AS latest_d \
+                     FROM rescan_d d GROUP BY d.parent_id\
+                 ), agg_e AS (\
+                     SELECT e.parent_id, count(*) AS cnt_e, \
+                            min(e.created_at) AS earliest_e, \
+                            string_agg(e.label, ',' ORDER BY e.label) AS labels \
+                     FROM rescan_e e GROUP BY e.parent_id\
+                 ) \
+                 SELECT p.id AS parent_id, \
+                        coalesce(d.cnt_pos, 0)::bigint AS cnt_pos, \
+                        coalesce(d.cnt_zero, 0)::bigint AS cnt_zero, \
+                        coalesce(e.cnt_e, 0)::bigint AS cnt_e, \
+                        d.latest_d, e.earliest_e, e.labels \
+                 FROM rescan_parent p \
+                 LEFT JOIN agg_d d ON d.parent_id = p.id \
+                 LEFT JOIN agg_e e ON e.parent_id = p.id";
+
+    db.create_st("rescan_join_st", query, "1m", "DIFFERENTIAL")
+        .await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    // Fold the first deltas into groups that already have NULL-padded ST rows.
+    db.execute("INSERT INTO rescan_d VALUES (1, 1, 'ignored', 1, 30)")
+        .await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    db.execute("INSERT INTO rescan_e VALUES (1, 1, 'ignored', 'beta', 40)")
+        .await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    // Change both joined aggregate branches in one refresh, including a newly
+    // populated parent group.
+    db.execute(
+        "INSERT INTO rescan_d VALUES (2, 1, 'ignored', 0, 50), \
+                                           (3, 2, 'ignored', 1, 60)",
+    )
+    .await;
+    db.execute(
+        "INSERT INTO rescan_e VALUES (2, 1, 'ignored', 'alpha', 35), \
+                                           (3, 2, 'ignored', 'gamma', 70)",
+    )
+    .await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    // UPDATE emits D/I pairs and changes each non-algebraic aggregate family.
+    db.execute("UPDATE rescan_d SET flag = 1, created_at = 55 WHERE id = 2")
+        .await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    db.execute("UPDATE rescan_e SET label = 'aardvark', created_at = 25 WHERE id = 2")
+        .await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    // Delete extrema and the only rows for parent 2 to exercise group rescans
+    // and the transition back to NULL-padded outer-join rows.
+    db.execute("DELETE FROM rescan_d WHERE id IN (2, 3)").await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+
+    db.execute("DELETE FROM rescan_e WHERE id IN (2, 3)").await;
+    db.refresh_st("rescan_join_st").await;
+    db.assert_st_matches_query("rescan_join_st", query).await;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 //  Tier 2 — Multi-Reference CTEs (Shared Delta)
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/e2e_cte_tests.rs
+++ b/tests/e2e_cte_tests.rs
@@ -639,6 +639,195 @@ async fn test_cte_chained_left_join_rescans_with_pruned_columns_stay_correct() {
     db.assert_st_matches_query("rescan_join_st", query).await;
 }
 
+#[tokio::test]
+async fn test_cte_aliases_survive_group_rescans() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute(
+        "CREATE TABLE cte_alias_src (\
+             id INT PRIMARY KEY, grp TEXT, val INT NOT NULL, unused TEXT\
+         )",
+    )
+    .await;
+    db.execute(
+        "INSERT INTO cte_alias_src VALUES \
+         (1, 'a', 10, 'ignored'), (2, 'a', 20, 'ignored'), (3, 'b', 30, 'ignored')",
+    )
+    .await;
+
+    let query = "WITH raw(g, v) AS (\
+                     SELECT s.grp, s.val FROM cte_alias_src s\
+                 ) \
+                 SELECT r.g, min(r.v) AS min_v, \
+                        string_agg(r.v::text, ',' ORDER BY r.v) AS vals \
+                 FROM raw AS r GROUP BY r.g";
+
+    db.create_st("cte_alias_rescan_st", query, "1m", "DIFFERENTIAL")
+        .await;
+    db.assert_st_matches_query("cte_alias_rescan_st", query)
+        .await;
+
+    db.execute("DELETE FROM cte_alias_src WHERE id = 1").await;
+    db.refresh_st("cte_alias_rescan_st").await;
+    db.assert_st_matches_query("cte_alias_rescan_st", query)
+        .await;
+
+    db.execute("UPDATE cte_alias_src SET grp = 'a', val = 5 WHERE id = 3")
+        .await;
+    db.refresh_st("cte_alias_rescan_st").await;
+    db.assert_st_matches_query("cte_alias_rescan_st", query)
+        .await;
+}
+
+#[tokio::test]
+async fn test_cte_aggregate_join_kinds_handle_simultaneous_dml() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute_seq(&[
+        "CREATE TABLE cte_join_parent (id INT PRIMARY KEY)",
+        "CREATE TABLE cte_join_l (\
+             id INT PRIMARY KEY, parent_id INT REFERENCES cte_join_parent(id), \
+             val INT NOT NULL, unused TEXT\
+         )",
+        "CREATE TABLE cte_join_r (\
+             id INT PRIMARY KEY, parent_id INT REFERENCES cte_join_parent(id), \
+             val INT NOT NULL, unused TEXT\
+         )",
+        "INSERT INTO cte_join_parent VALUES (1), (2)",
+        "INSERT INTO cte_join_l VALUES \
+             (1, 1, 10, 'ignored'), (2, 2, 20, 'ignored'), (4, NULL, 7, 'ignored')",
+        "INSERT INTO cte_join_r VALUES \
+             (1, 1, 100, 'ignored'), (2, 2, 200, 'ignored'), (4, NULL, 300, 'ignored')",
+    ])
+    .await;
+
+    let queries: Vec<(&str, String)> = [("inner", "INNER"), ("full", "FULL")]
+        .into_iter()
+        .map(|(name, join_kind)| {
+            (
+                name,
+                format!(
+                    "WITH agg_l AS (\
+                         SELECT parent_id, count(*) AS cnt_l, max(val) AS max_l \
+                         FROM cte_join_l GROUP BY parent_id\
+                     ), agg_r AS (\
+                         SELECT parent_id, count(*) AS cnt_r, min(val) AS min_r \
+                         FROM cte_join_r GROUP BY parent_id\
+                     ) \
+                     SELECT p.id AS parent_id, l.cnt_l, l.max_l, r.cnt_r, r.min_r \
+                     FROM cte_join_parent p \
+                     {join_kind} JOIN agg_l l ON l.parent_id = p.id \
+                     {join_kind} JOIN agg_r r ON r.parent_id = p.id"
+                ),
+            )
+        })
+        .collect();
+
+    for (name, query) in &queries {
+        db.create_st(
+            &format!("cte_{name}_agg_join_st"),
+            query,
+            "1m",
+            "DIFFERENTIAL",
+        )
+        .await;
+        db.assert_st_matches_query(&format!("cte_{name}_agg_join_st"), query)
+            .await;
+    }
+
+    db.execute("INSERT INTO cte_join_l VALUES (3, 1, 30, 'ignored')")
+        .await;
+    db.execute("INSERT INTO cte_join_r VALUES (3, 1, 50, 'ignored')")
+        .await;
+    db.execute("INSERT INTO cte_join_l VALUES (5, NULL, 3, 'ignored')")
+        .await;
+    db.execute("INSERT INTO cte_join_r VALUES (5, NULL, 400, 'ignored')")
+        .await;
+    for (name, query) in &queries {
+        let st_name = format!("cte_{name}_agg_join_st");
+        db.refresh_st(&st_name).await;
+        db.assert_st_matches_query(&st_name, query).await;
+    }
+
+    db.execute("UPDATE cte_join_l SET val = 40 WHERE id = 1")
+        .await;
+    db.execute("DELETE FROM cte_join_l WHERE id = 3").await;
+    db.execute("UPDATE cte_join_r SET val = 25 WHERE id = 1")
+        .await;
+    db.execute("DELETE FROM cte_join_r WHERE id = 3").await;
+    db.execute("UPDATE cte_join_l SET val = 9 WHERE id = 4")
+        .await;
+    db.execute("DELETE FROM cte_join_l WHERE id = 5").await;
+    db.execute("UPDATE cte_join_r SET val = 250 WHERE id = 4")
+        .await;
+    db.execute("DELETE FROM cte_join_r WHERE id = 5").await;
+    for (name, query) in &queries {
+        let st_name = format!("cte_{name}_agg_join_st");
+        db.refresh_st(&st_name).await;
+        db.assert_st_matches_query(&st_name, query).await;
+    }
+}
+
+#[tokio::test]
+async fn test_cte_nested_right_join_uses_consistent_old_snapshot() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute_seq(&[
+        "CREATE TABLE cte_nested_left (id INT PRIMARY KEY)",
+        "CREATE TABLE cte_nested_dim (\
+             id INT PRIMARY KEY, left_id INT NOT NULL REFERENCES cte_nested_left(id), \
+             unused TEXT\
+         )",
+        "CREATE TABLE cte_nested_event (\
+             id INT PRIMARY KEY, dim_id INT NOT NULL REFERENCES cte_nested_dim(id), \
+             val INT NOT NULL\
+         )",
+        "INSERT INTO cte_nested_left VALUES (1), (2), (3)",
+        "INSERT INTO cte_nested_dim VALUES (10, 1, 'ignored'), (20, 2, 'ignored')",
+        "INSERT INTO cte_nested_event VALUES (1, 10, 5), (2, 10, 8), (3, 20, 11)",
+    ])
+    .await;
+
+    let query = "WITH agg AS (\
+                     SELECT dim_id, count(*) AS cnt, max(val) AS max_v \
+                     FROM cte_nested_event GROUP BY dim_id\
+                 ) \
+                 SELECT l.id AS left_id, r.dim_id, r.cnt, r.max_v \
+                 FROM cte_nested_left l \
+                 LEFT JOIN (\
+                     SELECT d.left_id, a.dim_id, a.cnt, a.max_v \
+                     FROM cte_nested_dim d \
+                     INNER JOIN agg a ON a.dim_id = d.id\
+                 ) r ON r.left_id = l.id";
+
+    db.create_st("cte_nested_right_st", query, "1m", "DIFFERENTIAL")
+        .await;
+    db.assert_st_matches_query("cte_nested_right_st", query)
+        .await;
+
+    db.execute_seq(&[
+        "UPDATE cte_nested_dim SET left_id = 3 WHERE id = 10",
+        "DELETE FROM cte_nested_event WHERE id = 2",
+        "DELETE FROM cte_nested_event WHERE id = 3",
+        "INSERT INTO cte_nested_dim VALUES (30, 1, 'ignored')",
+        "INSERT INTO cte_nested_event VALUES (4, 30, 4)",
+    ])
+    .await;
+    db.refresh_st("cte_nested_right_st").await;
+    db.assert_st_matches_query("cte_nested_right_st", query)
+        .await;
+
+    db.execute_seq(&[
+        "UPDATE cte_nested_dim SET left_id = 2 WHERE id = 30",
+        "UPDATE cte_nested_event SET val = 12 WHERE id = 4",
+        "DELETE FROM cte_nested_event WHERE id = 1",
+    ])
+    .await;
+    db.refresh_st("cte_nested_right_st").await;
+    db.assert_st_matches_query("cte_nested_right_st", query)
+        .await;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 //  Tier 2 — Multi-Reference CTEs (Shared Delta)
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/e2e_dag_error_tests.rs
+++ b/tests/e2e_dag_error_tests.rs
@@ -396,8 +396,7 @@ async fn run_sibling_isolation_trace(seed: u64, config: TraceConfig) {
     for cycle in 1..=config.cycles {
         // Roll: 0=insert bad row(denom=0), 1-3=insert good row
         let roll = rng.usize_range(0, 3);
-        let step;
-        if roll == 0 {
+        let step = if roll == 0 {
             let id = ids.alloc();
             let grp = *rng.choose(&ERR_GROUPS);
             let val = rng.i32_range(1, 50);
@@ -405,7 +404,7 @@ async fn run_sibling_isolation_trace(seed: u64, config: TraceConfig) {
                 "INSERT INTO err_prop_src (id, grp, val, denom) VALUES ({id}, '{grp}', {val}, 0)"
             ))
             .await;
-            step = format!("ins-bad(id={id})");
+            format!("ins-bad(id={id})")
         } else {
             let id = ids.alloc();
             let grp = *rng.choose(&ERR_GROUPS);
@@ -416,8 +415,8 @@ async fn run_sibling_isolation_trace(seed: u64, config: TraceConfig) {
                  VALUES ({id}, '{grp}', {val}, {denom})"
             ))
             .await;
-            step = format!("ins-good(id={id})");
-        }
+            format!("ins-good(id={id})")
+        };
 
         // Healthy branch must always succeed.
         db.refresh_st("err_prop_ok").await;

--- a/tests/e2e_full_join_tests.rs
+++ b/tests/e2e_full_join_tests.rs
@@ -54,6 +54,46 @@ async fn test_full_join_basic_differential() {
     db.assert_st_matches_query("fj_basic_st", q).await;
 }
 
+#[tokio::test]
+async fn test_full_join_multi_event_null_transitions_emit_once() {
+    let db = E2eDb::new().await.with_extension().await;
+    db.execute("CREATE TABLE fj_transition_l (id INT PRIMARY KEY, key INT, val TEXT)")
+        .await;
+    db.execute("CREATE TABLE fj_transition_r (id INT PRIMARY KEY, key INT, val TEXT)")
+        .await;
+    db.execute(
+        "INSERT INTO fj_transition_l VALUES \
+         (1, 1, 'l1'), (2, 2, 'l2a'), (3, 2, 'l2b')",
+    )
+    .await;
+    db.execute(
+        "INSERT INTO fj_transition_r VALUES \
+         (1, 1, 'r1a'), (2, 1, 'r1b'), (3, 2, 'r2')",
+    )
+    .await;
+
+    let q = "SELECT l.id AS lid, l.key AS lkey, l.val AS lval, \
+                    r.id AS rid, r.key AS rkey, r.val AS rval \
+             FROM fj_transition_l l FULL JOIN fj_transition_r r ON l.key = r.key";
+    db.create_st("fj_transition_st", q, "1m", "DIFFERENTIAL")
+        .await;
+    db.assert_st_matches_query("fj_transition_st", q).await;
+
+    db.execute("DELETE FROM fj_transition_r WHERE key = 1")
+        .await;
+    db.execute("DELETE FROM fj_transition_l WHERE key = 2")
+        .await;
+    db.refresh_st("fj_transition_st").await;
+    db.assert_st_matches_query("fj_transition_st", q).await;
+
+    db.execute("INSERT INTO fj_transition_r VALUES (4, 1, 'r1c'), (5, 1, 'r1d')")
+        .await;
+    db.execute("INSERT INTO fj_transition_l VALUES (4, 2, 'l2c'), (5, 2, 'l2d')")
+        .await;
+    db.refresh_st("fj_transition_st").await;
+    db.assert_st_matches_query("fj_transition_st", q).await;
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // FULL JOIN with NULL join keys (F26)
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- preserve the full base-table source for ordinary aggregate rescans, so pruned scan columns cannot hide columns referenced by aggregate expressions
- keep projected source columns for intermediate aggregate rescans, where the reconstructed relation must match the delta shape used by the old-state calculation
- preserve CTE definitions and reference aliases while resolving chained CTE bodies for aggregate rescans
- make nullable aggregate-group filters null-safe with `IS NOT DISTINCT FROM`
- scope affected-group filters through renamed delta columns so source group expressions cannot be shadowed by the `EXISTS` subquery
- reconstruct exact pre-change snapshots for INNER, LEFT, and FULL join chains when their leaves support it, with a safe fallback for unsupported leaves
- use the correct pre-change state and real join keys for outer-join transition handling
- emit each NULL-padding transition once when several matching delta events affect the same preserved row
- expand CTE, aggregate, nested-join, NULL-group, simultaneous DML, and multi-event outer-join regression coverage

Closes #938

## Root cause

Column pruning narrowed scan nodes before aggregate rescan SQL was generated. The rescan then selected only the pruned columns even when the aggregate expression still referenced a raw or complex expression column. PostgreSQL consequently failed with errors such as `column "val" does not exist` and `column "priority" does not exist`.

The first NULL-safe affected-group filter also had a SQL name-resolution bug. A bare source group key inside `EXISTS` could resolve to the inner delta row, making the predicate tautological and rescanning every group. That inflated nested q13 distributions.

The same change exposed nearby snapshot assumptions. CTE aliases are not physical relations during recursive rescan reconstruction, unsupported join leaves cannot be combined from mixed old and current snapshots, FULL JOIN exclusion guards must use each side's actual join keys, and a NULL-padded outer-join row is a single state transition rather than one transition per matching delta event.

## Implementation

- ordinary aggregate rescans read the underlying table directly, while intermediate aggregate rescans retain the pruned projection required for positional old/new state alignment
- aggregate CTE reconstruction recursively resolves CTE bodies and applies definition and reference aliases
- affected-group filters project delta keys under private names before correlating them, preserving NULL-safe matching without source-column shadowing
- pre-change snapshot selection now distinguishes exact per-leaf reconstruction from combined fallback reconstruction
- outer-join parts use the correct L₀/R₀ state and `EXISTS` guards to prevent duplicate NULL-padding transitions
- aggregate intermediate row identities include the complete output state where D/I pairs flow through a parent operator

## Testing

- `just fmt`
- `just lint`
- local unit suite: 2,376 passed
- focused q13-shaped aggregate regression test: passed
- local correctness gate: 5/5 passed, including q13 with the normal aggregate fast path
- PR CI Linux unit tests, integration tests, lint, Semgrep, secret scanning, unsafe inventory, docs drift, Windows compile, and upgrade completeness: passed on the preceding fix revision
- E2E coverage includes pruned aggregate columns, CTE aliases, nullable groups, INNER/LEFT/FULL join chains, nested join snapshots, simultaneous insert/update/delete batches, repeated NULL-padding transitions, and the q13 nested aggregate query
