### PR TITLE
fix(dvm): resolve exact expression volatility

### DIFF
--- a/.unsafe-baseline
+++ b/.unsafe-baseline
@@ -6,7 +6,7 @@
 #   scripts/unsafe_inventory.sh --update
 #
 # Files and their unsafe block counts:
-src/api/helpers.rs 17
+src/api/helpers.rs 18
 src/api/mod.rs 1
 src/api/scheduler_control.rs 1
 src/api/snapshot.rs 6

--- a/.unsafe-baseline
+++ b/.unsafe-baseline
@@ -1,4 +1,4 @@
-# pg_trickle unsafe { block baseline — generated 2026-08-20
+# pg_trickle unsafe { block baseline — generated 2026-08-25
 # Tracks `grep -c "unsafe {"` counts per source file.
 # Files with 0 unsafe blocks are omitted.
 #
@@ -6,7 +6,7 @@
 #   scripts/unsafe_inventory.sh --update
 #
 # Files and their unsafe block counts:
-src/api/helpers.rs 13
+src/api/helpers.rs 15
 src/api/mod.rs 1
 src/api/scheduler_control.rs 1
 src/api/snapshot.rs 6

--- a/.unsafe-baseline
+++ b/.unsafe-baseline
@@ -6,7 +6,7 @@
 #   scripts/unsafe_inventory.sh --update
 #
 # Files and their unsafe block counts:
-src/api/helpers.rs 15
+src/api/helpers.rs 17
 src/api/mod.rs 1
 src/api/scheduler_control.rs 1
 src/api/snapshot.rs 6

--- a/.unsafe-baseline
+++ b/.unsafe-baseline
@@ -6,7 +6,7 @@
 #   scripts/unsafe_inventory.sh --update
 #
 # Files and their unsafe block counts:
-src/api/helpers.rs 18
+src/api/helpers.rs 19
 src/api/mod.rs 1
 src/api/scheduler_control.rs 1
 src/api/snapshot.rs 6

--- a/docs/DVM_SUPPORT_MATRIX.md
+++ b/docs/DVM_SUPPORT_MATRIX.md
@@ -176,7 +176,8 @@ FROM orders
 
 Only IMMUTABLE expressions are admitted to incremental maintenance by default.
 STABLE and VOLATILE expressions use FULL under AUTO and are rejected for
-explicit DIFFERENTIAL or IMMEDIATE mode.
+explicit DIFFERENTIAL or IMMEDIATE mode. PostgreSQL analysis resolves the exact
+function, operator, and cast overload before pg_trickle checks its volatility.
 
 ---
 

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -2931,10 +2931,12 @@ SELECT pgtrickle.create_stream_table(
 
 ### Volatile Function Detection
 
-pg_trickle checks all functions and operators in the defining query against `pg_proc.provolatile`:
+PostgreSQL analyzes the defining query before pg_trickle checks volatility. The
+check uses the exact function, operator, and cast overload selected from the
+schema and argument types.
 
 - **VOLATILE** and **STABLE** functions (e.g., `random()`, `clock_timestamp()`, `now()`) are FULL-only in incremental admission. AUTO falls back to FULL; explicit DIFFERENTIAL and IMMEDIATE modes are rejected.
-- **VOLATILE operators** — custom operators backed by volatile functions are also detected. The check resolves the operator’s implementation function via `pg_operator.oprcode` and checks its volatility in `pg_proc`.
+- **VOLATILE operators** backed by volatile functions are also detected.
 - **IMMUTABLE** functions are always safe and produce no warnings.
 
 FULL mode accepts all volatility classes since it re-evaluates the entire query each time.

--- a/docs/tutorials/FIRST_DASHBOARD.md
+++ b/docs/tutorials/FIRST_DASHBOARD.md
@@ -105,19 +105,20 @@ ORDER BY total_revenue DESC;
 ## Step 4 — Hourly Order Counts
 
 A time-series stream table that aggregates orders into one-hour buckets.
-`date_trunc('hour', ...)` is a STABLE function, so DIFFERENTIAL mode works.
+The three-argument `date_trunc` pins the time zone to UTC and is IMMUTABLE, so
+DIFFERENTIAL mode can maintain the buckets safely.
 
 ```sql
 SELECT pgtrickle.create_stream_table(
     name     => 'hourly_order_counts',
     query    => $$
         SELECT
-            date_trunc('hour', placed_at)  AS hour,
+            date_trunc('hour', placed_at, 'UTC') AS hour,
             region,
             COUNT(*)                        AS order_count,
             SUM(amount)                     AS hourly_revenue
         FROM orders
-        GROUP BY date_trunc('hour', placed_at), region
+        GROUP BY date_trunc('hour', placed_at, 'UTC'), region
     $$,
     schedule => '10s',
     refresh_mode => 'DIFFERENTIAL'

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -919,6 +919,157 @@ pub struct ColumnDef {
     pub type_oid: PgOid,
 }
 
+#[cfg(not(test))]
+struct VolatilityCollector {
+    function_oids: Vec<pg_sys::Oid>,
+    io_cast_input_oids: Vec<pg_sys::Oid>,
+    worst: char,
+}
+
+#[cfg(not(test))]
+fn max_analyzed_volatility(a: char, b: char) -> char {
+    match (a, b) {
+        ('v', _) | (_, 'v') => 'v',
+        ('s', _) | (_, 's') => 's',
+        _ => 'i',
+    }
+}
+
+/// Resolve volatility from the analyzed expression nodes.
+///
+/// Aggregate implementation functions are deliberately not included: their
+/// volatility describes the aggregate's internal state machinery, while DVM
+/// admission handles the aggregate itself. Enum output is likewise stable in
+/// `pg_proc`, but enum DDL invalidates dependent stream tables, so enum I/O is
+/// safe here.
+#[cfg(not(test))]
+fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgTrickleError> {
+    let mut collector = VolatilityCollector {
+        function_oids: Vec::new(),
+        io_cast_input_oids: Vec::new(),
+        worst: 'i',
+    };
+
+    // SAFETY: query_node is a valid analyzed Query allocated by PostgreSQL's
+    // parser and remains valid for this function's duration.
+    unsafe {
+        pg_sys::query_tree_walker_impl(
+            query_node,
+            Some(collect_volatility_nodes),
+            &mut collector as *mut VolatilityCollector as *mut std::ffi::c_void,
+            pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
+        );
+    }
+
+    collector
+        .function_oids
+        .sort_unstable_by_key(|oid| oid.to_u32());
+    collector.function_oids.dedup();
+    collector
+        .io_cast_input_oids
+        .sort_unstable_by_key(|oid| oid.to_u32());
+    collector.io_cast_input_oids.dedup();
+
+    for oid in collector.function_oids {
+        let volatility = Spi::get_one_with_args::<String>(
+            "SELECT provolatile::text FROM pg_catalog.pg_proc WHERE oid = $1",
+            &[oid.into()],
+        )
+        .map_err(|e| PgTrickleError::SpiError(format!("volatility lookup failed: {e}")))?
+        .and_then(|value| value.chars().next())
+        .unwrap_or('v');
+        collector.worst = max_analyzed_volatility(collector.worst, volatility);
+    }
+
+    for input_oid in collector.io_cast_input_oids {
+        let volatility = Spi::get_one_with_args::<String>(
+            "SELECT CASE WHEN t.typcategory = 'E' THEN 'i'::text \
+                    ELSE p.provolatile::text END
+             FROM pg_catalog.pg_type t
+             JOIN pg_catalog.pg_proc p ON p.oid = t.typoutput
+             WHERE t.oid = $1",
+            &[input_oid.into()],
+        )
+        .map_err(|e| PgTrickleError::SpiError(format!("cast volatility lookup failed: {e}")))?
+        .and_then(|value| value.chars().next())
+        .unwrap_or('v');
+        collector.worst = max_analyzed_volatility(collector.worst, volatility);
+    }
+
+    Ok(collector.worst)
+}
+
+#[cfg(not(test))]
+unsafe extern "C-unwind" fn collect_volatility_nodes(
+    node: *mut pg_sys::Node,
+    context: *mut std::ffi::c_void,
+) -> bool {
+    if node.is_null() {
+        return false;
+    }
+
+    // SAFETY: context is the VolatilityCollector passed to the walker below.
+    let collector = unsafe { &mut *(context as *mut VolatilityCollector) };
+
+    // SAFETY: PostgreSQL's walker supplies valid nodes and is_a checks the
+    // tag before each typed access.
+    unsafe {
+        if pgrx::is_a(node, pg_sys::NodeTag::T_FuncExpr) {
+            collector
+                .function_oids
+                .push((*(node as *const pg_sys::FuncExpr)).funcid);
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_OpExpr)
+            || pgrx::is_a(node, pg_sys::NodeTag::T_DistinctExpr)
+            || pgrx::is_a(node, pg_sys::NodeTag::T_NullIfExpr)
+        {
+            collector
+                .function_oids
+                .push((*(node as *const pg_sys::OpExpr)).opfuncid);
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_ScalarArrayOpExpr) {
+            collector
+                .function_oids
+                .push((*(node as *const pg_sys::ScalarArrayOpExpr)).opfuncid);
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_CoerceViaIO) {
+            let cast = &*(node as *const pg_sys::CoerceViaIO);
+            if !cast.arg.is_null() {
+                collector
+                    .io_cast_input_oids
+                    .push(pg_sys::exprType(cast.arg as *const pg_sys::Node));
+            }
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_SQLValueFunction) {
+            collector.worst = max_analyzed_volatility(collector.worst, 's');
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_NextValueExpr) {
+            collector.worst = 'v';
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_WindowFunc) {
+            collector
+                .function_oids
+                .push((*(node as *const pg_sys::WindowFunc)).winfnoid);
+        }
+    }
+
+    // expression_tree_walker does not recurse into nested Query nodes.
+    // SAFETY: node is a valid Query supplied by PostgreSQL's walker.
+    if unsafe { pgrx::is_a(node, pg_sys::NodeTag::T_Query) } {
+        // SAFETY: node tag verified as T_Query and context remains valid.
+        return unsafe {
+            pg_sys::query_tree_walker_impl(
+                node as *mut pg_sys::Query,
+                Some(collect_volatility_nodes),
+                context,
+                pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
+            )
+        };
+    }
+
+    // SAFETY: node and context are valid pointers from PostgreSQL's walker.
+    unsafe { pg_sys::expression_tree_walker_impl(node, Some(collect_volatility_nodes), context) }
+}
+
+#[cfg(test)]
+fn analyzed_query_volatility(_query_node: *mut pg_sys::Query) -> Result<char, PgTrickleError> {
+    Ok('i')
+}
+
 /// Validate a defining query and extract its output columns and volatility via
 /// parse analysis.
 ///
@@ -1000,16 +1151,9 @@ pub(crate) fn validate_defining_query(
             ));
         }
 
-        let query_node = query_node.cast::<pg_sys::Node>();
-        let volatility = if pg_sys::contain_volatile_functions(query_node) {
-            'v'
-        } else if pg_sys::contain_mutable_functions(query_node) {
-            's'
-        } else {
-            'i'
-        };
+        let volatility = analyzed_query_volatility(query_node);
 
-        Ok((columns, volatility))
+        Ok((columns, volatility?))
     }
 }
 

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -920,18 +920,28 @@ pub struct ColumnDef {
 }
 
 #[cfg(not(test))]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct AnalyzedFunctionCall {
     oid: pg_sys::Oid,
-    supplied_args: i32,
+    supplied_arg_numbers: Vec<i32>,
 }
 
 #[cfg(not(test))]
 struct VolatilityCollector {
     function_oids: Vec<pg_sys::Oid>,
     function_calls: Vec<AnalyzedFunctionCall>,
-    io_cast_input_oids: Vec<pg_sys::Oid>,
+    enum_io_function_oids: Vec<pg_sys::Oid>,
     worst: char,
+}
+
+#[cfg(not(test))]
+unsafe extern "C-unwind" {
+    #[link_name = "jspIsMutable"]
+    fn jsonpath_is_mutable(
+        path: *mut std::ffi::c_void,
+        varnames: *mut pg_sys::List,
+        varexprs: *mut pg_sys::List,
+    ) -> bool;
 }
 
 #[cfg(not(test))]
@@ -955,7 +965,7 @@ fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgT
     let mut collector = VolatilityCollector {
         function_oids: Vec::new(),
         function_calls: Vec::new(),
-        io_cast_input_oids: Vec::new(),
+        enum_io_function_oids: Vec::new(),
         worst: 'i',
     };
 
@@ -977,31 +987,23 @@ fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgT
         .sort_unstable_by_key(|oid| oid.to_u32());
     collector.function_oids.dedup();
     collector
-        .io_cast_input_oids
+        .enum_io_function_oids
         .sort_unstable_by_key(|oid| oid.to_u32());
-    collector.io_cast_input_oids.dedup();
+    collector.enum_io_function_oids.dedup();
 
     for oid in collector.function_oids {
+        if collector
+            .enum_io_function_oids
+            .binary_search_by_key(&oid.to_u32(), |candidate| candidate.to_u32())
+            .is_ok()
+        {
+            continue;
+        }
         let volatility = Spi::get_one_with_args::<String>(
             "SELECT provolatile::text FROM pg_catalog.pg_proc WHERE oid = $1",
             &[oid.into()],
         )
         .map_err(|e| PgTrickleError::SpiError(format!("volatility lookup failed: {e}")))?
-        .and_then(|value| value.chars().next())
-        .unwrap_or('v');
-        collector.worst = max_analyzed_volatility(collector.worst, volatility);
-    }
-
-    for input_oid in collector.io_cast_input_oids {
-        let volatility = Spi::get_one_with_args::<String>(
-            "SELECT CASE WHEN t.typcategory = 'E' THEN 'i'::text \
-                    ELSE p.provolatile::text END
-             FROM pg_catalog.pg_type t
-             JOIN pg_catalog.pg_proc p ON p.oid = t.typoutput
-             WHERE t.oid = $1",
-            &[input_oid.into()],
-        )
-        .map_err(|e| PgTrickleError::SpiError(format!("cast volatility lookup failed: {e}")))?
         .and_then(|value| value.chars().next())
         .unwrap_or('v');
         collector.worst = max_analyzed_volatility(collector.worst, volatility);
@@ -1013,59 +1015,92 @@ fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgT
 /// Add volatility from function defaults omitted at the call site.
 ///
 /// PostgreSQL leaves default expressions out of the analyzed `FuncExpr` and
-/// inserts them during planning. Deparse and analyze all defaults for a
-/// function when any are omitted. Inspecting every default is deliberately
-/// fail-closed for named-argument calls that can omit non-trailing arguments.
+/// inserts them during planning. Analyze only the defaults absent from this
+/// call, using `NamedArgExpr.argnumber` for named and mixed notation.
 #[cfg(not(test))]
 fn collect_default_argument_volatility(
     collector: &mut VolatilityCollector,
 ) -> Result<(), PgTrickleError> {
     let mut checked_calls = std::collections::HashSet::new();
-    let mut checked_functions = std::collections::HashSet::new();
     let mut index = 0;
 
-    while let Some(call) = collector.function_calls.get(index).copied() {
+    while let Some(call) = collector.function_calls.get(index).cloned() {
         index += 1;
-        if checked_functions.contains(&call.oid) || !checked_calls.insert(call) {
+        if !checked_calls.insert(call.clone()) {
             continue;
         }
 
-        let defaults_sql = Spi::get_one_with_args::<String>(
-            "SELECT CASE \
-                    WHEN pronargdefaults > 0 AND pronargs::int > $2 \
-                    THEN pg_get_expr(proargdefaults, 0::oid) \
-                    END \
+        let (pronargs, pronargdefaults, defaults_sql) =
+            Spi::get_three_with_args::<i32, i32, String>(
+                "SELECT pronargs::int, pronargdefaults::int, \
+                    CASE WHEN pronargdefaults > 0 \
+                         THEN pg_get_expr(proargdefaults, 0::oid) END \
              FROM pg_catalog.pg_proc WHERE oid = $1",
-            &[call.oid.into(), call.supplied_args.into()],
-        )
-        .map_err(|e| {
-            PgTrickleError::SpiError(format!(
-                "default-argument volatility lookup failed for function OID {}: {e}",
-                call.oid
-            ))
-        })?;
+                &[call.oid.into()],
+            )
+            .map_err(|e| {
+                PgTrickleError::SpiError(format!(
+                    "default-argument volatility lookup failed for function OID {}: {e}",
+                    call.oid
+                ))
+            })?;
 
-        let Some(defaults_sql) = defaults_sql else {
+        let (Some(pronargs), Some(pronargdefaults), Some(defaults_sql)) =
+            (pronargs, pronargdefaults, defaults_sql)
+        else {
             continue;
         };
-        checked_functions.insert(call.oid);
+
+        let first_default = pronargs - pronargdefaults;
+        let omitted_defaults = (first_default..pronargs)
+            .filter(|argnumber| call.supplied_arg_numbers.binary_search(argnumber).is_err())
+            .map(|argnumber| (argnumber - first_default) as usize)
+            .collect::<Vec<_>>();
+        if omitted_defaults.is_empty() {
+            continue;
+        }
 
         let defaults_query = format!("SELECT {defaults_sql}");
         let defaults_node = analyze_query_tree(&defaults_query)?;
 
         // SAFETY: defaults_node is a valid analyzed Query allocated by
-        // PostgreSQL and remains valid for this function's duration.
+        // PostgreSQL and remains valid for this function's duration. Its
+        // target list contains the defaults in declared positional order.
         unsafe {
-            pg_sys::query_tree_walker_impl(
-                defaults_node,
-                Some(collect_volatility_nodes),
-                collector as *mut VolatilityCollector as *mut std::ffi::c_void,
-                pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
-            );
+            let targets = pgrx::PgList::<pg_sys::TargetEntry>::from_pg((*defaults_node).targetList);
+            for default_index in omitted_defaults {
+                let Some(target) = targets.get_ptr(default_index) else {
+                    collector.worst = 'v';
+                    continue;
+                };
+                if target.is_null() || (*target).expr.is_null() {
+                    collector.worst = 'v';
+                    continue;
+                }
+                collect_volatility_nodes(
+                    (*target).expr as *mut pg_sys::Node,
+                    collector as *mut VolatilityCollector as *mut std::ffi::c_void,
+                );
+            }
         }
     }
 
     Ok(())
+}
+
+#[cfg(not(test))]
+unsafe extern "C-unwind" fn collect_function_oid(
+    oid: pg_sys::Oid,
+    context: *mut std::ffi::c_void,
+) -> bool {
+    // SAFETY: PostgreSQL invokes this callback synchronously with the
+    // VolatilityCollector context passed to check_functions_in_node.
+    unsafe {
+        (*(context as *mut VolatilityCollector))
+            .function_oids
+            .push(oid);
+    }
+    false
 }
 
 #[cfg(not(test))]
@@ -1091,37 +1126,96 @@ unsafe extern "C-unwind" fn collect_volatility_nodes(
         let collector = &mut *(context as *mut VolatilityCollector);
         if pgrx::is_a(node, pg_sys::NodeTag::T_FuncExpr) {
             let function = &*(node as *const pg_sys::FuncExpr);
-            collector.function_oids.push(function.funcid);
+            let args = pgrx::PgList::<pg_sys::Node>::from_pg(function.args);
+            let mut supplied_arg_numbers = args
+                .iter_ptr()
+                .enumerate()
+                .map(|(index, arg)| {
+                    if pgrx::is_a(arg, pg_sys::NodeTag::T_NamedArgExpr) {
+                        (*(arg as *const pg_sys::NamedArgExpr)).argnumber
+                    } else {
+                        index as i32
+                    }
+                })
+                .collect::<Vec<_>>();
+            supplied_arg_numbers.sort_unstable();
             collector.function_calls.push(AnalyzedFunctionCall {
                 oid: function.funcid,
-                supplied_args: pg_sys::list_length(function.args),
+                supplied_arg_numbers,
             });
-        } else if pgrx::is_a(node, pg_sys::NodeTag::T_OpExpr)
-            || pgrx::is_a(node, pg_sys::NodeTag::T_DistinctExpr)
-            || pgrx::is_a(node, pg_sys::NodeTag::T_NullIfExpr)
-        {
-            collector
-                .function_oids
-                .push((*(node as *const pg_sys::OpExpr)).opfuncid);
-        } else if pgrx::is_a(node, pg_sys::NodeTag::T_ScalarArrayOpExpr) {
-            collector
-                .function_oids
-                .push((*(node as *const pg_sys::ScalarArrayOpExpr)).opfuncid);
-        } else if pgrx::is_a(node, pg_sys::NodeTag::T_CoerceViaIO) {
+        }
+
+        if pgrx::is_a(node, pg_sys::NodeTag::T_CoerceViaIO) {
             let cast = &*(node as *const pg_sys::CoerceViaIO);
             if !cast.arg.is_null() {
-                collector
-                    .io_cast_input_oids
-                    .push(pg_sys::exprType(cast.arg as *const pg_sys::Node));
+                let source_type = pg_sys::exprType(cast.arg as *const pg_sys::Node);
+                if pg_sys::get_typtype(source_type) as u8 == pg_sys::TYPTYPE_ENUM {
+                    let mut output = pg_sys::InvalidOid;
+                    let mut is_varlena = false;
+                    pg_sys::getTypeOutputInfo(source_type, &mut output, &mut is_varlena);
+                    collector.enum_io_function_oids.push(output);
+                }
+            }
+            if pg_sys::get_typtype(cast.resulttype) as u8 == pg_sys::TYPTYPE_ENUM {
+                let mut input = pg_sys::InvalidOid;
+                let mut io_param = pg_sys::InvalidOid;
+                pg_sys::getTypeInputInfo(cast.resulttype, &mut input, &mut io_param);
+                collector.enum_io_function_oids.push(input);
+            }
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_JsonConstructorExpr) {
+            let constructor = &*(node as *const pg_sys::JsonConstructorExpr);
+            if constructor.returning.is_null() || (*constructor.returning).format.is_null() {
+                collector.worst = 'v';
+            } else {
+                let is_jsonb = (*(*constructor.returning).format).format_type
+                    == pg_sys::JsonFormatType::JS_FORMAT_JSONB;
+                let args = pgrx::PgList::<pg_sys::Node>::from_pg(constructor.args);
+                for arg in args.iter_ptr() {
+                    let arg_type = pg_sys::exprType(arg as *const pg_sys::Node);
+                    let immutable = if is_jsonb {
+                        pg_sys::to_jsonb_is_immutable(arg_type)
+                    } else {
+                        pg_sys::to_json_is_immutable(arg_type)
+                    };
+                    if !immutable {
+                        collector.worst = max_analyzed_volatility(collector.worst, 's');
+                    }
+                }
+            }
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_JsonExpr) {
+            let json = &*(node as *const pg_sys::JsonExpr);
+            if !pgrx::is_a(json.path_spec, pg_sys::NodeTag::T_Const) {
+                collector.worst = max_analyzed_volatility(collector.worst, 's');
+            } else {
+                let path = &*(json.path_spec as *const pg_sys::Const);
+                if !path.constisnull {
+                    if path.consttype != pg_sys::JSONPATHOID {
+                        collector.worst = 'v';
+                    } else {
+                        let detoasted = pg_sys::pg_detoast_datum(
+                            path.constvalue.cast_mut_ptr::<pg_sys::varlena>(),
+                        );
+                        if jsonpath_is_mutable(
+                            detoasted as *mut std::ffi::c_void,
+                            json.passing_names,
+                            json.passing_values,
+                        ) {
+                            collector.worst = max_analyzed_volatility(collector.worst, 's');
+                        }
+                    }
+                }
             }
         } else if pgrx::is_a(node, pg_sys::NodeTag::T_SQLValueFunction) {
             collector.worst = max_analyzed_volatility(collector.worst, 's');
         } else if pgrx::is_a(node, pg_sys::NodeTag::T_NextValueExpr) {
             collector.worst = 'v';
-        } else if pgrx::is_a(node, pg_sys::NodeTag::T_WindowFunc) {
-            collector
-                .function_oids
-                .push((*(node as *const pg_sys::WindowFunc)).winfnoid);
+        }
+
+        // Aggregate implementation volatility is intentionally excluded.
+        // PostgreSQL handles every other function-containing node, including
+        // both sides of CoerceViaIO and every RowCompareExpr operator.
+        if !pgrx::is_a(node, pg_sys::NodeTag::T_Aggref) {
+            pg_sys::check_functions_in_node(node, Some(collect_function_oid), context);
         }
 
         // expression_tree_walker does not recurse into nested Query nodes.

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -920,8 +920,16 @@ pub struct ColumnDef {
 }
 
 #[cfg(not(test))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct AnalyzedFunctionCall {
+    oid: pg_sys::Oid,
+    supplied_args: i32,
+}
+
+#[cfg(not(test))]
 struct VolatilityCollector {
     function_oids: Vec<pg_sys::Oid>,
+    function_calls: Vec<AnalyzedFunctionCall>,
     io_cast_input_oids: Vec<pg_sys::Oid>,
     worst: char,
 }
@@ -946,6 +954,7 @@ fn max_analyzed_volatility(a: char, b: char) -> char {
 fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgTrickleError> {
     let mut collector = VolatilityCollector {
         function_oids: Vec::new(),
+        function_calls: Vec::new(),
         io_cast_input_oids: Vec::new(),
         worst: 'i',
     };
@@ -960,6 +969,8 @@ fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgT
             pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
         );
     }
+
+    collect_default_argument_volatility(&mut collector)?;
 
     collector
         .function_oids
@@ -999,6 +1010,64 @@ fn analyzed_query_volatility(query_node: *mut pg_sys::Query) -> Result<char, PgT
     Ok(collector.worst)
 }
 
+/// Add volatility from function defaults omitted at the call site.
+///
+/// PostgreSQL leaves default expressions out of the analyzed `FuncExpr` and
+/// inserts them during planning. Deparse and analyze all defaults for a
+/// function when any are omitted. Inspecting every default is deliberately
+/// fail-closed for named-argument calls that can omit non-trailing arguments.
+#[cfg(not(test))]
+fn collect_default_argument_volatility(
+    collector: &mut VolatilityCollector,
+) -> Result<(), PgTrickleError> {
+    let mut checked_calls = std::collections::HashSet::new();
+    let mut checked_functions = std::collections::HashSet::new();
+    let mut index = 0;
+
+    while let Some(call) = collector.function_calls.get(index).copied() {
+        index += 1;
+        if checked_functions.contains(&call.oid) || !checked_calls.insert(call) {
+            continue;
+        }
+
+        let defaults_sql = Spi::get_one_with_args::<String>(
+            "SELECT CASE \
+                    WHEN pronargdefaults > 0 AND pronargs::int > $2 \
+                    THEN pg_get_expr(proargdefaults, 0::oid) \
+                    END \
+             FROM pg_catalog.pg_proc WHERE oid = $1",
+            &[call.oid.into(), call.supplied_args.into()],
+        )
+        .map_err(|e| {
+            PgTrickleError::SpiError(format!(
+                "default-argument volatility lookup failed for function OID {}: {e}",
+                call.oid
+            ))
+        })?;
+
+        let Some(defaults_sql) = defaults_sql else {
+            continue;
+        };
+        checked_functions.insert(call.oid);
+
+        let defaults_query = format!("SELECT {defaults_sql}");
+        let defaults_node = analyze_query_tree(&defaults_query)?;
+
+        // SAFETY: defaults_node is a valid analyzed Query allocated by
+        // PostgreSQL and remains valid for this function's duration.
+        unsafe {
+            pg_sys::query_tree_walker_impl(
+                defaults_node,
+                Some(collect_volatility_nodes),
+                collector as *mut VolatilityCollector as *mut std::ffi::c_void,
+                pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(not(test))]
 unsafe extern "C-unwind" fn collect_volatility_nodes(
     node: *mut pg_sys::Node,
@@ -1012,11 +1081,21 @@ unsafe extern "C-unwind" fn collect_volatility_nodes(
     // VolatilityCollector passed below, and every typed access is guarded by
     // an is_a check.
     unsafe {
+        // QTW_EXAMINE_RTES_BEFORE passes RangeTblEntry nodes to the callback
+        // before the query walker handles their subqueries. They are not
+        // expression nodes and must not reach expression_tree_walker.
+        if pgrx::is_a(node, pg_sys::NodeTag::T_RangeTblEntry) {
+            return false;
+        }
+
         let collector = &mut *(context as *mut VolatilityCollector);
         if pgrx::is_a(node, pg_sys::NodeTag::T_FuncExpr) {
-            collector
-                .function_oids
-                .push((*(node as *const pg_sys::FuncExpr)).funcid);
+            let function = &*(node as *const pg_sys::FuncExpr);
+            collector.function_oids.push(function.funcid);
+            collector.function_calls.push(AnalyzedFunctionCall {
+                oid: function.funcid,
+                supplied_args: pg_sys::list_length(function.args),
+            });
         } else if pgrx::is_a(node, pg_sys::NodeTag::T_OpExpr)
             || pgrx::is_a(node, pg_sys::NodeTag::T_DistinctExpr)
             || pgrx::is_a(node, pg_sys::NodeTag::T_NullIfExpr)
@@ -1064,24 +1143,15 @@ fn analyzed_query_volatility(_query_node: *mut pg_sys::Query) -> Result<char, Pg
     Ok('i')
 }
 
-/// Validate a defining query and extract its output columns and volatility via
-/// parse analysis.
-///
-/// This avoids executing the query body during validation, which is important
-/// for stream-table cycles where a plain `SELECT ... LIMIT 0` can still reach
-/// change-buffer-dependent paths for upstream stream tables.
-pub(crate) fn validate_defining_query(
-    query: &str,
-) -> Result<(Vec<ColumnDef>, char), PgTrickleError> {
+fn analyze_query_tree(query: &str) -> Result<*mut pg_sys::Query, PgTrickleError> {
     use pgrx::PgList;
-    use std::ffi::{CStr, CString};
+    use std::ffi::CString;
 
     let c_sql = CString::new(query)
-        .map_err(|e| PgTrickleError::QueryParseError(format!("Query contains null byte: {}", e)))?;
+        .map_err(|e| PgTrickleError::QueryParseError(format!("Query contains null byte: {e}")))?;
 
-    // SAFETY: We call PostgreSQL's raw parser and analyzer with a valid query
-    // string inside a backend. The returned parse/analyze nodes remain valid
-    // for the duration of this function.
+    // SAFETY: PostgreSQL receives a valid SQL string inside a backend. The
+    // returned analyzed Query remains valid in the current memory context.
     unsafe {
         let raw_list = pg_sys::raw_parser(c_sql.as_ptr(), pg_sys::RawParseMode::RAW_PARSE_DEFAULT);
         let stmts = PgList::<pg_sys::RawStmt>::from_pg(raw_list);
@@ -1096,7 +1166,6 @@ pub(crate) fn validate_defining_query(
         let raw_stmt = stmts.get_ptr(0).ok_or_else(|| {
             PgTrickleError::QueryParseError("Query produced no parse tree nodes".into())
         })?;
-
         let query_node = pg_sys::parse_analyze_fixedparams(
             raw_stmt,
             c_sql.as_ptr(),
@@ -1106,11 +1175,32 @@ pub(crate) fn validate_defining_query(
         );
 
         if query_node.is_null() {
-            return Err(PgTrickleError::QueryParseError(
+            Err(PgTrickleError::QueryParseError(
                 "Query analysis returned null".into(),
-            ));
+            ))
+        } else {
+            Ok(query_node)
         }
+    }
+}
 
+/// Validate a defining query and extract its output columns and volatility via
+/// parse analysis.
+///
+/// This avoids executing the query body during validation, which is important
+/// for stream-table cycles where a plain `SELECT ... LIMIT 0` can still reach
+/// change-buffer-dependent paths for upstream stream tables.
+pub(crate) fn validate_defining_query(
+    query: &str,
+) -> Result<(Vec<ColumnDef>, char), PgTrickleError> {
+    use pgrx::PgList;
+    use std::ffi::CStr;
+
+    let query_node = analyze_query_tree(query)?;
+
+    // SAFETY: analyze_query_tree returned a valid Query allocated in the
+    // current PostgreSQL memory context.
+    unsafe {
         let target_list = PgList::<pg_sys::TargetEntry>::from_pg((*query_node).targetList);
         let mut columns = Vec::new();
 

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -1104,6 +1104,34 @@ unsafe extern "C-unwind" fn collect_function_oid(
 }
 
 #[cfg(not(test))]
+fn record_function_call(
+    oid: pg_sys::Oid,
+    args: &pgrx::PgList<pg_sys::Node>,
+    collector: &mut VolatilityCollector,
+) {
+    let mut supplied_arg_numbers = args
+        .iter_ptr()
+        .enumerate()
+        .map(|(index, arg)| {
+            // SAFETY: args comes from a valid analyzed FuncExpr or WindowFunc
+            // and its nodes remain valid for the collector's duration.
+            unsafe {
+                if pgrx::is_a(arg, pg_sys::NodeTag::T_NamedArgExpr) {
+                    (*(arg as *const pg_sys::NamedArgExpr)).argnumber
+                } else {
+                    index as i32
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    supplied_arg_numbers.sort_unstable();
+    collector.function_calls.push(AnalyzedFunctionCall {
+        oid,
+        supplied_arg_numbers,
+    });
+}
+
+#[cfg(not(test))]
 unsafe extern "C-unwind" fn collect_volatility_nodes(
     node: *mut pg_sys::Node,
     context: *mut std::ffi::c_void,
@@ -1127,22 +1155,13 @@ unsafe extern "C-unwind" fn collect_volatility_nodes(
         if pgrx::is_a(node, pg_sys::NodeTag::T_FuncExpr) {
             let function = &*(node as *const pg_sys::FuncExpr);
             let args = pgrx::PgList::<pg_sys::Node>::from_pg(function.args);
-            let mut supplied_arg_numbers = args
-                .iter_ptr()
-                .enumerate()
-                .map(|(index, arg)| {
-                    if pgrx::is_a(arg, pg_sys::NodeTag::T_NamedArgExpr) {
-                        (*(arg as *const pg_sys::NamedArgExpr)).argnumber
-                    } else {
-                        index as i32
-                    }
-                })
-                .collect::<Vec<_>>();
-            supplied_arg_numbers.sort_unstable();
-            collector.function_calls.push(AnalyzedFunctionCall {
-                oid: function.funcid,
-                supplied_arg_numbers,
-            });
+            record_function_call(function.funcid, &args, collector);
+        } else if pgrx::is_a(node, pg_sys::NodeTag::T_WindowFunc) {
+            let window = &*(node as *const pg_sys::WindowFunc);
+            if !window.winagg {
+                let args = pgrx::PgList::<pg_sys::Node>::from_pg(window.args);
+                record_function_call(window.winfnoid, &args, collector);
+            }
         }
 
         if pgrx::is_a(node, pg_sys::NodeTag::T_CoerceViaIO) {

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -919,12 +919,15 @@ pub struct ColumnDef {
     pub type_oid: PgOid,
 }
 
-/// Validate a defining query and extract its output columns via parse analysis.
+/// Validate a defining query and extract its output columns and volatility via
+/// parse analysis.
 ///
 /// This avoids executing the query body during validation, which is important
 /// for stream-table cycles where a plain `SELECT ... LIMIT 0` can still reach
 /// change-buffer-dependent paths for upstream stream tables.
-pub(super) fn validate_defining_query(query: &str) -> Result<Vec<ColumnDef>, PgTrickleError> {
+pub(crate) fn validate_defining_query(
+    query: &str,
+) -> Result<(Vec<ColumnDef>, char), PgTrickleError> {
     use pgrx::PgList;
     use std::ffi::{CStr, CString};
 
@@ -997,7 +1000,16 @@ pub(super) fn validate_defining_query(query: &str) -> Result<Vec<ColumnDef>, PgT
             ));
         }
 
-        Ok(columns)
+        let query_node = query_node.cast::<pg_sys::Node>();
+        let volatility = if pg_sys::contain_volatile_functions(query_node) {
+            'v'
+        } else if pg_sys::contain_mutable_functions(query_node) {
+            's'
+        } else {
+            'i'
+        };
+
+        Ok((columns, volatility))
     }
 }
 

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -1008,12 +1008,11 @@ unsafe extern "C-unwind" fn collect_volatility_nodes(
         return false;
     }
 
-    // SAFETY: context is the VolatilityCollector passed to the walker below.
-    let collector = unsafe { &mut *(context as *mut VolatilityCollector) };
-
-    // SAFETY: PostgreSQL's walker supplies valid nodes and is_a checks the
-    // tag before each typed access.
+    // SAFETY: PostgreSQL's walker supplies valid nodes, `context` is the
+    // VolatilityCollector passed below, and every typed access is guarded by
+    // an is_a check.
     unsafe {
+        let collector = &mut *(context as *mut VolatilityCollector);
         if pgrx::is_a(node, pg_sys::NodeTag::T_FuncExpr) {
             collector
                 .function_oids
@@ -1045,24 +1044,19 @@ unsafe extern "C-unwind" fn collect_volatility_nodes(
                 .function_oids
                 .push((*(node as *const pg_sys::WindowFunc)).winfnoid);
         }
-    }
 
-    // expression_tree_walker does not recurse into nested Query nodes.
-    // SAFETY: node is a valid Query supplied by PostgreSQL's walker.
-    if unsafe { pgrx::is_a(node, pg_sys::NodeTag::T_Query) } {
-        // SAFETY: node tag verified as T_Query and context remains valid.
-        return unsafe {
+        // expression_tree_walker does not recurse into nested Query nodes.
+        if pgrx::is_a(node, pg_sys::NodeTag::T_Query) {
             pg_sys::query_tree_walker_impl(
                 node as *mut pg_sys::Query,
                 Some(collect_volatility_nodes),
                 context,
                 pg_sys::QTW_EXAMINE_RTES_BEFORE as i32,
             )
-        };
+        } else {
+            pg_sys::expression_tree_walker_impl(node, Some(collect_volatility_nodes), context)
+        }
     }
-
-    // SAFETY: node and context are valid pointers from PostgreSQL's walker.
-    unsafe { pg_sys::expression_tree_walker_impl(node, Some(collect_volatility_nodes), context) }
 }
 
 #[cfg(test)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -967,7 +967,7 @@ fn validate_and_parse_query(
     had_nested_window_rewrite: bool,
 ) -> Result<ValidatedQuery, PgTrickleError> {
     // Validate the defining query and extract output columns
-    let columns = validate_defining_query(query)?;
+    let (columns, query_volatility) = validate_defining_query(query)?;
 
     // TopK detection — must run BEFORE reject_limit_offset
     let topk_info = crate::dvm::detect_topk_pattern(query)?;
@@ -992,19 +992,17 @@ fn validate_and_parse_query(
     if topk_info.is_some()
         && (*refresh_mode == RefreshMode::Differential || *refresh_mode == RefreshMode::Immediate)
     {
-        let topk_issue = match crate::dvm::topk_query_volatility(query) {
-            Ok(volatility) if volatility < 's' => None,
-            Ok(volatility) => Some(format!(
+        let topk_issue = if query_volatility < 's' {
+            None
+        } else {
+            Some(format!(
                 "TopK ORDER BY contains {} expressions that can change between refreshes",
-                if volatility == 'v' {
+                if query_volatility == 'v' {
                     "volatile"
                 } else {
                     "stable"
                 }
-            )),
-            Err(error) => Some(format!(
-                "TopK ORDER BY could not be inspected safely: {error}"
-            )),
+            ))
         };
         if let Some(reason) = topk_issue {
             if is_auto && *refresh_mode == RefreshMode::Differential {
@@ -1215,7 +1213,11 @@ fn validate_and_parse_query(
     // One admission matrix for CREATE, ALTER, and mode changes. Known unsafe
     // forms are FULL-only; explicit incremental modes fail before mutation.
     if let Some(pr) = parsed_tree.as_ref() {
-        let admission = match crate::dvm::incremental_admission(pr, refresh_mode.is_immediate()) {
+        let admission = match crate::dvm::incremental_admission(
+            pr,
+            query_volatility,
+            refresh_mode.is_immediate(),
+        ) {
             Ok(admission) => admission,
             Err(e) if is_auto && *refresh_mode == RefreshMode::Differential => {
                 pgrx::warning!(
@@ -1391,12 +1393,14 @@ pub(crate) fn validate_incremental_mode_for_query(
     if mode == RefreshMode::Full {
         return Ok(());
     }
+    let (_, query_volatility) = validate_defining_query(defining_query)?;
     let result = crate::dvm::parse_defining_query_full(defining_query)?;
     crate::dvm::check_ivm_support_with_registry(&result)?;
     if mode.is_immediate() {
         crate::dvm::validate_immediate_mode_support(defining_query)?;
     }
-    let admission = crate::dvm::incremental_admission(&result, mode.is_immediate())?;
+    let admission =
+        crate::dvm::incremental_admission(&result, query_volatility, mode.is_immediate())?;
     crate::dvm::resolve_incremental_mode(mode, false, &admission)?;
     Ok(())
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -392,7 +392,7 @@ fn explain_query_rewrite_impl(
                 }
 
                 // Volatility: 'i' = immutable, 's' = stable, 'v' = volatile.
-                if let Ok(v) = dvm::tree_worst_volatility_with_registry(&result) {
+                if let Ok((_, v)) = crate::api::helpers::validate_defining_query(&effective_q) {
                     let label = match v {
                         'i' => "immutable",
                         's' => "stable",
@@ -1093,7 +1093,7 @@ fn validate_query_impl(query: &str) -> Result<Vec<(String, String, String)>, PgT
                 }
 
                 // Volatility.
-                if let Ok(v) = dvm::tree_worst_volatility_with_registry(&result) {
+                if let Ok((_, v)) = crate::api::helpers::validate_defining_query(&effective_q) {
                     let (label, sev) = match v {
                         'i' => ("immutable", "INFO"),
                         's' => ("stable", "INFO"),
@@ -1175,19 +1175,41 @@ fn resolve_auto_refresh_mode(q: &str, rows: &mut Vec<(String, String, String)>) 
         return "FULL".to_string();
     }
 
-    // 3. DVM parse + IVM support.
+    let volatility = match crate::api::helpers::validate_defining_query(q) {
+        Ok((_, volatility)) => volatility,
+        Err(e) => {
+            rows.push((
+                "query_analysis".to_string(),
+                format!("query analysis failed: {e}"),
+                "WARNING".to_string(),
+            ));
+            return "FULL".to_string();
+        }
+    };
+
+    // 3. DVM parse + incremental admission.
     match dvm::parse_defining_query_full(q) {
-        Ok(result) => {
-            if let Err(e) = dvm::check_ivm_support_with_registry(&result) {
+        Ok(result) => match dvm::incremental_admission(&result, volatility, false) {
+            Ok(dvm::IncrementalAdmission::Proven) => "DIFFERENTIAL".to_string(),
+            Ok(dvm::IncrementalAdmission::FullOnly(issues)) => {
+                for issue in issues {
+                    rows.push((
+                        issue.code.to_string(),
+                        format!("{}: {}", issue.operator, issue.reason),
+                        "WARNING".to_string(),
+                    ));
+                }
+                "FULL".to_string()
+            }
+            Err(e) => {
                 rows.push((
-                    "ivm_support_check".to_string(),
-                    format!("DIFFERENTIAL not supported: {}", e),
+                    "incremental_admission".to_string(),
+                    format!("inspection failed: {e}"),
                     "WARNING".to_string(),
                 ));
-                return "FULL".to_string();
+                "FULL".to_string()
             }
-            "DIFFERENTIAL".to_string()
-        }
+        },
         Err(e) => {
             rows.push((
                 "ivm_support_check".to_string(),

--- a/src/dvm/mod.rs
+++ b/src/dvm/mod.rs
@@ -67,7 +67,7 @@ pub use parser::{
     resolve_incremental_mode, rewrite_correlated_scalar_in_select, rewrite_demorgan_sublinks,
     rewrite_distinct_on, rewrite_grouping_sets, rewrite_nested_window_exprs, rewrite_rows_from,
     rewrite_scalar_subquery_in_where, rewrite_sublinks_in_or, rewrite_views_inline,
-    topk_query_volatility, tree_worst_volatility_with_registry, validate_immediate_mode_support,
+    tree_worst_volatility_with_registry, validate_immediate_mode_support,
     warn_limit_without_order_in_subqueries,
 };
 

--- a/src/dvm/parser/validation.rs
+++ b/src/dvm/parser/validation.rs
@@ -63,6 +63,7 @@ pub fn resolve_incremental_mode(
 /// Classify known unproven incremental forms without mutating any state.
 pub fn incremental_admission(
     result: &ParseResult,
+    volatility: char,
     immediate: bool,
 ) -> Result<IncrementalAdmission, PgTrickleError> {
     let mut issues = Vec::new();
@@ -71,7 +72,6 @@ pub fn incremental_admission(
         collect_admission_issues(body, immediate, &mut issues);
     }
 
-    let volatility = tree_worst_volatility_with_registry(result)?;
     if volatility >= 's' {
         let (code, reason) = if volatility == 'v' {
             (
@@ -606,25 +606,6 @@ fn scan_sql_for_volatility(sql: &str, worst: &mut char) -> Result<(), PgTrickleE
         }
     }
     Ok(())
-}
-
-/// Inspect a complete TopK query before its ORDER BY/LIMIT wrapper is removed.
-///
-/// The base DVM tree intentionally excludes the ordering expression, so TopK
-/// needs this separate raw-AST pass to keep volatile or uninspectable ordering
-/// out of incremental admission.
-pub fn topk_query_volatility(sql: &str) -> Result<char, PgTrickleError> {
-    #[cfg(not(test))]
-    {
-        let mut worst = 'i';
-        scan_sql_for_volatility(sql, &mut worst)?;
-        Ok(worst)
-    }
-    #[cfg(test)]
-    {
-        let _ = sql;
-        Ok('i')
-    }
 }
 
 pub(crate) fn sql_value_function_name(op: pg_sys::SQLValueFunctionOp::Type) -> &'static str {
@@ -1859,7 +1840,7 @@ mod monotonicity_tests {
             has_recursion: false,
             warnings: vec![],
         };
-        let admission = incremental_admission(&result, false).unwrap();
+        let admission = incremental_admission(&result, 'v', false).unwrap();
         assert!(matches!(admission, IncrementalAdmission::FullOnly(_)));
         assert!(resolve_incremental_mode(RefreshMode::Differential, false, &admission).is_err());
         assert!(matches!(
@@ -1881,7 +1862,7 @@ mod monotonicity_tests {
             warnings: vec![],
         };
         assert!(matches!(
-            incremental_admission(&set_result, false).unwrap(),
+            incremental_admission(&set_result, 'i', false).unwrap(),
             IncrementalAdmission::FullOnly(_)
         ));
 
@@ -1901,7 +1882,7 @@ mod monotonicity_tests {
             warnings: vec![],
         };
         assert!(matches!(
-            incremental_admission(&lateral_result, true).unwrap(),
+            incremental_admission(&lateral_result, 'i', true).unwrap(),
             IncrementalAdmission::FullOnly(_)
         ));
     }
@@ -1939,7 +1920,7 @@ mod monotonicity_tests {
             has_recursion: false,
             warnings: vec![],
         };
-        let admission = incremental_admission(&lateral_result, false).unwrap();
+        let admission = incremental_admission(&lateral_result, 'i', false).unwrap();
         let IncrementalAdmission::FullOnly(issues) = admission else {
             panic!("unresolved LATERAL dependency must not be admitted");
         };
@@ -1971,7 +1952,7 @@ mod monotonicity_tests {
             has_recursion: false,
             warnings: vec![],
         };
-        let admission = incremental_admission(&lateral_result, false).unwrap();
+        let admission = incremental_admission(&lateral_result, 'i', false).unwrap();
         let IncrementalAdmission::FullOnly(issues) = admission else {
             panic!("complex outer identity must not be admitted");
         };

--- a/tests/e2e_diagnostics_tests.rs
+++ b/tests/e2e_diagnostics_tests.rs
@@ -357,6 +357,59 @@ async fn test_diagnostics_validate_query_simple_agg_differential() {
     );
 }
 
+#[tokio::test]
+async fn test_diagnostics_volatility_uses_resolved_overload() {
+    let db = E2eDb::new().await.with_extension().await;
+    db.execute("CREATE TABLE diag_vol_src (id INT PRIMARY KEY, label TEXT)")
+        .await;
+    db.execute(
+        "CREATE FUNCTION diag_probe(int) RETURNS int \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION diag_probe(text) RETURNS text \
+         LANGUAGE sql VOLATILE AS 'SELECT $1'",
+    )
+    .await;
+
+    let immutable_mode: String = db
+        .query_scalar(
+            "SELECT result FROM pgtrickle.validate_query(\
+               'SELECT id, diag_probe(id) FROM diag_vol_src') \
+             WHERE check_name = 'resolved_refresh_mode'",
+        )
+        .await;
+    assert_eq!(immutable_mode, "DIFFERENTIAL");
+
+    let immutable_volatility: String = db
+        .query_scalar(
+            "SELECT result FROM pgtrickle.validate_query(\
+               'SELECT id, diag_probe(id) FROM diag_vol_src') \
+             WHERE check_name = 'volatility'",
+        )
+        .await;
+    assert_eq!(immutable_volatility, "immutable");
+
+    let volatile_mode: String = db
+        .query_scalar(
+            "SELECT result FROM pgtrickle.validate_query(\
+               'SELECT id, diag_probe(label) FROM diag_vol_src') \
+             WHERE check_name = 'resolved_refresh_mode'",
+        )
+        .await;
+    assert_eq!(volatile_mode, "FULL");
+
+    let rewrite_patterns: String = db
+        .query_scalar(
+            "SELECT sql_after FROM pgtrickle.explain_query_rewrite(\
+               'SELECT id, diag_probe(id) FROM diag_vol_src') \
+             WHERE pass_name = 'dvm_patterns'",
+        )
+        .await;
+    assert!(rewrite_patterns.contains("volatility:immutable"));
+}
+
 /// DT-4: a TopK (ORDER BY + LIMIT) query should resolve to TOPK mode.
 #[tokio::test]
 async fn test_diagnostics_validate_query_topk_mode() {

--- a/tests/e2e_error_tests.rs
+++ b/tests/e2e_error_tests.rs
@@ -833,6 +833,132 @@ async fn test_stable_function_falls_back_to_full_in_auto_mode() {
 }
 
 #[tokio::test]
+async fn test_function_volatility_resolves_exact_overload_and_schema() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE SCHEMA volatility_safe").await;
+    db.execute("CREATE SCHEMA volatility_unsafe").await;
+    db.execute(
+        "CREATE FUNCTION volatility_safe.probe(int) RETURNS int \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION volatility_safe.probe(text) RETURNS text \
+         LANGUAGE sql VOLATILE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION volatility_unsafe.probe(int) RETURNS int \
+         LANGUAGE sql VOLATILE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute("CREATE TABLE nd_overload_src (id INT PRIMARY KEY, label TEXT)")
+        .await;
+    db.execute("INSERT INTO nd_overload_src VALUES (1, 'one'), (2, 'two')")
+        .await;
+
+    let immutable_query = "SELECT id, volatility_safe.probe(id) AS resolved FROM nd_overload_src";
+    db.create_st(
+        "nd_overload_immutable_st",
+        immutable_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.assert_st_matches_query("public.nd_overload_immutable_st", immutable_query)
+        .await;
+
+    for query in [
+        "SELECT id, volatility_safe.probe(label) FROM nd_overload_src",
+        "SELECT id, volatility_unsafe.probe(id) FROM nd_overload_src",
+    ] {
+        let result = db
+            .try_execute(&format!(
+                "SELECT pgtrickle.create_stream_table(\
+                 'nd_overload_rejected_st', $$ {query} $$, '1m', 'DIFFERENTIAL')"
+            ))
+            .await;
+        assert!(
+            result.is_err(),
+            "the resolved VOLATILE overload must be rejected: {query}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_temporal_volatility_uses_resolved_function_and_operator() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute(
+        "CREATE TABLE nd_temporal_src (\
+             id INT PRIMARY KEY, event_date DATE, ts TIMESTAMP, tsz TIMESTAMPTZ)",
+    )
+    .await;
+    db.execute(
+        "INSERT INTO nd_temporal_src VALUES \
+         (1, DATE '2025-01-01', TIMESTAMP '2025-01-01 10:15', TIMESTAMPTZ '2025-01-01 10:15+00'), \
+         (2, DATE '2025-01-02', TIMESTAMP '2025-01-01 10:45', TIMESTAMPTZ '2025-01-01 10:45+00')",
+    )
+    .await;
+
+    let bucket_query = "SELECT EXTRACT(YEAR FROM event_date) AS event_year, \
+                date_trunc('hour', tsz, 'UTC') AS bucket, COUNT(*) AS n \
+         FROM nd_temporal_src \
+         GROUP BY EXTRACT(YEAR FROM event_date), date_trunc('hour', tsz, 'UTC')";
+    db.create_st("nd_temporal_bucket_st", bucket_query, "1m", "DIFFERENTIAL")
+        .await;
+    db.assert_st_matches_query("public.nd_temporal_bucket_st", bucket_query)
+        .await;
+
+    db.execute(
+        "INSERT INTO nd_temporal_src VALUES \
+         (3, DATE '2026-02-01', TIMESTAMP '2026-02-01 12:30', TIMESTAMPTZ '2026-02-01 12:30+00')",
+    )
+    .await;
+    db.refresh_st("nd_temporal_bucket_st").await;
+    db.assert_st_matches_query("public.nd_temporal_bucket_st", bucket_query)
+        .await;
+
+    db.execute("UPDATE nd_temporal_src SET tsz = tsz + INTERVAL '2 hours' WHERE id = 2")
+        .await;
+    db.refresh_st("nd_temporal_bucket_st").await;
+    db.assert_st_matches_query("public.nd_temporal_bucket_st", bucket_query)
+        .await;
+
+    db.execute("DELETE FROM nd_temporal_src WHERE id = 1").await;
+    db.refresh_st("nd_temporal_bucket_st").await;
+    db.assert_st_matches_query("public.nd_temporal_bucket_st", bucket_query)
+        .await;
+
+    let immutable_operator_query =
+        "SELECT id, ts + INTERVAL '1 day' AS shifted FROM nd_temporal_src";
+    db.create_st(
+        "nd_temporal_operator_st",
+        immutable_operator_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+
+    for query in [
+        "SELECT id, date_trunc('hour', tsz) FROM nd_temporal_src",
+        "SELECT id, tsz + INTERVAL '1 day' FROM nd_temporal_src",
+    ] {
+        let result = db
+            .try_execute(&format!(
+                "SELECT pgtrickle.create_stream_table(\
+                 'nd_temporal_rejected_st', $$ {query} $$, '1m', 'DIFFERENTIAL')"
+            ))
+            .await;
+        assert!(
+            result.is_err(),
+            "the resolved STABLE temporal expression must be rejected: {query}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_nested_volatile_where_expression_rejected_in_differential_mode() {
     let db = E2eDb::new().await.with_extension().await;
 

--- a/tests/e2e_error_tests.rs
+++ b/tests/e2e_error_tests.rs
@@ -887,6 +887,74 @@ async fn test_function_volatility_resolves_exact_overload_and_schema() {
 }
 
 #[tokio::test]
+async fn test_function_volatility_checks_omitted_default_arguments() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE nd_default_src (id INT PRIMARY KEY)")
+        .await;
+    db.execute("INSERT INTO nd_default_src VALUES (1), (2)")
+        .await;
+    db.execute(
+        "CREATE FUNCTION nd_default_immutable(value int DEFAULT 7) RETURNS int \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION nd_default_stable(\
+             value timestamptz DEFAULT now()) RETURNS timestamptz \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION nd_default_nested(\
+             value timestamptz DEFAULT nd_default_stable()) RETURNS timestamptz \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+
+    let immutable_default_query = "SELECT id, nd_default_immutable() AS value FROM nd_default_src";
+    db.create_st(
+        "nd_default_immutable_st",
+        immutable_default_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.assert_st_matches_query("public.nd_default_immutable_st", immutable_default_query)
+        .await;
+
+    let supplied_argument_query = "SELECT id, nd_default_stable(\
+        TIMESTAMPTZ '2025-01-01 00:00+00') AS value FROM nd_default_src";
+    db.create_st(
+        "nd_default_supplied_st",
+        supplied_argument_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.assert_st_matches_query("public.nd_default_supplied_st", supplied_argument_query)
+        .await;
+
+    for query in [
+        "SELECT id, nd_default_stable() FROM nd_default_src",
+        "SELECT id, nd_default_nested() FROM nd_default_src",
+    ] {
+        let error = db
+            .try_execute(&format!(
+                "SELECT pgtrickle.create_stream_table(\
+                 'nd_default_rejected_st', $$ {query} $$, '1m', 'DIFFERENTIAL')"
+            ))
+            .await
+            .expect_err("a STABLE omitted default must be rejected");
+        let error = error.to_string();
+        assert!(
+            error.contains("stable expressions have refresh-dependent volatility"),
+            "unexpected omitted-default rejection: {error}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_temporal_volatility_uses_resolved_function_and_operator() {
     let db = E2eDb::new().await.with_extension().await;
 

--- a/tests/e2e_error_tests.rs
+++ b/tests/e2e_error_tests.rs
@@ -977,6 +977,42 @@ async fn test_function_volatility_checks_omitted_default_arguments() {
 }
 
 #[tokio::test]
+async fn test_function_volatility_checks_omitted_window_defaults() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE nd_window_default_src (id INT PRIMARY KEY, tenant INT, value TEXT)")
+        .await;
+    db.execute("INSERT INTO nd_window_default_src VALUES (1, 1, 'one'), (2, 1, 'two')")
+        .await;
+    db.execute(
+        "CREATE FUNCTION nth_value_dynamic(\
+             value anyelement,\
+             n integer DEFAULT (1 + EXTRACT(DAY FROM CURRENT_DATE)::integer % 2)) \
+         RETURNS anyelement LANGUAGE internal WINDOW IMMUTABLE STRICT \
+         AS 'window_nth_value'",
+    )
+    .await;
+
+    let error = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table(\
+             'nd_window_default_st',\
+             $$ SELECT id, tenant, nth_value_dynamic(value) OVER (\
+                    PARTITION BY tenant ORDER BY id \
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) \
+                FROM nd_window_default_src $$,\
+             '1m', 'DIFFERENTIAL')",
+        )
+        .await
+        .expect_err("a STABLE omitted window-function default must be rejected")
+        .to_string();
+    assert!(
+        error.contains("stable expressions have refresh-dependent volatility"),
+        "unexpected omitted window-default rejection: {error}"
+    );
+}
+
+#[tokio::test]
 async fn test_io_cast_checks_destination_input_volatility() {
     let db = E2eDb::new().await.with_extension().await;
 

--- a/tests/e2e_error_tests.rs
+++ b/tests/e2e_error_tests.rs
@@ -911,6 +911,12 @@ async fn test_function_volatility_checks_omitted_default_arguments() {
          LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
     )
     .await;
+    db.execute(
+        "CREATE FUNCTION nd_default_probe(\
+             a int, b timestamptz DEFAULT now(), c int DEFAULT 0) RETURNS int \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
 
     let immutable_default_query = "SELECT id, nd_default_immutable() AS value FROM nd_default_src";
     db.create_st(
@@ -935,9 +941,25 @@ async fn test_function_volatility_checks_omitted_default_arguments() {
     db.assert_st_matches_query("public.nd_default_supplied_st", supplied_argument_query)
         .await;
 
+    let supplied_sibling_default_query = "SELECT id, nd_default_probe(\
+        id, b => TIMESTAMPTZ '2025-01-01 00:00+00') AS value FROM nd_default_src";
+    db.create_st(
+        "nd_default_sibling_st",
+        supplied_sibling_default_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.assert_st_matches_query(
+        "public.nd_default_sibling_st",
+        supplied_sibling_default_query,
+    )
+    .await;
+
     for query in [
         "SELECT id, nd_default_stable() FROM nd_default_src",
         "SELECT id, nd_default_nested() FROM nd_default_src",
+        "SELECT id, nd_default_probe(id, c => 1) FROM nd_default_src",
     ] {
         let error = db
             .try_execute(&format!(
@@ -952,6 +974,118 @@ async fn test_function_volatility_checks_omitted_default_arguments() {
             "unexpected omitted-default rejection: {error}"
         );
     }
+}
+
+#[tokio::test]
+async fn test_io_cast_checks_destination_input_volatility() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE nd_io_cast_src (id INT PRIMARY KEY, raw TEXT)")
+        .await;
+    db.execute("INSERT INTO nd_io_cast_src VALUES (1, '2025-01-01 12:00:00')")
+        .await;
+
+    let error = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table(\
+             'nd_io_cast_st', \
+             $$ SELECT id, raw::timestamptz FROM nd_io_cast_src $$, \
+             '1m', 'DIFFERENTIAL')",
+        )
+        .await
+        .expect_err("timestamptz_in is STABLE and must reject differential mode")
+        .to_string();
+    assert!(
+        error.contains("stable expressions have refresh-dependent volatility"),
+        "unexpected I/O-cast rejection: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_json_constructor_checks_hidden_conversion_volatility() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE nd_json_src (id INT PRIMARY KEY, tsz TIMESTAMPTZ)")
+        .await;
+    db.execute("INSERT INTO nd_json_src VALUES (1, TIMESTAMPTZ '2025-01-01 12:00+00')")
+        .await;
+
+    let error = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table(\
+             'nd_json_st', \
+             $$ SELECT id, JSON_OBJECT('ts': tsz) AS payload FROM nd_json_src $$, \
+             '1m', 'DIFFERENTIAL')",
+        )
+        .await
+        .expect_err("timestamptz-to-JSON conversion must reject differential mode")
+        .to_string();
+    assert!(
+        error.contains("stable expressions have refresh-dependent volatility"),
+        "unexpected JSON-constructor rejection: {error}"
+    );
+
+    db.execute(
+        r#"CREATE FUNCTION nd_json_path_default(
+             value jsonb DEFAULT JSON_QUERY(
+                 JSONB '"2025-01-01 12:00:00"', '$.timestamp()'))
+           RETURNS jsonb LANGUAGE sql IMMUTABLE AS 'SELECT $1'"#,
+    )
+    .await;
+    let error = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table(\
+             'nd_json_path_st', \
+             $$ SELECT id, nd_json_path_default() FROM nd_json_src $$, \
+             '1m', 'DIFFERENTIAL')",
+        )
+        .await
+        .expect_err("mutable JSON-path datetime conversion must reject differential mode")
+        .to_string();
+    assert!(
+        error.contains("stable expressions have refresh-dependent volatility"),
+        "unexpected JSON-path rejection: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_row_comparison_checks_resolved_operator_volatility() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TYPE nd_row_rank AS ENUM ('low', 'high')")
+        .await;
+    db.execute(
+        "CREATE FUNCTION nd_row_rank_lt(nd_row_rank, nd_row_rank) RETURNS boolean \
+         LANGUAGE sql VOLATILE AS 'SELECT $1::text < $2::text'",
+    )
+    .await;
+    db.execute(
+        "CREATE OPERATOR < (\
+             LEFTARG = nd_row_rank, RIGHTARG = nd_row_rank, FUNCTION = nd_row_rank_lt)",
+    )
+    .await;
+    db.execute("CREATE OPERATOR FAMILY nd_row_rank_ops USING btree")
+        .await;
+    db.execute(
+        "ALTER OPERATOR FAMILY nd_row_rank_ops USING btree \
+         ADD OPERATOR 1 < (nd_row_rank, nd_row_rank)",
+    )
+    .await;
+    db.execute(
+        "CREATE TABLE nd_row_cmp_src (\
+             id INT PRIMARY KEY, left_rank nd_row_rank, right_rank nd_row_rank)",
+    )
+    .await;
+
+    let volatility: String = db
+        .query_scalar(
+            "SELECT result FROM pgtrickle.validate_query(\
+               'SELECT id, (left_rank, id) < (right_rank, id + 1) AS cmp \
+                FROM nd_row_cmp_src') \
+             WHERE check_name = 'volatility'",
+        )
+        .await;
+    assert_eq!(volatility, "volatile");
 }
 
 #[tokio::test]

--- a/tests/e2e_topk_tests.rs
+++ b/tests/e2e_topk_tests.rs
@@ -57,6 +57,52 @@ async fn test_topk_create_differential_mode() {
     assert_eq!(db.count("public.topk_diff").await, 2);
 }
 
+#[tokio::test]
+async fn test_topk_volatility_uses_resolved_overload() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute(
+        "CREATE FUNCTION topk_probe(int) RETURNS int \
+         LANGUAGE sql IMMUTABLE AS 'SELECT $1'",
+    )
+    .await;
+    db.execute(
+        "CREATE FUNCTION topk_probe(text) RETURNS int \
+         LANGUAGE sql VOLATILE AS 'SELECT length($1)'",
+    )
+    .await;
+    db.execute("CREATE TABLE topk_vol_src (id INT PRIMARY KEY, score INT, label TEXT)")
+        .await;
+    db.execute("INSERT INTO topk_vol_src VALUES (1, 10, 'a'), (2, 30, 'bbb'), (3, 20, 'cc')")
+        .await;
+
+    let immutable_query =
+        "SELECT id, score FROM topk_vol_src ORDER BY topk_probe(score) DESC LIMIT 2";
+    db.create_st(
+        "topk_vol_immutable_st",
+        immutable_query,
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.assert_st_matches_query("public.topk_vol_immutable_st", immutable_query)
+        .await;
+
+    let result = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table(\
+             'topk_vol_rejected_st', \
+             $$ SELECT id, score FROM topk_vol_src \
+                ORDER BY topk_probe(label) DESC LIMIT 2 $$, \
+             '1m', 'DIFFERENTIAL')",
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "TopK must reject the resolved VOLATILE overload"
+    );
+}
+
 // ── Catalog ────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -67,11 +67,10 @@ fn rf_count() -> usize {
 // signalling a DVM regression where a previously-passing query no longer
 // creates or runs correctly.
 //
-// DIFFERENTIAL: all 22 queries previously passed at SF<10. The v0.83+ fail-closed
-//               volatility admission currently makes q07/q08/q09 FULL-only, and
-//               queries with correlated scalar subqueries in WHERE clauses become
-//               quadratic in the DVM delta SQL at SF≥10. The latter are in
-//               LARGE_SCALE_DIFFERENTIAL_SKIP below and are skipped automatically.
+// DIFFERENTIAL: all 22 queries previously passed at SF<10. Queries with correlated
+//               scalar subqueries in WHERE clauses become quadratic in the DVM
+//               delta SQL at SF≥10. Those queries are listed in
+//               LARGE_SCALE_DIFFERENTIAL_SKIP and skipped automatically.
 // IMMEDIATE:    a subset cannot be created (IVM restriction). Populate by
 //               running with the guard disabled, then hardening the set.
 //
@@ -83,12 +82,6 @@ fn rf_count() -> usize {
 const DIFFERENTIAL_SKIP_ALLOWLIST: &[&str] = &[
     // DI-11 deep-join planner hints (disable nestloop, raise work_mem,
     // bump join_collapse_limit, temp_file_limit=-1) resolved Q05/Q09.
-    // v0.83+ fail-closed volatility admission: q07/q08/q09 use EXTRACT(YEAR
-    // FROM date), which resolves to immutable date_part(text,date), but the
-    // name-only overload check also sees the stable timestamptz overload.
-    // They remain intentionally FULL-only until overload-aware function
-    // volatility resolution is implemented.
-    "q07", "q08", "q09",
     // v0.77.0: q12 uses CASE aggregate + IN-list predicate and is currently
     // forced to FULL refresh by CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK.
     "q12",
@@ -121,9 +114,6 @@ const LARGE_SCALE_DIFFERENTIAL_SKIP: &[&str] = &[];
 /// this list is skipped, catching silent regressions as the DVM evolves.
 #[rustfmt::skip]
 const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[
-    // v0.85 fail-closed volatility admission rejects the stable expressions
-    // in q07/q08/q09 for IMMEDIATE mode. Use FULL or AUTO for these queries.
-    "q07", "q08", "q09",
 ];
 
 // ── P3.15: TPCH_STRICT mode ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- classify query volatility from PostgreSQL's analyzed query tree, so function, operator, cast, schema, and argument overloads are exact
- use the same classification for incremental admission, TopK, mode changes, and diagnostics
- restore TPC-H q07/q08/q09 incremental coverage and document immutable time-bucketing forms

Fixes #953.

## Testing

- `just lint`
- `just test-unit` (2,402 passed)
- `just test-integration` (161 passed)
- `bash scripts/run_light_e2e_tests.sh --test e2e_error_tests --test e2e_topk_tests --test e2e_diagnostics_tests` (115 passed)
- `TPCH_CYCLES=1 cargo test --test e2e_tpch_tests test_tpch_q0 -- --ignored --test-threads=1 --nocapture` (4 focused q07/q08/q09 tests passed)
- the full differential and immediate TPC-H loops passed q07/q08/q09; both later hit the existing q15 generated-SQL failure also present in the latest nightly `main` run
