### PR TITLE
docs: add lifecycle security roadmap releases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -443,6 +443,14 @@ exact oracle and durable test system first. The sequence hardens failure
 detection, makes cases replayable, broadens composition and state coverage,
 adds DVM contracts, and ends with a machine-enforced release gate.
 
+The lifecycle-security review for issue #941 found another boundary that must
+land before v0.88.0. Seven releases, about 42 person-weeks in total, separate
+private extension work from caller-authored SQL, move every refresh mode to
+stream-owner execution, harden each lifecycle API, and finish with independent
+snapshot, publication, and pg_tide outbox gates. The
+[reimplementation plan](plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+defines the shared invariants and test matrix.
+
 | Version | Theme | User promise | Status | Scope | Full details |
 |---------|-------|--------------|--------|-------|--------------|
 | [v0.81.0](roadmap/v0.81.0.md) | Observability, Self-Tuning & Quick Wins: commit-to-visible latency metric using pg_xact_commit_timestamp (QW-1), configuration advisor function pgtrickle.tune_recommendations() (QW-2), preview/dry-run mode pgtrickle.preview_stream_table() (QW-3), OpenTelemetry trace spans on scheduler_tick/refresh_cycle/delta_execute/merge_apply with OTLP export (QW-4), bounded LRU eviction on thread-local L0/L1 template caches (QW-5), DeltaOperator trait for extensible operator dispatch (QW-6), split config.rs into config/scheduler.rs + config/cdc.rs + config/dvm.rs + config/monitoring.rs (QW-7), self-healing circuit breaker with auto-remediation for OOM/lock-timeout/sustained-lag (QW-8), chunked MERGE for large deltas with configurable merge_batch_size GUC (QW-9), stream table presets ('real-time'/'batch'/'cost-optimized') (QW-10) | — | ✅ Released | Large | [Full details](roadmap/v0.81.0.md) |
@@ -458,6 +466,13 @@ adds DVM contracts, and ends with a machine-enforced release gate.
 | [v0.87.4](roadmap/v0.87.4.md) | Stateful and Metamorphic Correctness: directed boundary transitions, simultaneous multi-source histories, and equivalent query and mutation paths | "Equivalent queries and mutation histories stay equivalent." | Planned | 7-8 pw | [Full details](roadmap/v0.87.4.md) |
 | [v0.87.5](roadmap/v0.87.5.md) | DVM Correctness Contracts and Semantic Coverage: typed relation schemas, structured snapshot plans, decision traces, and observed-path coverage floors | "The DVM checks and reports the assumptions behind each delta." | Planned | 7-8 pw | [Full details](roadmap/v0.87.5.md) |
 | [v0.87.6](roadmap/v0.87.6.md) | Deep Fuzzing, Shrinking, and Release Gate: automatic minimization, coverage-selected corpus retention, tiered deep jobs, and active negative controls | "Known differential defect classes cannot return unnoticed." | Planned | 6-8 pw | [Full details](roadmap/v0.87.6.md) |
+| [v0.87.7](roadmap/v0.87.7.md) | Security Context and Catalog Foundation: exact outer-caller identity and path capture, restricted stream-owner execution, guaranteed restoration, and defining-path catalog migration | "Lifecycle APIs never lend extension-owner privileges to defining SQL." | Planned | 6 pw | [Full details](roadmap/v0.87.7.md) |
+| [v0.87.8](roadmap/v0.87.8.md) | Refresh Execution Identity: prepare, owner-execute, and finalize phases for full and differential refresh, private CDC staging, and owner execution in every refresh mode | "Every refresh evaluates defining SQL as the stream owner." | Planned | 6 pw | [Full details](roadmap/v0.87.8.md) |
+| [v0.87.9](roadmap/v0.87.9.md) | Core Lifecycle Security: canonical name resolution, hardened create-or-replace and alter, owner-preserving recreation, and fully preauthorized cascade drop | "An owner can manage a stream table without private-schema grants." | Planned | 6 pw | [Full details](roadmap/v0.87.9.md) |
+| [v0.87.10](roadmap/v0.87.10.md) | Complete Lifecycle Policy: remaining owner APIs, atomic bulk operations, exact SQL policy, static boundary checks, upgrade preflight, and least-privilege documentation | "Every lifecycle API has one enforced execution and authorization policy." | Planned | 6 pw | [Full details](roadmap/v0.87.10.md) |
+| [v0.87.11](roadmap/v0.87.11.md) | Snapshot Security: caller-checked target schemas, explicit snapshot ownership, provenance-bound restore and drop, and transfer-safe behavior | "Snapshots cannot cross ownership or schema boundaries by accident." | Planned | 6 pw | [Full details](roadmap/v0.87.11.md) |
+| [v0.87.12](roadmap/v0.87.12.md) | Publication Security: caller-equivalent database privileges, explicit publication ownership, provenance-safe bindings, and atomic catalog integration | "Publication APIs grant no authority beyond the caller's own database rights." | Planned | 6 pw | [Full details](roadmap/v0.87.12.md) |
+| [v0.87.13](roadmap/v0.87.13.md) | pg_tide Outbox Boundary: caller-context pg_tide calls, separate private bookkeeping, rollback-safe integration, and absent, denied, and authorized compatibility tests | "pg_trickle never lends its owner identity to pg_tide." | Planned | 6 pw | [Full details](roadmap/v0.87.13.md) |
 | [v0.88.0](roadmap/v0.88.0.md) | Vectorized Aggregates & Delta Planning: DiffContext decomposition into CdcContext/CacheContext/OptimizationContext first (ENG-1), a vectorized columnar path for pure-aggregate stream tables gated on an ADR that revisits the v0.76.0 Arrow dependency removal (MT-8), and cost-based operator scheduling reordering operators within delta queries based on estimated cardinality (LT-9) | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.88.0.md) |
 | [v0.89.0](roadmap/v0.89.0.md) | Incremental Window Functions: a bounded, crash-safe auxiliary state model (LT-7a), rank-family algorithms (LT-7b), offset and boundary algorithms (LT-7c), aggregate-over-window algorithms (LT-7d), and documented fallback with reason codes and support-matrix entries for uncovered frames (LT-7e) | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.89.0.md) |
 | [v0.90.0](roadmap/v0.90.0.md) | Freshness Controller & Self-Tuning: target_freshness becomes authoritative with every scheduler knob demoted to an optional override (SLA-1), a closed-loop controller choosing refresh timing, DIFFERENTIAL vs FULL, batch size, concurrency, priority and deferral from measured cost (SLA-2), adaptive worker pool sizing driven by CPU utilization, queue depth and SLA risk (SLA-3), pgtrickle.freshness() plus sla_status in pg_stat_pgtrickle, health_check() and Prometheus/OTel (SLA-4), continuous infeasible-SLA detection (SLA-5), and an audit that retires the knobs users should not need (SLA-6) | "Tell it how fresh I need data; it figures out the rest." | Planned | Large | [Full details](roadmap/v0.90.0.md) |
@@ -482,7 +497,9 @@ is not a plan.
 > **On the version count.** The six v0.87.x correctness releases add about 42
 > person-weeks before v0.88.0. They do not add SQL features. They build the
 > oracle, generation, contracts, corpus, and release gates that must protect
-> later DVM changes.
+> later DVM changes. The seven lifecycle-security releases add another 42
+> person-weeks. They establish the execution boundary that later engine changes
+> must preserve.
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
@@ -633,6 +650,8 @@ v0.86    ─── Product UX & transparency: pgtrickle.explain(), FULL-reason c
 v0.87    ─── Low-impact refresh: pipelined execution (supersedes chunked MERGE), cheaper capture, backpressure, memory budget, overhead benchmark gate
     │
 v0.87.1-6 ─── DVM correctness program: exact oracle, replay corpus, composition and state testing, contracts, shrinking, release gate
+    │
+v0.87.7-13 ─── Lifecycle security: owner execution, refresh isolation, hardened APIs, snapshots, publications, pg_tide boundary
     │
 v0.88    ─── Vectorized aggregates & delta planning: DiffContext split first, columnar aggregate path behind a dependency ADR, cost-based operator scheduling
     │
@@ -999,9 +1018,12 @@ does not start immediately after that work. v0.87.1 through v0.87.6 make wrong
 results impossible to hide behind counts, skips, or fallback, preserve every
 failure as a replayable scenario, exercise operator compositions and stateful
 histories, add explicit DVM schema and snapshot contracts, and enforce the
-result in CI. v0.88.0 and v0.89.0 then change engine internals: a vectorized
-aggregate path and cost-based delta planning first, followed by incremental
-window-function algorithms, with no deployment or API change.
+result in CI. v0.87.7 through v0.87.13 then ensure that caller-authored SQL
+runs only as the stream owner. The sequence hardens refresh, lifecycle,
+snapshot, publication, and pg_tide boundaries with separate release gates.
+v0.88.0 and v0.89.0 then change engine internals: a vectorized aggregate path
+and cost-based delta planning first, followed by incremental window-function
+algorithms, with no deployment or API change.
 
 v0.90.0 makes freshness authoritative: the closed-loop controller derives the
 schedule, the DIFFERENTIAL/FULL decision, batch sizes, concurrency and priority

--- a/plans/pg_trickle_lifecycle_security_reimplementation_plan.md
+++ b/plans/pg_trickle_lifecycle_security_reimplementation_plan.md
@@ -1,0 +1,979 @@
+# Reimplementation Plan: Secure Stream-Table Lifecycle APIs on `origin/main`
+
+## 1. Executive summary
+
+Reimplement the work behind issue `#941` and PRs `#942`/`#943` from a fresh branch based on the current upstream `origin/main`. Do **not** cherry-pick either PR. Use them only as a catalogue of edge cases and useful regression tests.
+
+The implementation must solve two separate problems:
+
+1. **Private-infrastructure access:** a non-superuser stream-table owner should be able to call an explicitly granted lifecycle API without direct privileges on `pgtrickle` catalog tables or the `pgtrickle_changes` schema.
+2. **Execution-identity safety:** SQL supplied by a stream-table author, including user-defined functions, operators, views, casts, and RLS policies, must not accidentally execute with the extension owner's elevated privileges merely because a lifecycle function is `SECURITY DEFINER`.
+
+The recommended design is:
+
+- Public owner-lifecycle entry points may use `SECURITY DEFINER` with a pinned path when they need private infrastructure.
+- Every call captures the original caller's role and exact pre-function `search_path` in a typed `CallerContext`.
+- Every operation that parses, resolves, rewrites, plans, or executes user-authored SQL runs under a restricted **stream-owner context**, not under the extension owner.
+- Private catalog, CDC, trigger, and bookkeeping operations remain in the privileged context and use fully qualified, catalog-derived identifiers.
+- Refresh execution is split into **prepare → execute-as-owner → finalize** phases so the same identity rule holds for initial, manual, scheduled, full, differential, and immediate refreshes.
+- The work is delivered as several reviewable PRs, with the core issue fixed before the higher-risk snapshot/publication/outbox integrations.
+
+This is deliberately more structured than mechanically adding `security_definer` annotations. The latter fixes the grant problem but can widen the authority of caller-controlled SQL and object creation.
+
+---
+
+## 2. Baseline and branch policy
+
+At the time this plan was written:
+
+- Upstream branch: `origin/main`
+- Baseline commit: `e5fed2dc8c31ff8d1311f3f51db934ec58aff3ce`
+- Package version: `0.87.2`
+- PostgreSQL target: PostgreSQL 18
+- pgrx version: `0.18.0`
+
+Create the implementation branch from the latest upstream head at the time coding begins:
+
+```bash
+git fetch origin --prune
+git switch --create fix/lifecycle-privilege-boundary origin/main
+git rev-parse HEAD
+git status --short
+```
+
+Record the actual base SHA in the first commit and PR description. Rebase on `origin/main` again immediately before final CI and merge.
+
+### Branch rules
+
+- Do not merge or cherry-pick PR `#942` or `#943` into the implementation branch.
+- Port only well-understood ideas: exact caller-path handling, storage-owner preservation, all-target cascade authorization, and relevant behavioral tests.
+- Keep generated SQL, upgrade SQL, API policy, docs, and test changes in the same PR as the behavior they describe.
+- Avoid a single very large PR. Use the staged PR sequence in section 8.
+
+---
+
+## 3. Security model and non-negotiable invariants
+
+The implementation is complete only when all of these invariants are true.
+
+### 3.1 Caller identity
+
+1. `GetOuterUserId()` identifies the original SQL caller at every public `SECURITY DEFINER` boundary.
+2. Authorization is always evaluated against that caller, never against `current_user` while the definer is active.
+3. A caller can operate only on stream tables they own, except for the existing superuser bypass.
+4. Cascades and bulk operations authorize **every affected stream table before the first mutation**.
+
+### 3.2 User-authored SQL
+
+5. User-authored defining SQL never executes as the extension owner.
+6. Query parsing, rewrite, view expansion, function/operator resolution, full refresh SQL, differential SQL, Top-K SQL, and immediate-mode expression execution use the current stream-table owner's role.
+7. Source-table ACLs and RLS are therefore evaluated consistently as the stream-table owner for initial, manual, and scheduled refreshes.
+8. A privilege error in user SQL fails the operation without advancing the frontier or leaving partially rebuilt storage.
+
+### 3.3 Search path
+
+9. Public definer functions use a fixed path containing only trusted schemas, normally:
+
+   ```text
+   pgtrickle, pg_catalog, pg_temp
+   ```
+
+10. The exact caller path that was active before entering the definer function is captured, normalized, and stored with the defining query.
+11. The special `"$user"` path element is expanded to the quoted original caller before storage, so later ownership changes do not reinterpret it under the extension owner.
+12. Unqualified target and source names resolve under the captured caller context, not under the pinned definer path.
+13. The previous role, security flags, GUC nesting level, and search path are restored after success, PostgreSQL `ERROR`, and Rust error paths.
+
+### 3.4 Privileged work
+
+14. Privileged code accepts canonical OIDs and quoted/catalog-derived identifiers, not unresolved caller strings.
+15. Caller SQL is never interpolated or executed inside a privileged-only section.
+16. Calls into another extension, such as `pg_tide`, are not automatically made with pg_trickle's owner privileges. The called extension must enforce its own boundary.
+17. Caller-selected output schemas and database-wide objects require caller-equivalent privilege checks.
+
+### 3.5 Transactionality
+
+18. Storage recreation, catalog replacement, trigger/CDC changes, and full repopulation remain atomic in one PostgreSQL transaction or an internal subtransaction.
+19. Failed cascades, failed owner-context execution, or failed ownership transfer roll back all preceding mutations.
+20. Refresh frontiers and success history are finalized only after owner-context SQL succeeds.
+
+---
+
+## 4. Scope
+
+### 4.1 Core issue scope
+
+The first functional delivery fixes the three functions named by issue `#941`:
+
+- `pgtrickle.create_or_replace_stream_table`
+- `pgtrickle.alter_stream_table`
+- `pgtrickle.drop_stream_table`
+
+It also refactors shared creation and refresh machinery used by:
+
+- `create_stream_table`
+- `create_stream_table_if_not_exists`
+- creation presets and `bulk_create`
+- full refreshes triggered by ALTER or reinitialization
+
+This shared work is necessary because create-or-replace delegates to existing create/alter implementations.
+
+### 4.2 Follow-up owner-lifecycle scope
+
+After the core boundary is proven, extend it to:
+
+- `set_stream_table_refresh_policy`
+- `set_stream_table_storage_policy`
+- `bulk_alter_stream_tables`
+- `bulk_drop_stream_tables`
+- `reset_fuse`
+- `stat_reset`
+- `pause_stream_table`
+- `resume_stream_table`
+- `repair_stream_table`
+- `refresh_stream_table` only after all refresh modes use owner-context execution
+
+### 4.3 Separate capability-specific scope
+
+Handle these in independent PRs because stream ownership is not the only relevant permission:
+
+- Snapshot APIs
+- Publication APIs
+- Outbox/pg_tide APIs
+
+### 4.4 Functions intentionally left `SECURITY INVOKER`
+
+Unless a separate design demonstrates a need, retain invoker execution for:
+
+- `write_and_refresh`, because it executes arbitrary caller SQL
+- `exec_stream_ddl`, because it is a dispatcher to checked APIs
+- `refresh_if_stale`, if it only delegates to the hardened refresh API
+- canary wrappers that delegate to checked lifecycle functions
+- subscription APIs that do not resolve a canonical stream relation
+- global cross-stream diagnostic reports
+
+The API policy should explain each exception instead of relying on a name-based convention.
+
+---
+
+## 5. Architecture
+
+## 5.1 New security-context module
+
+Create `src/api/security_context.rs` and keep all identity-switching `unsafe` code in this module.
+
+### Types
+
+```rust
+pub(crate) struct CallerContext {
+    pub role_oid: pg_sys::Oid,
+    pub role_name: String,
+    pub search_path: String,
+}
+
+pub(crate) struct StreamExecutionContext {
+    pub owner_oid: pg_sys::Oid,
+    pub search_path: String,
+}
+
+pub(crate) enum EntryContext {
+    SecurityDefiner,
+    SecurityInvoker,
+}
+```
+
+### Capture functions
+
+Implement:
+
+```rust
+capture_caller_context(entry: EntryContext) -> Result<CallerContext, PgTrickleError>
+stream_execution_context(meta: &StreamTableMeta) -> Result<StreamExecutionContext, PgTrickleError>
+```
+
+For a definer entry:
+
+- Read `GetOuterUserId()`.
+- Recover the exact pre-function `search_path` from PostgreSQL's function GUC stack.
+- Fail closed if the `search_path` GUC record or expected `GUC_SAVE` stack entry is absent.
+- Expand a standalone `"$user"` element while preserving quoted identifiers, commas inside quoted names, escaped quotes, and whitespace.
+
+For an invoker entry:
+
+- Read `current_setting('search_path')` directly.
+- Still use `GetOuterUserId()` for consistent nested-wrapper behavior.
+
+### Restricted owner execution
+
+PostgreSQL 18 provides `SwitchToUntrustedUser` and `RestoreUserContext`. Add a small `#[repr(C)]` declaration for PostgreSQL's `UserContext` and local FFI declarations if pgrx does not expose them.
+
+Implement one audited helper:
+
+```rust
+with_stream_owner_context<T>(
+    ctx: &StreamExecutionContext,
+    f: impl FnOnce() -> Result<T, PgTrickleError>,
+) -> Result<T, PgTrickleError>
+```
+
+Required behavior:
+
+1. Save the current definer identity and security flags.
+2. Switch to the stream owner using PostgreSQL's untrusted-user helper.
+3. Set the stored defining `search_path` transaction-locally.
+4. Explicitly set `row_security = on` for owner-executed defining SQL.
+5. Execute the closure through `PgTryBuilder`.
+6. Restore GUC state and identity in `finally`, including PostgreSQL `ERROR` paths.
+7. Support nested calls without leaking the inner path or role.
+8. Add a debug assertion that the active user inside the closure equals the expected owner.
+
+Do not expose a generic “run as arbitrary role” public API. The target role must come from the canonical stream relation or captured outer caller.
+
+### Unsafe-code requirements
+
+- Every unsafe block receives a precise `// SAFETY:` explanation.
+- Update `.unsafe-baseline` only after review of the new blocks.
+- Add unit tests for the pure search-path parser.
+- Add PostgreSQL-backed tests for identity restoration after errors.
+
+---
+
+## 5.2 Persist the defining-query search path
+
+Add a column to `pgtrickle.pgt_stream_tables`:
+
+```sql
+defining_search_path TEXT NOT NULL
+```
+
+Update `StreamTableMeta` and all row decoding/insert/update paths.
+
+### Write policy
+
+- On CREATE: store the captured caller path.
+- On `ALTER ... query => ...`: store the caller path used to resolve the new query.
+- On create-or-replace with a changed query: store the new caller path.
+- On config-only ALTER or no-op create-or-replace: preserve the existing value.
+- On scheduled/manual refresh: use the stored value.
+- On storage ownership transfer: preserve the stored value; execution identity changes to the new current relation owner, but name resolution remains the path under which the definition was authored.
+
+### Legacy-row backfill
+
+For existing rows, backfill the behavior used by current main:
+
+```text
+quote_ident(current storage owner) + ', public'
+```
+
+Use `pg_class.relowner` and `pg_roles.rolname`. Fail the upgrade if a catalog row references a missing storage relation rather than silently inventing a path.
+
+---
+
+## 5.3 Canonical name resolution
+
+Replace ad hoc `splitn('.')`, hard-coded `public`, and `current_schema()` calls made under a definer path.
+
+Implement context-aware resolvers:
+
+```rust
+resolve_existing_stream_table(name, caller_ctx)
+resolve_create_target(name, caller_ctx)
+resolve_existing_relation(name, execution_ctx)
+resolve_target_schema(name, caller_ctx)
+```
+
+Rules:
+
+- Existing relations resolve via PostgreSQL under the caller role/path and return OID plus canonical schema/name.
+- Nonexistent create targets use the caller's effective `current_schema()` under their captured path.
+- Once resolved, all privileged phases use canonical OIDs or `QualifiedIdentifier` values.
+- Identifier quoting must use a single shared helper; never concatenate unescaped caller strings into SQL.
+
+Apply this to create, create-or-replace, alter, drop, bulk operations, snapshots, publications, and outbox APIs.
+
+---
+
+## 5.4 Split lifecycle implementations into phases
+
+Refactor mixed functions into explicit phases. Use typed structs rather than threading raw strings through privileged code.
+
+### Create
+
+```text
+prepare_create_as_caller
+    → apply_private_create_as_definer
+    → initialize_storage_as_owner
+    → finalize_create_as_definer
+```
+
+`prepare_create_as_caller`:
+
+- Resolve the output target.
+- Validate caller `CREATE` on the target schema.
+- Parse/rewrite/validate the defining query as caller.
+- Resolve source OIDs as caller.
+- Validate caller `SELECT` and schema `USAGE`.
+- Produce a `PreparedCreatePlan` containing only canonical values.
+
+`apply_private_create_as_definer`:
+
+- Create storage and private catalog rows.
+- Create CDC/IVM infrastructure.
+- Transfer storage ownership to the caller before any defining-query execution.
+- Store `defining_search_path`.
+
+`initialize_storage_as_owner`:
+
+- Run the generated full-population SQL as the storage owner.
+- Use the stored path and `row_security = on`.
+
+`finalize_create_as_definer`:
+
+- Store frontier/history state.
+- Invalidate scheduler/DAG caches.
+
+All phases remain in one transaction.
+
+### Alter
+
+```text
+load_and_authorize_target
+    → prepare_alter_as_owner
+    → apply_private_alter_as_definer
+    → repopulate_as_owner when required
+    → finalize_as_definer
+```
+
+Requirements:
+
+- Capture the old storage `relowner` before destructive recreation.
+- Transfer every recreated table back to that exact owner before repopulation.
+- Query rewrite, dependency extraction, Top-K detection, incremental-admission parsing, and full repopulation run as owner.
+- Private catalog/CDC mutation remains definer-only.
+- Preserve atomic rollback across query migration, mode changes, and partition-key changes.
+
+### Drop
+
+Replace recursive “authorize root, mutate, then recurse” behavior with a precomputed `DropPlan`:
+
+1. Resolve root under caller context.
+2. Traverse all downstream dependencies without mutation.
+3. Detect cycles/duplicates and build deterministic child-first order.
+4. Check ownership of every target against the original caller.
+5. Reject the whole plan before mutation if one target is unauthorized.
+6. Execute the plan as definer using canonical IDs.
+
+Reuse the same planner for single cascade and bulk drop.
+
+---
+
+## 5.5 Refresh execution: prepare, owner execution, finalize
+
+This work is a prerequisite for making `refresh_stream_table` definer-backed and for claiming that defining SQL does not inherit extension-owner privileges.
+
+### Full refresh
+
+Split current full refresh into:
+
+1. **Privileged prepare**
+   - Load private metadata/dependencies.
+   - Acquire locks.
+   - Validate private change buffers.
+   - Snapshot downstream state if needed.
+   - Disable extension-managed bookkeeping where required.
+
+2. **Owner execution**
+   - Run the defining `SELECT` and its row-identity/auxiliary expressions as stream owner.
+   - Write to the owner-owned storage table.
+   - Use stored path and RLS-on semantics.
+
+3. **Privileged finalize**
+   - Capture downstream deltas.
+   - Re-enable triggers.
+   - Store frontier/history.
+   - Clean private buffers and invalidate caches.
+
+### Differential refresh
+
+Current generated MERGE SQL reads private CDC buffers and may also evaluate expressions originating in the defining query. Separate those concerns.
+
+Introduce a `DeltaStage` abstraction:
+
+```rust
+struct DeltaStage {
+    source_oid: pg_sys::Oid,
+    relation: QualifiedIdentifier, // pg_temp relation
+    lower_bound: String,
+    upper_bound: String,
+}
+```
+
+Privileged prepare:
+
+- Copy only the bounded CDC rows required for this refresh into uniquely named `pg_temp` staging tables.
+- Preserve typed columns, operation markers, LSNs, changed-column masks, and row identity fields.
+- Grant the stream owner `SELECT` on each staging relation; do not grant access to `pgtrickle_changes`.
+- Return a source-OID → staged-relation map.
+
+Owner execution:
+
+- Extend DVM/codegen APIs to accept the staged-relation map instead of embedding private buffer names.
+- Execute the generated delta/MERGE SQL as stream owner.
+- Ensure this phase references only source relations, owner-owned stream storage, `pg_temp` stages, and trusted `pg_catalog` objects.
+
+Privileged finalize:
+
+- Advance frontier only after successful owner execution.
+- Perform buffer cleanup using the committed bounds.
+- Drop stages explicitly; retain `ON COMMIT DROP` as a safety net.
+
+### Immediate mode
+
+Audit `src/ivm.rs` and trigger apply functions. CDC capture may remain definer-owned, but expression-bearing SQL derived from a stream definition must run under the stream owner's stored execution context. Add the same identity tests for IMMEDIATE mode.
+
+### Fused and parallel refresh
+
+A fused execution unit may contain only stream tables with the same owner OID
+and stored defining path. Split mixed-owner or mixed-path units before SQL
+generation and preserve dependency order. Parallel workers establish and
+restore their owner context independently.
+
+### Failure rules
+
+- Owner-context permission or RLS errors mark refresh failed.
+- Never advance frontier on failure.
+- Never clean source buffer rows beyond a failed refresh's previous frontier.
+- Always restore the scheduler backend's original superuser context.
+
+---
+
+## 6. API-specific authorization rules
+
+## 6.1 Core and simple lifecycle APIs
+
+| API | Required checks | Execution notes |
+|---|---|---|
+| create/create-or-replace | caller source `SELECT`, source schema `USAGE`, target schema `CREATE` | defining SQL as caller/owner; private setup as definer |
+| alter/policy/bulk alter | ownership of every target; source checks for changed query | prevalidate full batch before mutation |
+| drop/bulk drop | ownership of every target in complete drop plan | child-first atomic execution |
+| pause/resume | stream ownership | no defining SQL; private CDC/catalog work allowed as definer |
+| repair | stream ownership; canonical dependency validation | no arbitrary caller SQL in privileged phase |
+| reset_fuse/stat_reset | stream ownership | catalog-only mutation |
+| refresh | stream ownership | enable only after all refresh modes use owner execution |
+
+## 6.2 Snapshots
+
+Define explicit ownership semantics rather than inheriting definer authority accidentally.
+
+Recommended policy:
+
+- Default internally named snapshots may be created in `pgtrickle` as definer, then transferred to the caller.
+- A caller-supplied target schema requires caller `USAGE` and `CREATE` privileges.
+- Every created snapshot is owned by its creator and records creator OID/provenance.
+- Restore requires:
+  - ownership of the destination stream table, and
+  - `SELECT` on the snapshot relation.
+- Drop requires ownership of the snapshot relation, or superuser.
+- Transferring a stream table does not silently transfer historical snapshots.
+
+Add tests for ownership transfer and custom target schemas.
+
+## 6.3 Publications
+
+- Require stream ownership.
+- Require caller-equivalent `CREATE` privilege on the current database.
+- Prefer running `CREATE PUBLICATION` under caller context; update the private pg_trickle catalog separately as definer.
+- If privileged creation is unavoidable, transfer publication ownership to the caller and verify it in `pg_publication`.
+- Drop must verify both the pg_trickle binding and the publication's expected identity/owner.
+
+## 6.4 pg_tide outbox integration
+
+- Check stream ownership first.
+- Invoke `tide.outbox_create`/related pg_tide APIs as the caller, allowing pg_tide to enforce its own security model.
+- Never lend pg_trickle's extension-owner identity to a different extension.
+- Register or remove pg_trickle's private mapping in a separate definer phase.
+- Add integration tests for pg_tide absent, present-but-denied, and present-and-authorized states.
+
+---
+
+## 7. SQL attributes and API policy
+
+### Public function attributes
+
+For each converted public lifecycle function:
+
+```rust
+#[pg_extern(schema = "pgtrickle", security_definer)]
+#[search_path(pgtrickle, pg_catalog, pg_temp)]
+```
+
+Do not add `public` or caller-writable schemas to a definer path.
+
+Functions that execute arbitrary SQL, such as `write_and_refresh`, remain invoker.
+
+### API policy
+
+Update `scripts/sql_api_policy.json` with exact overload identities. Do not rely solely on prefix classification.
+
+Enhance policy validation so every `owner_lifecycle` entry declares one of:
+
+- `definer_owner_checked`
+- `invoker_delegating`
+- `capability_specific`
+
+This may be an additional field or a companion checked file. CI should reject an owner-lifecycle function with no declared execution policy.
+
+### Static boundary check
+
+Add `scripts/check_privilege_boundaries.py` and/or Semgrep rules that flag:
+
+- `SECURITY DEFINER` without the pinned path.
+- Calls that execute `query`, `defining_query`, `original_query`, or generated DVM SQL outside an owner-context helper.
+- Dynamic caller-controlled identifiers in privileged SPI SQL.
+- External-extension calls inside an extension-owner-only section.
+- Newly exported lifecycle functions absent from the policy matrix.
+
+The check should be conservative and allow narrowly documented suppressions.
+
+---
+
+## 8. Delivery plan, roadmap versions, and PR sequence
+
+Each release is one reviewable PR with a six-person-week budget. The sequence
+starts after v0.87.6 and must finish before v0.88.0. A release cannot absorb
+work from a later boundary unless its own merge gate remains unchanged.
+
+## v0.87.7 / PR 1: Security-context foundation and catalog migration
+
+Roadmap: [v0.87.7](../roadmap/v0.87.7.md)
+
+Files expected:
+
+- `src/api/security_context.rs` (new)
+- `src/api/mod.rs`
+- `src/api/helpers.rs`
+- `src/catalog.rs` or the current catalog module
+- `src/lib.rs`
+- `.unsafe-baseline`
+- unit/pg tests
+- upgrade SQL and archive SQL
+
+Deliverables:
+
+- `CallerContext` and `StreamExecutionContext`.
+- Exact caller-path capture and `$user` expansion.
+- Restricted owner-context execution with guaranteed restoration.
+- `defining_search_path` catalog column and legacy backfill.
+- No public API attribute changes yet, except any necessary shared correction to existing creation paths.
+
+Merge gate:
+
+- Unit tests and PostgreSQL-backed context restoration tests green.
+- Upgrade from current upstream release succeeds.
+- No behavior change outside the documented execution-context foundation.
+
+## v0.87.8 / PR 2: Refresh engine owner-context execution
+
+Roadmap: [v0.87.8](../roadmap/v0.87.8.md)
+
+Files expected:
+
+- `src/api/refresh_ops.rs`
+- `src/refresh/mod.rs`
+- `src/refresh/merge/mod.rs`
+- `src/refresh/codegen.rs`
+- merge submodules as needed
+- `src/ivm.rs`
+- CDC staging helpers
+- E2E security and correctness tests
+
+Deliverables:
+
+- Full refresh split into prepare/execute/finalize.
+- Differential `DeltaStage` implementation.
+- Scheduled, manual, initial, reinitialize, Top-K, fused, parallel, and immediate paths use stream-owner execution for definition-derived SQL.
+- RLS and privilege semantics documented and tested.
+
+Merge gate:
+
+- Existing DVM correctness corpus unchanged.
+- TPC-H/correctness gates pass.
+- Security exploit tests prove no extension-owner execution of caller UDFs.
+- Parallel/manual/scheduler refresh tests pass.
+
+## v0.87.9 / PR 3: Core issue `#941`
+
+Roadmap: [v0.87.9](../roadmap/v0.87.9.md)
+
+Files expected:
+
+- `src/api/create.rs`
+- `src/api/alter.rs`
+- `src/api/helpers.rs`
+- `tests/e2e_ownership_tests.rs`
+- docs/policy/generated SQL
+
+Deliverables:
+
+- Harden `create_or_replace_stream_table`, `alter_stream_table`, and `drop_stream_table`.
+- Preserve exact storage owner across all recreation paths.
+- Preauthorize complete cascade plans.
+- Non-superusers need no private catalog/change-schema grants.
+
+Merge gate:
+
+- Both create and replace paths work with exact public API grants only.
+- Mixed-owner cascade is denied and fully rolled back.
+- Query-changing and partition-changing ALTER preserve owner and data.
+
+## v0.87.10 / PR 4: Remaining lifecycle APIs and policy enforcement
+
+Roadmap: [v0.87.10](../roadmap/v0.87.10.md)
+
+Deliverables:
+
+- Policy wrappers and bulk APIs.
+- Pause/resume/repair.
+- Fuse/stat reset.
+- Manual refresh conversion now that PR 2 is present.
+- Exact API-policy declarations and static privilege-boundary checks.
+- Upgrade preflight diagnostics and least-privilege grant documentation.
+
+Keep this PR free of snapshot/publication/outbox changes.
+
+## v0.87.11 / PR 5: Snapshots
+
+Roadmap: [v0.87.11](../roadmap/v0.87.11.md)
+
+Implement the target-schema and snapshot-owner policy in section 6.2 with dedicated E2E tests.
+
+## v0.87.12 / PR 6: Publications
+
+Roadmap: [v0.87.12](../roadmap/v0.87.12.md)
+
+Implement the capability-specific publication checks in section 6.3 with
+dedicated E2E, upgrade, rollback, and concurrency tests.
+
+## v0.87.13 / PR 7: pg_tide outbox integration
+
+Roadmap: [v0.87.13](../roadmap/v0.87.13.md)
+
+Implement the pg_tide boundary in section 6.4 with absent, denied, authorized,
+rollback, upgrade, and supported-version tests.
+
+After the replacements are open, close PRs `#942` and `#943` as superseded, linking the new PR sequence.
+
+---
+
+## 9. Database migration and packaging
+
+The sequence uses v0.87.6 as its implementation baseline and ships as v0.87.7
+through v0.87.13. Each release adds a direct upgrade from its predecessor and
+keeps chained upgrades green. If another release claims one of these versions,
+renumber the complete sequence before implementation instead of merging two
+security boundaries into one release.
+
+### Migration contents
+
+Create:
+
+```text
+sql/pg_trickle--<current>--<next>.sql
+sql/archive/pg_trickle--<next>.sql
+```
+
+The upgrade script must:
+
+1. Add `defining_search_path` nullable.
+2. Backfill from each storage relation's current owner.
+3. Assert no unresolved rows remain.
+4. Set the column `NOT NULL`.
+5. Apply `ALTER FUNCTION ... SECURITY DEFINER` and `SET search_path` for converted exact signatures.
+6. Explicitly preserve or set `SECURITY INVOKER` for functions intentionally left invoker where generated SQL could otherwise drift.
+7. Preserve existing function ACLs.
+8. Update the schema-version ledger if required by repository release conventions.
+
+### Upgrade verification
+
+Add upgrade E2E assertions for:
+
+- Backfilled path values.
+- `prosecdef` and `proconfig` on every converted overload.
+- Existing ACLs retained.
+- Pre-upgrade stream tables can refresh under their current owner.
+- A non-superuser can use converted lifecycle APIs without private grants after upgrade.
+- Rollback of a failing owner-context query leaves the catalog/frontier unchanged.
+
+Run:
+
+```bash
+just check-upgrade <current> <next>
+just check-upgrade-all
+just test-upgrade <current> <next>
+```
+
+---
+
+## 10. Test strategy
+
+## 10.1 Pure unit tests
+
+Add tests for:
+
+- `$user` expansion.
+- Quoted role names.
+- Schema names containing commas.
+- Escaped double quotes.
+- Empty path elements and whitespace preservation.
+- Canonical identifier parsing.
+- Drop-plan ordering and duplicate elimination.
+- Authorization matrix helpers.
+
+Fuzz the search-path segment parser and qualified-identifier parser.
+
+## 10.2 PostgreSQL-backed context tests
+
+Create a focused test file, for example `tests/e2e_security_context_tests.rs`.
+
+Required cases:
+
+1. **Identity probe:** a caller-owned function returning `current_user` is used in a stream definition. Initial, full, differential, manual, scheduled, reinitialize, Top-K, fused, parallel, and immediate refreshes must materialize the stream owner, never the extension owner.
+2. **Privilege probe:** a caller-owned function tries to read a table readable only by the extension owner. Creation/refresh must fail with insufficient privilege.
+3. **DDL probe:** a caller-owned function tries to create or alter an object in `pgtrickle`; it must fail.
+4. **RLS probe:** source RLS results are identical for initial and later refreshes and reflect the stream-owner policy.
+5. **Error restoration:** after a PostgreSQL `ERROR`, `current_user`, search path, GUC nest state, and backend usability are restored.
+6. **Nested context:** create-or-replace delegating to alter does not lose the outer caller or path.
+7. **Custom path:** a role whose source schema differs from its role name resolves an unqualified source correctly.
+8. **Quoted path:** quoted schema names and `$user` work.
+9. **Ownership transfer:** after `ALTER TABLE ... OWNER TO`, refresh executes as the new owner but uses the stored defining path.
+10. **Revoked source privilege:** revoking source `SELECT` causes refresh failure without frontier advancement.
+
+## 10.3 Lifecycle E2E tests
+
+Rewrite the ownership fixture to grant only:
+
+- `USAGE` on `pgtrickle`
+- exact `EXECUTE` on the function under test
+- required source/output privileges
+
+Do **not** grant:
+
+- `USAGE` on `pgtrickle_changes`
+- `SELECT` on private pgtrickle catalog tables
+- `EXECUTE ON ALL FUNCTIONS`
+
+Core cases:
+
+- Owner succeeds, non-owner fails, superuser succeeds.
+- Create-or-replace create path and replace path both succeed.
+- Query-incompatible ALTER recreates storage and preserves owner.
+- Partition-key ALTER recreates storage and preserves owner.
+- Mode change that triggers full refresh preserves identity and data.
+- Cross-owner cascade fails before mutation.
+- Same-owner cascade succeeds.
+- Bulk operations prevalidate all targets and are atomic.
+
+## 10.4 Snapshot tests
+
+- Default internal snapshot succeeds and is transferred to caller.
+- Custom schema without `CREATE` fails.
+- Custom schema with `CREATE` succeeds.
+- Restore requires destination ownership and snapshot `SELECT`.
+- Drop requires snapshot ownership.
+- Stream ownership transfer does not silently transfer old snapshots.
+- Provenance mismatch/recreated relation is rejected.
+
+## 10.5 Publication tests
+
+- Caller without database `CREATE` is denied.
+- Caller with database `CREATE` and stream ownership succeeds.
+- Resulting publication owner matches the documented policy.
+- Non-owner cannot create/drop.
+- Recreated or renamed publication cannot be confused with the recorded binding.
+
+## 10.6 Outbox tests
+
+- pg_tide absent returns the documented actionable error.
+- pg_tide present but caller unauthorized is denied by pg_tide.
+- Authorized caller succeeds without pg_trickle private grants.
+- Mapping registration rolls back if pg_tide creation fails.
+- pg_trickle does not invoke pg_tide as the extension owner.
+
+## 10.7 Concurrency and rollback tests
+
+- Scheduler and manual refresh contend without leaking identity.
+- Owner-context failure under an advisory/row lock releases state correctly.
+- Parallel refresh mode uses the correct owner independently in each backend.
+- Cascaded drop and storage recreation roll back on injected failures.
+- Temp delta-stage names cannot collide across concurrent refreshes.
+
+## 10.8 Performance and correctness gates
+
+The differential staging refactor changes the hot path, so record before/after measurements.
+
+Required gates:
+
+- Existing DVM corpus: zero result changes.
+- SQLancer/correctness oracle: zero new mismatches.
+- TPC-H correctness: all supported queries pass.
+- Median differential-refresh overhead stays within an agreed bound; use 10% as the initial review threshold for representative small/medium deltas unless maintainers set another value.
+- No unbounded temp-table growth or leaked temp relations after errors.
+
+---
+
+## 11. Local and CI validation matrix
+
+Run targeted checks while developing, then the full matrix before each merge.
+
+### Fast development loop
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-targets --features pg18 -- -D warnings
+bash scripts/check_security_definer.sh
+python3 scripts/check_sql_api_policy.py self-test
+just test-unit
+```
+
+### Targeted E2E
+
+```bash
+just build-e2e-image
+./scripts/run_e2e_tests.sh --test e2e_ownership_tests --no-capture
+./scripts/run_e2e_tests.sh --test e2e_security_context_tests --no-capture
+./scripts/run_e2e_tests.sh --test e2e_upgrade_tests --run-ignored all --no-capture
+```
+
+### Full required matrix
+
+```bash
+just lint-ci
+just unsafe-inventory
+just test-unit
+just test-integration
+just test-light-e2e
+just test-e2e
+just test-e2e-parallel
+just test-pgrx
+just dvm-corpus
+just test-correctness-gate
+just sqlancer-rust-only
+just check-upgrade-all
+just test-upgrade <current> <next>
+just test-dbt
+```
+
+CI must also pass Semgrep, secret scanning, docs drift, unsafe inventory, generated SQL/API drift, and all repository-required workflows.
+
+No PR in this sequence is mergeable merely because GitHub reports `mergeable: true`; it requires green tests and an approving security-aware review.
+
+---
+
+## 12. Documentation updates
+
+Update together, not after implementation:
+
+- `docs/SECURITY_MODEL.md`
+- `docs/SECURITY_GUIDE.md`
+- `docs/SQL_REFERENCE.md`
+- generated `docs/SQL_API_CATALOG.md`
+- release notes/changelog
+- operator grant examples
+
+The documents must agree on:
+
+- who executes defining queries;
+- how source ACLs and RLS apply;
+- which APIs are definer vs invoker;
+- what exact grants a stream author needs;
+- snapshot/publication/outbox ownership semantics;
+- the pre-upgrade privilege diagnostic and the hard stream-owner cutover.
+
+Remove examples that grant `EXECUTE ON ALL FUNCTIONS` or private catalog/change-schema access to routine stream authors. Show exact grants generated by the API policy tool.
+
+---
+
+## 13. Compatibility and rollout
+
+Changing defining-query execution from extension owner to stream owner can
+expose deployments that relied on implicit superuser access. Treat this as an
+intentional security-hardening compatibility change.
+
+Do not provide a `legacy_extension_owner` mode. Such a mode would violate the
+non-negotiable execution-identity invariant and leave a privileged SQL path in
+production. Provide a superuser-only pre-upgrade diagnostic that lists stream
+tables whose owners lack source `SELECT` or schema `USAGE`. The diagnostic must
+name the missing grant and make no changes. Upgrade fails before catalog
+mutation when unresolved privilege gaps remain.
+
+Fresh installations and upgrades both use stream-owner execution. The upgrade
+notes must describe the diagnostic, required grants, hard cutover, and rollback
+procedure.
+
+---
+
+## 14. Observability
+
+Add structured diagnostics for security-context failures without logging query text or secrets:
+
+- stream `pgt_id` and canonical name;
+- requested operation;
+- expected execution owner OID/name;
+- stage: capture, prepare, owner execution, or finalize;
+- SQLSTATE/category;
+- whether frontier advancement was suppressed.
+
+Expose a read-only diagnostic function that reports:
+
+- current storage owner;
+- stored defining search path;
+- whether owner has source privileges;
+- configured execution-identity mode;
+- last refresh identity failure.
+
+Do not include raw defining SQL in routine error logs.
+
+---
+
+## 15. Review checklist
+
+Each PR reviewer should explicitly verify:
+
+- [ ] No caller-controlled SQL executes in extension-owner context.
+- [ ] Every new definer function has a pinned trusted path.
+- [ ] Original caller identity is used for authorization.
+- [ ] Every bulk/cascade target is authorized before mutation.
+- [ ] Recreated relations retain the intended owner.
+- [ ] Unqualified names resolve using captured/stored caller context.
+- [ ] Error paths restore role, path, GUC state, locks, and temp resources.
+- [ ] Upgrade SQL changes existing functions, not only fresh installs.
+- [ ] Minimal-grant E2E tests prove private schemas remain inaccessible.
+- [ ] Docs, API policy, generated SQL, and implementation agree.
+- [ ] Full CI and correctness gates are green.
+
+---
+
+## 16. Definition of done
+
+The reimplementation is complete when:
+
+1. A non-superuser owner can create-or-replace, alter, drop, pause, resume, repair, and refresh their own stream table with exact function grants and normal source/output privileges only.
+2. The same role has no direct access to pg_trickle private catalogs or `pgtrickle_changes`.
+3. A non-owner cannot operate on the table, including through bulk or cascade paths.
+4. Caller-defined executable objects never observe the extension owner as `current_user` during any refresh mode.
+5. Custom and quoted search paths behave consistently across initial, manual, and scheduled refreshes.
+6. Storage and auxiliary objects retain documented ownership after recreation.
+7. Snapshot, publication, and outbox operations enforce their additional capability-specific checks.
+8. Fresh install and upgrade paths produce identical function attributes, ACL policy, and catalog shape.
+9. All required CI, E2E, upgrade, DVM corpus, and correctness tests pass.
+10. PRs `#942` and `#943` are closed as superseded with links to the replacement series.
+
+---
+
+## 17. Source references used for this plan
+
+- Current upstream baseline: <https://github.com/trickle-labs/pg-trickle/tree/e5fed2dc8c31ff8d1311f3f51db934ec58aff3ce>
+- Issue `#941`: <https://github.com/trickle-labs/pg-trickle/issues/941>
+- Superseded PR `#942`: <https://github.com/trickle-labs/pg-trickle/pull/942>
+- Superseded PR `#943`: <https://github.com/trickle-labs/pg-trickle/pull/943>
+- PostgreSQL 18 `UserContext`: <https://github.com/postgres/postgres/blob/REL_18_STABLE/src/include/utils/usercontext.h>
+- PostgreSQL 18 user-context implementation: <https://github.com/postgres/postgres/blob/REL_18_STABLE/src/backend/utils/init/usercontext.c>

--- a/roadmap/v0.87.10.md
+++ b/roadmap/v0.87.10.md
@@ -1,0 +1,76 @@
+# v0.87.10 - Complete Lifecycle Policy
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"Every lifecycle API has one enforced execution and authorization policy."*
+> **Blocked by:** [v0.87.9](v0.87.9.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Apply the proven owner boundary to the remaining lifecycle APIs. Make the policy
+machine-readable, reject unclassified exports in CI, and provide an upgrade
+preflight that reports missing owner privileges before the hard cutover.
+
+This release does not add a legacy extension-owner execution mode. Keeping that
+path would preserve the privilege escalation that this sequence removes.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Remaining single-target lifecycle functions | 1.00 |
+| Atomic bulk operations and manual refresh exposure | 1.25 |
+| API policy, static boundary checks, and preflight diagnostic | 1.50 |
+| Security, batch, upgrade, generated-doc, and regression tests | 2.25 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-10: Remaining owner lifecycle APIs
+
+Harden refresh-policy, storage-policy, pause, resume, repair, reset-fuse,
+statistics-reset, and manual-refresh entry points. Each function checks the
+outer caller against the canonical stream owner before private mutation.
+
+Keep arbitrary-SQL dispatchers and pure checked delegates as invokers. Record
+the reason for each exception in the API policy.
+
+### LSEC-11: Atomic bulk lifecycle operations
+
+Resolve and authorize every bulk-alter and bulk-drop target before mutation.
+Reuse the single-target prepared plans and drop planner. One invalid, missing,
+duplicate, or unauthorized target fails the batch without partial changes.
+
+### LSEC-12: Enforced policy and upgrade preflight
+
+Give every exported lifecycle overload an exact policy classification. CI
+rejects an unclassified export, an unpinned definer path, caller-controlled SQL
+outside the owner helper, unsafe dynamic identifiers, and external-extension
+calls in a definer-only phase.
+
+Add a read-only superuser preflight that lists each owner missing source
+`SELECT` or schema `USAGE`, including the exact remediation. Upgrade refuses to
+change catalog state until the report is clear.
+
+## Required tests
+
+- A generated matrix exercises every lifecycle overload as owner, non-owner,
+  superuser, and a role with only the documented exact grants.
+- Bulk tests cover mixed ownership, duplicates, missing targets, cycles,
+  mid-plan failure injection, and concurrent target changes.
+- Static-checker self-tests include one positive and one negative fixture for
+  every rule and fail when a new lifecycle export lacks policy.
+- Fresh-install and chained-upgrade tests compare function attributes, ACLs,
+  catalog state, preflight output, and generated API documentation.
+- Manual refresh repeats the v0.87.8 identity, RLS, rollback, and frontier tests
+  through the public API.
+
+## Exit criteria
+
+- [ ] Every owner-lifecycle overload has one checked policy classification.
+- [ ] Bulk operations authorize the complete set before the first mutation.
+- [ ] The public manual-refresh API preserves the v0.87.8 owner boundary.
+- [ ] Preflight reports every missing grant and changes no state.
+- [ ] No legacy extension-owner query-execution mode exists.
+- [ ] Policy, generated-doc, security, upgrade, and full repository CI gates pass.

--- a/roadmap/v0.87.11.md
+++ b/roadmap/v0.87.11.md
@@ -1,0 +1,73 @@
+# v0.87.11 - Snapshot Security
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"Snapshots cannot cross ownership or schema boundaries by accident."*
+> **Blocked by:** [v0.87.10](v0.87.10.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Give snapshots their own ownership and provenance contract. Internal snapshot
+creation may use private infrastructure, but a caller-selected schema uses the
+caller's privileges. Restore and drop require checks against both the snapshot
+and the destination stream table.
+
+Stream ownership transfer does not rewrite historical snapshot ownership. A
+recreated relation cannot inherit trust from a stale name-only binding.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Snapshot target resolution and ownership | 1.25 |
+| Provenance-bound restore and drop | 1.25 |
+| Upgrade, cleanup, and concurrency behavior | 1.00 |
+| Security, rollback, provenance, and upgrade tests | 2.50 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-13: Caller-checked snapshot creation
+
+Default internal snapshots are created through private infrastructure and then
+owned by the caller. A caller-supplied schema requires caller `USAGE` and
+`CREATE`. Store creator OID, relation OID, stream OID, and immutable provenance
+needed to reject name reuse.
+
+### LSEC-14: Restore and drop authorization
+
+Restore requires ownership of the destination stream table and `SELECT` on the
+snapshot relation. Snapshot drop requires snapshot ownership or superuser.
+Resolve both objects canonically before private mutation.
+
+### LSEC-15: Transfer and stale-binding behavior
+
+Changing stream ownership leaves existing snapshots with their documented
+owners. Renamed, dropped, or recreated snapshot relations fail with a specific
+provenance error. Cleanup is idempotent and cannot remove an unrelated object
+that reused a name.
+
+## Required tests
+
+- Default and custom-schema creation cover allowed and denied `USAGE`, `CREATE`,
+  ownership, quoted identifiers, and schema shadowing.
+- Restore covers destination owner versus non-owner, snapshot `SELECT` grant and
+  revocation, RLS-visible data, mismatched source, and owner transfer.
+- Drop covers snapshot owner, stream owner who does not own the snapshot,
+  superuser, stale OID, renamed relation, and name reuse.
+- Failure injection between relation creation, ownership transfer, provenance
+  insert, restore, and cleanup proves transaction rollback.
+- Concurrent create, restore, drop, rename, and stream-owner transfer use
+  deterministic synchronization and leave no orphaned private rows.
+- Fresh-install and v0.87.10 upgrade tests verify provenance constraints,
+  ownership, ACL retention, and cleanup of legacy metadata.
+
+## Exit criteria
+
+- [ ] Caller-selected schemas never receive definer-equivalent authority.
+- [ ] Every snapshot relation has an explicit owner and immutable provenance.
+- [ ] Restore checks both destination ownership and snapshot access.
+- [ ] Transfer and name reuse cannot redirect snapshot operations.
+- [ ] Failed and concurrent operations leave no orphaned or partial state.
+- [ ] Security, rollback, concurrency, upgrade, and full repository CI gates pass.

--- a/roadmap/v0.87.12.md
+++ b/roadmap/v0.87.12.md
@@ -1,0 +1,74 @@
+# v0.87.12 - Publication Security
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"Publication APIs grant no authority beyond the caller's own database rights."*
+> **Blocked by:** [v0.87.11](v0.87.11.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Treat publication management as a database capability, not an automatic
+consequence of stream ownership. The caller must own the stream and hold the
+database privilege PostgreSQL requires. Publication ownership and the private
+binding remain explicit and verifiable.
+
+Creation and drop separate caller-context PostgreSQL DDL from private catalog
+bookkeeping. A stale, renamed, or recreated publication cannot match a binding
+by name alone.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Caller-equivalent creation and ownership | 1.25 |
+| Provenance-bound drop and reconciliation | 1.25 |
+| Upgrade and operational diagnostics | 1.00 |
+| Security, rollback, concurrency, and upgrade tests | 2.50 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-16: Caller-equivalent publication creation
+
+Require stream ownership and caller-equivalent `CREATE` on the current
+database. Run `CREATE PUBLICATION` under caller context when PostgreSQL permits
+it. If a privileged substep is unavoidable, transfer ownership before private
+registration and verify the owner in `pg_publication`.
+
+### LSEC-17: Immutable publication binding
+
+Record the publication OID, owner OID, stream OID, and expected relation set.
+Drop and repair validate the live object against that binding. Name reuse,
+rename, ownership transfer, or relation-set drift produces a specific error
+before mutation.
+
+### LSEC-18: Atomic private integration
+
+Update pg_trickle's private binding in a separate definer phase within the same
+transaction. Failed DDL, ownership transfer, verification, or catalog work
+rolls back both the PostgreSQL object and private state.
+
+## Required tests
+
+- Creation covers stream owner versus non-owner, database `CREATE` grant and
+  revocation, quoted names, conflicting names, and exact publication owner.
+- Drop and repair cover owner mismatch, rename, recreate with the same name,
+  relation-set drift, stale private bindings, and unrelated publications.
+- Failure injection at each phase proves no orphan publication or private row
+  survives.
+- Concurrent create, drop, rename, and ownership transfer use deterministic
+  barriers and produce one consistent final binding.
+- Fresh-install and v0.87.11 upgrade tests verify function attributes, ACLs,
+  provenance columns, old binding migration, and generated API policy.
+- Minimal-grant tests prove that private catalog access is neither granted nor
+  required.
+
+## Exit criteria
+
+- [ ] Stream ownership alone cannot bypass database publication privileges.
+- [ ] The resulting publication owner matches the documented caller policy.
+- [ ] Bindings use live object identity and reject stale name reuse.
+- [ ] Public DDL and private bookkeeping commit or roll back together.
+- [ ] No publication path executes caller-selected SQL as extension owner.
+- [ ] Security, rollback, concurrency, upgrade, and full repository CI gates pass.

--- a/roadmap/v0.87.13.md
+++ b/roadmap/v0.87.13.md
@@ -1,0 +1,76 @@
+# v0.87.13 - pg_tide Outbox Boundary
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"pg_trickle never lends its owner identity to pg_tide."*
+> **Blocked by:** [v0.87.12](v0.87.12.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Finish the lifecycle-security sequence at the extension boundary. pg_trickle
+checks stream ownership, then invokes pg_tide as the original caller so pg_tide
+enforces its own API and privilege model. pg_trickle updates its private mapping
+only after the external operation succeeds.
+
+The integration must fail cleanly when pg_tide is absent, incompatible, or
+denies the caller. It may not grant pg_tide access or duplicate pg_tide's
+authorization logic.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Caller-context pg_tide invocation | 1.25 |
+| Private mapping, provenance, and rollback | 1.25 |
+| Version compatibility and operational diagnostics | 1.00 |
+| Security, rollback, concurrency, and compatibility tests | 2.50 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-19: Preserve the external trust boundary
+
+Resolve and authorize the stream under the outer caller. Invoke supported
+pg_tide create, alter, and drop APIs in caller context. Pass canonical object
+identity, not unresolved caller text. Do not run an external-extension function
+inside an extension-owner-only phase.
+
+### LSEC-20: Atomic private mapping
+
+Register or remove pg_trickle's private mapping in a separate definer phase.
+Store enough pg_tide object identity and version provenance to reject stale
+name reuse. A pg_tide error or private catalog error rolls back the complete
+operation.
+
+### LSEC-21: Explicit compatibility contract
+
+Detect pg_tide absence and unsupported installed versions without parsing error
+text. Return errors that name the missing extension, supported version range,
+or denied pg_tide operation. Keep the supported-version matrix in tests and
+release documentation.
+
+## Required tests
+
+- The matrix covers pg_tide absent, supported and authorized, supported but
+  denied, unsupported older, unsupported newer, and upgrade-in-progress states.
+- Identity probes inside pg_tide observe the original caller, never the
+  pg_trickle owner.
+- Owner, non-owner, exact-grant, quoted-name, name-collision, stale-OID, and
+  ownership-transfer cases cover create, alter, and drop.
+- Failure injection before and after each extension call and mapping mutation
+  proves atomic rollback and idempotent retry.
+- Concurrent create, drop, and retry use deterministic barriers and leave one
+  external object and one matching private row, or neither.
+- Fresh-install and v0.87.12 upgrade tests verify policy, ACLs, provenance,
+  compatibility errors, and no new private grants.
+
+## Exit criteria
+
+- [ ] Every pg_tide call runs as the original caller.
+- [ ] pg_tide remains the sole authority for its own permissions.
+- [ ] External objects and private mappings commit or roll back together.
+- [ ] Absence, denial, and version incompatibility return distinct errors.
+- [ ] Stale names and OIDs cannot redirect an outbox operation.
+- [ ] Security, rollback, concurrency, compatibility, upgrade, and full
+      repository CI gates pass.

--- a/roadmap/v0.87.7.md
+++ b/roadmap/v0.87.7.md
@@ -1,0 +1,78 @@
+# v0.87.7 - Security Context and Catalog Foundation
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"Lifecycle APIs never lend extension-owner privileges to defining SQL."*
+> **Blocked by:** [v0.87.6](v0.87.6.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Build one audited boundary for original-caller capture and stream-owner
+execution before any public function becomes `SECURITY DEFINER`. Persist the
+defining query's exact resolution path so manual and background refreshes use
+the same names that creation used.
+
+This release changes no public lifecycle function attributes. It supplies the
+foundation and proves that success, nested calls, Rust errors, and PostgreSQL
+errors restore the backend's prior role and GUC state.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Caller identity and exact search-path capture | 1.25 |
+| Restricted stream-owner execution and restoration | 1.50 |
+| `defining_search_path` catalog and upgrade migration | 1.25 |
+| Unit, fuzz, PostgreSQL, upgrade, and review work | 2.00 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-1: Typed caller and owner contexts
+
+Add `CallerContext` and `StreamExecutionContext`. Definer entries use
+`GetOuterUserId()` and the saved pre-function path. Invoker entries read the
+active path. Expand only a standalone `"$user"` element, including quoted role
+names, commas inside identifiers, escaped quotes, and whitespace.
+
+Keep PostgreSQL identity-switching `unsafe` code in one module. Every block has
+a precise `// SAFETY:` comment. Fail closed when the expected GUC stack state
+is absent.
+
+### LSEC-2: Restricted stream-owner execution
+
+Add one internal helper backed by PostgreSQL 18's untrusted-user context. It
+sets the stored path and `row_security = on`, runs through PostgreSQL error
+capture, and restores role, security flags, path, and GUC nesting in all exit
+paths. The role must come from canonical stream metadata, never a caller string.
+
+### LSEC-3: Defining-path catalog contract
+
+Add `defining_search_path TEXT NOT NULL` to the private stream-table catalog.
+Creation and query-changing alter paths replace it. Configuration-only changes
+and ownership transfer preserve it. Backfill legacy rows from the current
+storage owner and fail the upgrade if a storage relation is missing.
+
+## Required tests
+
+- Pure unit and property tests cover all path grammar cases, empty elements,
+  malformed quoting, and deterministic normalization.
+- PostgreSQL-backed tests cover success, nested contexts, Rust errors,
+  PostgreSQL `ERROR`, RLS-on behavior, and backend reuse after failure.
+- Negative probes verify that owner code cannot read extension-owner-only data
+  or create objects in `pgtrickle`.
+- Fresh-install and v0.87.6 upgrade tests compare catalog shape, values,
+  constraints, and generated SQL.
+- The unsafe inventory and static analysis must report only reviewed additions.
+
+## Exit criteria
+
+- [ ] Original caller identity and exact path survive nested definer calls.
+- [ ] Every exit path restores role, security flags, path, GUC nesting, and
+      backend usability.
+- [ ] Legacy rows receive a deterministic owner-derived path or the upgrade
+      fails before mutation.
+- [ ] Fresh installation and upgraded installation have identical catalogs.
+- [ ] No public lifecycle function becomes a definer in this release.
+- [ ] Unit, PostgreSQL, upgrade, unsafe, and full repository CI gates pass.

--- a/roadmap/v0.87.8.md
+++ b/roadmap/v0.87.8.md
@@ -1,0 +1,85 @@
+# v0.87.8 - Refresh Execution Identity
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"Every refresh evaluates defining SQL as the stream owner."*
+> **Blocked by:** [v0.87.7](v0.87.7.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Separate private refresh bookkeeping from SQL derived from a stream definition.
+Full and differential refreshes use prepare, owner-execute, and finalize phases
+inside one transaction. Initial, manual, scheduled, reinitialize, Top-K,
+parallel, fused, fallback, and immediate paths obey the same identity rule.
+
+The release preserves committed data and frontiers on every failure. Performance
+may not silently fall back to full refresh or move private CDC scans into the
+owner phase.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Full-refresh phase split | 1.00 |
+| Differential CDC staging and code-generation input | 1.50 |
+| Remaining refresh modes and scheduler restoration | 1.25 |
+| Security, correctness, failure, concurrency, and performance tests | 2.25 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-4: Full refresh phases
+
+The privileged prepare phase loads metadata, locks state, validates buffers,
+and records bounds. The owner phase evaluates all defining and row-identity SQL
+against owner-visible sources and writes owner-owned storage. The privileged
+finalize phase advances history and frontiers only after owner execution
+succeeds.
+
+### LSEC-5: Differential delta stages
+
+Copy the bounded CDC rows for one refresh into unique `pg_temp` staging
+relations. Preserve types, operation markers, LSNs, changed-column masks, and
+row identity. Grant the stream owner only the access needed for that stage.
+
+DVM code generation receives a source-OID-to-stage map. Owner-executed SQL may
+reference source relations, stream storage, the temporary stages, and trusted
+catalog objects. It may not reference `pgtrickle_changes`.
+
+### LSEC-6: Complete refresh-path coverage
+
+Route initial, manual, scheduled, reinitialize, Top-K, parallel, fused,
+fallback, and immediate expression evaluation through the same owner boundary.
+Restore the scheduler backend's original identity after success and failure.
+
+A fused execution unit may contain only streams with the same owner OID and
+stored defining path. Split mixed-owner or mixed-path units before SQL
+generation and retain dependency order. One SQL statement never borrows an
+identity or path from a neighboring stream.
+
+## Required tests
+
+- Identity probes cover every refresh path and assert `current_user` equals the
+  current storage owner.
+- Privilege and RLS probes compare initial, full, and differential results.
+- Revoked source access, injected owner errors, and stage failures leave the
+  prior result, frontier, history, and private buffers unchanged.
+- Deterministic barriers test manual versus scheduled contention, parallel
+  workers, fused DAGs, and temporary-name isolation without timing-only sleeps.
+- Mixed-owner and mixed-path DAGs prove that fusion splits before execution and
+  that every resulting stream still converges.
+- The complete DVM corpus, SQLancer oracle, TPC-H correctness suite, and
+  supported strategy matrix report no result changes or silent fallback.
+- Median differential-refresh overhead must stay within 10% on representative
+  small and medium deltas. Any exception requires measured maintainer approval.
+
+## Exit criteria
+
+- [ ] No definition-derived expression executes as the extension owner.
+- [ ] Owner execution cannot read private change-buffer relations directly.
+- [ ] A failed owner phase never advances or cleans past the prior frontier.
+- [ ] Temporary stages are collision-free and do not leak after errors.
+- [ ] Initial, manual, scheduled, full, differential, Top-K, fused, parallel,
+      fallback, and immediate tests pass.
+- [ ] Correctness, performance, concurrency, and full repository CI gates pass.

--- a/roadmap/v0.87.9.md
+++ b/roadmap/v0.87.9.md
@@ -1,0 +1,80 @@
+# v0.87.9 - Core Lifecycle Security
+
+> **Status:** Planned
+> **Scope:** 6 person-weeks
+> **User promise:** *"An owner can manage a stream table without private-schema grants."*
+> **Blocked by:** [v0.87.8](v0.87.8.md)
+> **Program:** [Lifecycle security reimplementation](../plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
+
+## Theme
+
+Fix issue #941 for create-or-replace, alter, and drop. Public entry points may
+use a pinned `SECURITY DEFINER` path only after they capture the original caller
+and resolve caller-controlled names under that caller's context.
+
+Privileged phases accept canonical OIDs and quoted catalog-derived identifiers.
+Create and alter run defining SQL as the stream owner. Drop authorizes the
+complete dependency plan before the first mutation.
+
+## Scope allocation
+
+| Work package | Person-weeks |
+|---|---:|
+| Canonical resolution and prepared lifecycle plans | 1.25 |
+| Create-or-replace and alter hardening | 1.50 |
+| Atomic cascade and bulk-ready drop planning | 1.00 |
+| Lifecycle, exploit, rollback, upgrade, and documentation tests | 2.25 |
+| **Total** | **6.00** |
+
+## Items
+
+### LSEC-7: Canonical caller-context resolution
+
+Resolve existing relations through PostgreSQL under the caller role and path.
+Resolve new targets through the caller's effective schema. After resolution,
+private phases use only OIDs or one shared qualified-identifier type.
+
+Remove ad hoc dotted-name splitting, hard-coded `public`, and definer-context
+`current_schema()` from the affected paths.
+
+### LSEC-8: Prepared create and alter phases
+
+Preflight source `SELECT`, source-schema `USAGE`, target-schema `CREATE`, query
+validation, and dependency resolution as the caller. Create private state as
+the definer, transfer storage ownership before population, execute population
+as owner, and finalize private state last.
+
+Alter preserves the exact pre-change owner across every storage recreation.
+Query migration, partition-key changes, mode changes, and full repopulation
+remain atomic.
+
+### LSEC-9: Fully authorized drop plans
+
+Build a deterministic child-first plan without mutation. Deduplicate targets,
+detect cycles, and check every affected stream table against the original
+caller. Reject the complete operation before dropping anything when one target
+is unauthorized.
+
+## Required tests
+
+- Minimal-grant fixtures provide exact function grants and normal source and
+  target privileges, with no private catalog or change-schema grants.
+- Owner, non-owner, superuser, quoted-name, custom-path, and `$user` cases cover
+  both create and replace branches.
+- Query-changing, partition-changing, mode-changing, no-op, and failing alter
+  cases verify owner, path, data, catalog, CDC, and frontier state.
+- Same-owner cascade succeeds. Mixed-owner and injected-failure cascades leave
+  every relation and catalog row intact.
+- Malicious functions, operators, views, casts, RLS policies, and target names
+  cannot observe or use extension-owner authority.
+- Fresh install and v0.87.8 upgrade tests verify exact `prosecdef`, `proconfig`,
+  overload identity, and retained ACLs.
+
+## Exit criteria
+
+- [ ] The three issue #941 APIs work for an owner with exact public grants.
+- [ ] The same owner has no direct private-schema access.
+- [ ] Every caller-controlled name resolves under the original caller context.
+- [ ] Every recreation preserves the exact storage owner and stored path.
+- [ ] Unauthorized cascade targets cause zero mutations.
+- [ ] Security, rollback, upgrade, and full repository CI gates pass.

--- a/roadmap/v0.88.0.md
+++ b/roadmap/v0.88.0.md
@@ -3,7 +3,7 @@
 > **Status:** Planned
 > **Scope:** Large
 > **User promise:** *"One PostgreSQL instance can handle a lot."*
-> **Blocked by:** [v0.87.6](v0.87.6.md)
+> **Blocked by:** [v0.87.13](v0.87.13.md)
 > **Renumbered and split:** previously the first half of v0.84.0 "Fast
 > Incremental Engine". Incremental window functions moved to
 > [v0.89.0](v0.89.0.md); parallel delta fan-out moved past 1.0.
@@ -17,6 +17,10 @@ ordering inside delta queries so intermediate results stay small.
 The v0.87.1 through v0.87.6 correctness program lands first. Its exact oracle,
 replay corpus, semantic coverage, schema contracts, snapshot plans, and release
 gate protect each physical rewrite in this release.
+
+The v0.87.7 through v0.87.13 lifecycle-security program also lands first. Its
+stream-owner execution boundary applies to every new delta plan and physical
+execution path in this release.
 
 This is one of two places where deep complexity is justified, because all of it
 is **inside the engine**. Users get the same extension, the same PostgreSQL, the
@@ -108,7 +112,7 @@ in this release depends on it.
 - [ ] ADR published deciding the vectorized-aggregate dependency question, and
       the v0.76.0 dependency-removal rationale explicitly addressed
 - [ ] Vectorized aggregate path active for pure-aggregate stream tables; ≥5×
-      throughput on the aggregate benchmark versus v0.87.6, with identical
+      throughput on the aggregate benchmark versus v0.87.13, with identical
       results verified against the FULL oracle
 - [ ] Cost-based operator scheduling on by default; `explain_delta_plan()` shows
       the chosen order; no plan regression on the TPC-H suite


### PR DESCRIPTION
## Summary

- add the lifecycle-security reimplementation plan for issue #941
- split the work into seven sequential releases, v0.87.7 through v0.87.13, with a six-person-week budget and an explicit test allocation for each release
- separate refresh identity, core lifecycle APIs, snapshots, publications, and the pg_tide outbox behind independent merge gates
- require a hard stream-owner execution cutover with a read-only upgrade preflight instead of retaining an extension-owner compatibility path
- block v0.88.0 on the completed lifecycle-security sequence

## Proposed roadmap entries

  - v0.87.7: Build the safe mechanism for remembering the real caller and running their SQL with their permissions.
  - v0.87.8: Apply that mechanism to every refresh type. Failures must not lose data or advance progress markers.
  - v0.87.9: Secure create, replace, alter, and drop. Owners no longer need access to private extension tables.
  - v0.87.10: Secure the remaining lifecycle functions and automatically check that every function follows the policy.
  - v0.87.11: Ensure snapshots respect schema permissions, ownership, and their original source.
  - v0.87.12: Ensure publication functions use only the caller’s normal PostgreSQL permissions.
  - v0.87.13: Ensure pg_trickle never lends its powerful extension-owner account to pg_tide.

  Together, they secure the full stream-table lifecycle before v0.88.0 begins performance work.

## Validation

- `just fmt`
- `just lint`
- `just docs-build`
- `git diff --check`

## Scope

Documentation and planning only. This pull request does not change extension behavior.
