### PR TITLE
fix: remove unit tests from coverage-floors release gate step

### DIFF
--- a/scripts/dvm_release_gate.py
+++ b/scripts/dvm_release_gate.py
@@ -152,11 +152,7 @@ STEPS: list[tuple[str, str, bool]] = [
     ),
     (
         "coverage-floors",
-        "cargo test --lib --features pg18 dvm::schema "
-        "&& cargo test --lib --features pg18 dvm::snapshot "
-        "&& cargo test --lib --features pg18 "
-        "dvm::diff::tests::test_decision_trace_records_declared_schema_and_snapshot_plan "
-        "&& cargo test --test e2e_dvm_composition_tests --features pg18 "
+        "cargo test --test e2e_dvm_composition_tests --features pg18 "
         "semantic_floors_pass_and_report_missing_buckets",
         False,
     ),


### PR DESCRIPTION
## Summary
Removes unit tests that cannot run in the release gate environment due to pgrx extension requirements.

Unit tests for PostgreSQL extensions built with pgrx cannot run with `cargo test --lib` because they depend on PostgreSQL runtime symbols (via `pg_module_magic!()`) that are only available in a PostgreSQL process context. These symbols aren't linked in standalone test binaries, causing symbol lookup errors.

The coverage-floors step retains the semantic_floors_pass_and_report_missing_buckets e2e test, which validates schema coverage within a proper PostgreSQL environment.

Fixes #952 workflow failures.