### PR TITLE
Fix source DDL for IMMEDIATE stream tables

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -812,6 +812,21 @@ fn handle_alter_table(objid: pg_sys::Oid, identity: &str) {
         return;
     }
 
+    // IMMEDIATE consumers use transition-table IVM triggers, not CDC buffers.
+    // A source shared with any deferred consumer still needs CDC maintenance.
+    let uses_deferred_cdc = match StDependency::effective_requested_mode_for_source(objid) {
+        Ok(mode) => mode.is_some(),
+        Err(e) => {
+            pgrx::error!(
+                "pg_trickle: DDL hook could not inspect refresh modes — \
+                 schema change blocked to prevent inconsistent state \
+                 (source: {}, error: {})",
+                identity,
+                e
+            );
+        }
+    };
+
     // Classify the schema change and only reinitialize for column-affecting
     // changes.  Benign DDL (adding indexes, comments, statistics) and
     // constraint-only changes skip reinit when column tracking is populated.
@@ -851,6 +866,23 @@ fn handle_alter_table(objid: pg_sys::Oid, identity: &str) {
                          and re-enable: SET pg_trickle.block_source_ddl = true.",
                         identity,
                     );
+                }
+                if !uses_deferred_cdc {
+                    pgrx::notice!(
+                        "pg_trickle_ddl_tracker: ALTER TABLE ADD COLUMN on {} for ST {} \
+                         — no change buffer update needed for IMMEDIATE mode",
+                        identity,
+                        pgt_id,
+                    );
+                    if let Err(e) = crate::catalog::store_column_snapshot_for_pgt_id(*pgt_id, objid)
+                    {
+                        pgrx::warning!(
+                            "pg_trickle_ddl_tracker: failed to refresh column snapshot for ST {}: {}",
+                            pgt_id,
+                            e,
+                        );
+                    }
+                    continue;
                 }
                 // Task 3.5: Only new columns were added — extend the change buffer
                 // and rebuild the CDC trigger in-place without a full reinit.
@@ -996,7 +1028,7 @@ fn handle_alter_table(objid: pg_sys::Oid, identity: &str) {
     // Always rebuild — even for benign changes — to stay in sync with the
     // catalog. The cost is negligible (single CREATE OR REPLACE FUNCTION).
     let change_schema = config::pg_trickle_change_buffer_schema();
-    if let Err(e) = cdc::rebuild_cdc_trigger_function(objid, &change_schema) {
+    if uses_deferred_cdc && let Err(e) = cdc::rebuild_cdc_trigger_function(objid, &change_schema) {
         pgrx::warning!(
             "pg_trickle_ddl_tracker: failed to rebuild CDC trigger function for {}: {}",
             identity,

--- a/tests/e2e_ddl_event_tests.rs
+++ b/tests/e2e_ddl_event_tests.rs
@@ -429,6 +429,49 @@ async fn test_add_column_unused_st_survives_refresh() {
         .await;
 }
 
+#[tokio::test]
+async fn test_add_column_unused_immediate_st_stays_functional() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ddl_add_imm_src (id INT PRIMARY KEY, val INT)")
+        .await;
+    db.execute("INSERT INTO ddl_add_imm_src VALUES (1, 10)")
+        .await;
+    db.create_st(
+        "ddl_add_imm_st",
+        "SELECT id, val FROM ddl_add_imm_src",
+        "1m",
+        "IMMEDIATE",
+    )
+    .await;
+
+    db.execute_seq(&[
+        "SET pg_trickle.block_source_ddl = false",
+        "ALTER TABLE ddl_add_imm_src ADD COLUMN extra TEXT DEFAULT 'unused'",
+        "SET pg_trickle.block_source_ddl = true",
+    ])
+    .await;
+    db.execute("UPDATE ddl_add_imm_src SET val = 20 WHERE id = 1")
+        .await;
+
+    db.assert_st_matches_query(
+        "public.ddl_add_imm_st",
+        "SELECT id, val FROM ddl_add_imm_src",
+    )
+    .await;
+
+    let source_oid = db.table_oid("ddl_add_imm_src").await;
+    let buffer_exists: bool = db
+        .query_scalar(&format!(
+            "SELECT to_regclass('pgtrickle_changes.changes_{source_oid}') IS NOT NULL"
+        ))
+        .await;
+    assert!(
+        !buffer_exists,
+        "IMMEDIATE source DDL must not create a CDC change buffer"
+    );
+}
+
 // ══════════════════════════════════════════════════════════════════════
 // B2 — DROP COLUMN not referenced in query → ST remains functional
 // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Skip CDC buffer and trigger-function maintenance when a source has only `IMMEDIATE` consumers.
- Preserve CDC maintenance when the source also has a deferred consumer.
- Refresh dependency column snapshots after an allowed `ADD COLUMN` on an `IMMEDIATE` source.
- Add light-E2E coverage for `ADD COLUMN`, synchronous DML propagation, and the absence of a CDC buffer.

## Why

`IMMEDIATE` stream tables use transition-table IVM triggers and do not create CDC change buffers. The DDL hook treated every source as deferred CDC and cast the missing buffer name to `regclass`, which aborted `ALTER TABLE ADD COLUMN`.

## Testing

- `just fmt`
- `just lint`
- `just test-unit`
- `bash ./scripts/run_light_e2e_tests.sh --package --test e2e_ddl_event_tests`

Fixes #940
