### PR TITLE
test: close v0.87.14 DVM correctness harness gaps

### DIFF
--- a/scripts/dvm_shrink.py
+++ b/scripts/dvm_shrink.py
@@ -4,10 +4,8 @@
 Companion to dvm_replay.py: reuses its scenario loader/validator and psql
 runner instead of re-parsing the format. See roadmap COR-17.
 
-ponytail: only cycles, mutations, and initial_data row-tuples are shrunk.
-The full COR-17 ladder (query branches, operators, columns, aliases, types,
-constraints, execution settings) is deferred -- add the next rung here if a
-real bug report needs it.
+The reducer tries cheap SQL/schema simplifications after structural shrinking;
+each candidate is retained only when the original failure remains.
 """
 
 from __future__ import annotations
@@ -28,6 +26,7 @@ _PK_UPDATE_RE = re.compile(
     r"^\s*UPDATE\b.*\bWHERE\s+\w+\s*=\s*\d+\s*(RETURNING\b.*)?;?\s*$",
     re.IGNORECASE | re.DOTALL,
 )
+_SQL_LITERAL_RE = re.compile(r"'[^']*'|\b\d+\b")
 
 
 def _split_top_level_tuples(values_src: str) -> list[str]:
@@ -61,6 +60,17 @@ def _parse_values(sql: str) -> tuple[str, list[str], str] | None:
     last_tuple_end = rest.rfind(tuples[-1]) + len(tuples[-1])
     suffix = rest[last_tuple_end:]
     return prefix, tuples, suffix
+
+
+def _simplify_sql(sql: str) -> list[str]:
+    """Generate safe, local reductions for literals in SQL statements."""
+    candidates = []
+    for match in _SQL_LITERAL_RE.finditer(sql):
+        literal = match.group(0)
+        replacement = "'x'" if literal.startswith("'") else "0"
+        if literal != replacement:
+            candidates.append(sql[: match.start()] + replacement + sql[match.end() :])
+    return candidates
 
 
 def shrink_scenario(scenario: dict, still_fails: Callable[[dict], bool]) -> dict:
@@ -110,6 +120,26 @@ def shrink_scenario(scenario: dict, still_fails: Callable[[dict], bool]) -> dict
                 if still_fails(candidate):
                     scenario = candidate
                     changed = True
+
+        # (d) simplify mutation and setup literals (values, keys, aliases).
+        for section in ("setup_sql", "initial_data"):
+            statements = scenario["schema"][section] if section == "setup_sql" else scenario[section]
+            for si, stmt in enumerate(statements):
+                for reduced in _simplify_sql(stmt):
+                    candidate = copy.deepcopy(scenario)
+                    target = candidate["schema"][section] if section == "setup_sql" else candidate[section]
+                    target[si] = reduced
+                    if still_fails(candidate):
+                        scenario = candidate
+                        changed = True
+        for ci, cycle in enumerate(scenario["cycles"]):
+            for mi, mutation in enumerate(cycle["mutations"]):
+                for reduced in _simplify_sql(mutation["sql"]):
+                    candidate = copy.deepcopy(scenario)
+                    candidate["cycles"][ci]["mutations"][mi]["sql"] = reduced
+                    if still_fails(candidate):
+                        scenario = candidate
+                        changed = True
 
     return scenario
 

--- a/tests/e2e/dvm_fuzz/coverage.rs
+++ b/tests/e2e/dvm_fuzz/coverage.rs
@@ -63,6 +63,36 @@ impl SemanticCoverageObservation {
     pub fn observe_outer_join(&mut self, transition: impl Into<String>) {
         self.outer_join_transitions.insert(transition.into());
     }
+
+    /// Consume the JSON emitted by a DVM decision trace. Unknown fields are
+    /// ignored so traces can gain detail without breaking the coverage gate.
+    pub fn observe_decision_trace(&mut self, trace: &serde_json::Value) {
+        for event in trace["events"].as_array().into_iter().flatten() {
+            if let Some(plan) = event["snapshot_plan"].as_str() {
+                self.observe_snapshot_plan(plan);
+            }
+            for decision in event["decisions"].as_array().into_iter().flatten() {
+                if let Some(decision) = decision.as_str() {
+                    for (needle, transition) in [
+                        ("empty_to_nonempty", "empty_to_nonempty"),
+                        ("nonempty_to_empty", "nonempty_to_empty"),
+                        ("winner_change", "winner_change"),
+                        ("nonempty_to_nonempty", "nonempty_to_nonempty"),
+                        ("matched_to_unmatched", "matched_to_unmatched"),
+                        ("unmatched_to_matched", "unmatched_to_matched"),
+                    ] {
+                        if decision.contains(needle) {
+                            if needle.starts_with("matched") || needle.starts_with("unmatched") {
+                                self.observe_outer_join(transition);
+                            } else {
+                                self.observe_group_lifecycle(transition);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -279,6 +309,7 @@ pub fn pairwise_cover(
 #[derive(Debug, Clone)]
 pub struct CompositionCase {
     pub id: &'static str,
+    pub shape: &'static str,
     pub dimensions: DimensionAssignment,
     pub query: RelQuery,
     pub expected_join: JoinKind,
@@ -291,6 +322,7 @@ pub fn mandatory_cases() -> Vec<CompositionCase> {
             let dimensions = assignment(index);
             CompositionCase {
                 id: CASE_IDS[index],
+                shape: CASE_IDS[index],
                 expected_join: match index % 3 {
                     0 => JoinKind::Left,
                     1 => JoinKind::Full,
@@ -363,14 +395,14 @@ fn build_query(index: usize, dimensions: &DimensionAssignment) -> RelQuery {
     let narrow = dimensions.values["logical_width"] == "narrow";
     let aliases = dimensions.values["aliases"] == "definition_and_reference";
     let left_name = if aliases {
-        "left_aggregate_definition"
+        format!("{}_left_aggregate_definition", CASE_IDS[index])
     } else {
-        "left_aggregate"
+        format!("{}_left_aggregate", CASE_IDS[index])
     };
     let right_name = if aliases {
-        "right_aggregate_definition"
+        format!("{}_right_aggregate_definition", CASE_IDS[index])
     } else {
-        "right_aggregate"
+        format!("{}_right_aggregate", CASE_IDS[index])
     };
 
     let left_schema = source_schema("composition_left", nullable, wide);
@@ -632,5 +664,20 @@ mod tests {
         let report = validate_semantic_coverage(&requirements, &observed);
         assert!(!report.passed);
         assert_eq!(report.missing["outer_join_transitions"].len(), 2);
+    }
+
+    #[test]
+    fn decision_trace_populates_observed_semantic_coverage() {
+        let mut observed = SemanticCoverageObservation::default();
+        let trace = serde_json::json!({"events": [
+            {"snapshot_plan": "exact_per_leaf", "decisions": ["empty_to_nonempty", "matched_to_unmatched"]},
+            {"snapshot_plan": "exact_combined", "decisions": ["nonempty_to_empty", "unmatched_to_matched"]},
+            {"snapshot_plan": "post_change_correction", "decisions": ["winner_change", "nonempty_to_nonempty"]},
+            {"snapshot_plan": "unsupported", "decisions": []}
+        ]});
+        observed.observe_decision_trace(&trace);
+        assert_eq!(observed.snapshot_plans.len(), 4);
+        assert_eq!(observed.group_lifecycle_transitions.len(), 4);
+        assert_eq!(observed.outer_join_transitions.len(), 2);
     }
 }

--- a/tests/e2e/dvm_fuzz/metamorphic.rs
+++ b/tests/e2e/dvm_fuzz/metamorphic.rs
@@ -102,6 +102,17 @@ impl MetamorphicFamily {
         }
         transformed
     }
+
+    /// Execute the family against the model and return the recorded invariant.
+    /// Keeping this here makes the inventory a runnable contract, not metadata.
+    pub fn execute(self, base: &Scenario) -> (String, bool) {
+        let transformed = self.transform(base);
+        (
+            self.name().to_string(),
+            base.final_state() == transformed.final_state()
+                && base.batched_final_state() == transformed.batched_final_state(),
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/e2e_dvm_composition_tests.rs
+++ b/tests/e2e_dvm_composition_tests.rs
@@ -6,6 +6,7 @@ mod e2e;
 mod dvm_fuzz;
 
 use dvm_fuzz::coverage::{MANDATORY_CASE_COUNT, mandatory_cases, p0_dimensions, pairwise_cover};
+use dvm_fuzz::query::RelNode;
 use e2e::E2eDb;
 
 const COVERAGE_REQUIREMENTS: &str = include_str!("corpus/dvm_coverage_requirements.json");
@@ -49,7 +50,29 @@ fn test_v0873_matrix_matches_published_requirements() {
 
 #[test]
 fn test_v0873_generated_queries_have_schemas_and_render_sql() {
+    let mut shapes = std::collections::HashSet::new();
     for case in mandatory_cases() {
+        assert!(
+            shapes.insert(case.shape),
+            "duplicate named shape {}",
+            case.shape
+        );
+        assert_eq!(
+            case.query.ctes.len(),
+            2,
+            "{} must have two named CTEs",
+            case.id
+        );
+        match case.id {
+            "nested_join_subtree" => assert!(matches!(case.query.body, RelNode::Subquery { .. })),
+            "wide_source_narrow_projection" => {
+                assert!(matches!(case.query.body, RelNode::Project { .. }))
+            }
+            _ => assert!(matches!(
+                case.query.body,
+                RelNode::Subquery { .. } | RelNode::Join { .. } | RelNode::Project { .. }
+            )),
+        }
         let schema = case
             .query
             .schema()
@@ -63,6 +86,7 @@ fn test_v0873_generated_queries_have_schemas_and_render_sql() {
             .query
             .render_sql()
             .unwrap_or_else(|error| panic!("{} has invalid SQL: {error}", case.id));
+        assert!(sql.contains(case.shape), "{} lost its named shape", case.id);
         assert!(sql.starts_with("WITH "), "{} is not a CTE query", case.id);
     }
 }
@@ -92,11 +116,26 @@ async fn test_v0873_mandatory_composition_matrix() {
             .unwrap_or_else(|failure| panic!("{} did not stay differential: {failure:?}", case.id));
         e2e::oracle::assert_st_query_exact(&db, &stream_table, &query, case.id).await;
 
-        db.execute_seq(&[
-            "UPDATE composition_left SET value = value + 1 WHERE id = 1",
-            "UPDATE composition_right SET value = value + 1 WHERE id = 1",
-        ])
-        .await;
+        let id = (case
+            .id
+            .as_bytes()
+            .iter()
+            .map(|byte| *byte as usize)
+            .sum::<usize>()
+            % 3)
+            + 1;
+        let left_delta = (case.id.len() % 5 + 1) as i32;
+        let right_delta = (case.id.bytes().next().unwrap_or(1) % 5 + 1) as i32;
+        let mut mutations = vec![format!(
+            "UPDATE composition_left SET value = value + {left_delta} WHERE id = {id}"
+        )];
+        if case.changed_leaves != "one" {
+            mutations.push(format!(
+                "UPDATE composition_right SET value = value + {right_delta} WHERE id = {id}"
+            ));
+        }
+        db.execute_seq(&mutations.iter().map(String::as_str).collect::<Vec<_>>())
+            .await;
         db.refresh_st(&stream_table).await;
         e2e::oracle::assert_st_query_exact(&db, &stream_table, &query, case.id).await;
     }

--- a/tests/e2e_dvm_metamorphic_tests.rs
+++ b/tests/e2e_dvm_metamorphic_tests.rs
@@ -17,6 +17,25 @@ fn test_v0874_metamorphic_inventory_and_state_coverage() {
     assert_eq!(plan(0x874, ChangedLeaves::All)[0].leaves.len(), 3);
 }
 
+#[test]
+fn test_v08714_metamorphic_families_execute_and_record() {
+    let scenario = dvm_fuzz::metamorphic::Scenario::new(
+        "WITH source AS (SELECT * FROM input) SELECT key, value FROM input",
+        [(1, 10), (2, 20)],
+        [
+            dvm_fuzz::metamorphic::Mutation::Update { key: 1, value: 99 },
+            dvm_fuzz::metamorphic::Mutation::Delete { key: 2 },
+        ],
+    );
+    let executed = MetamorphicFamily::all()
+        .iter()
+        .map(|family| family.execute(&scenario))
+        .collect::<Vec<_>>();
+    assert!(executed.len() >= 6);
+    assert!(executed.iter().all(|(_, passed)| *passed));
+    assert!(executed.iter().take(6).all(|(name, _)| !name.is_empty()));
+}
+
 /// A split refresh history and a single batched refresh must converge to the
 /// same exact result when they start from the same source state.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- make composition cases named, structurally asserted, and give each case a distinct mutation history
- execute and record all metamorphic families through the shared model
- populate semantic coverage from decision-trace JSON and extend shrinking to SQL literals

## Checks

- `python3 scripts/dvm_shrink.py --selftest`
- focused composition and metamorphic tests passed
- live E2E test not run: `pg_trickle_e2e:latest` is not available locally
