### PR TITLE
Revise the v1.0 roadmap critical path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,7 +391,7 @@ and durability foundations that must be proven before v1.0.
 | [v0.79.0](roadmap/v0.79.0.md) | Code Quality, API Ergonomics & Security: remove unused-import suppressions in src/refresh/codegen.rs and src/refresh/merge/mod.rs module-by-module (Q-1), convert internal create/alter API implementations to typed parameter structs eliminating too-many-arguments in business logic (Q-2), replace global #![allow(dead_code)] with narrower per-module allowances on pgrx/export boundaries (Q-3), remove or #[deprecated] consume_slot_changes() replacing with clearly named status function (Q-4), add SQL convenience helpers create_stream_table_fast_append_only/set_stream_table_refresh_policy/set_stream_table_storage_policy (A-1), add first-class pause_stream_table/resume_stream_table wrappers (A-2), add/strengthen semgrep CI rules for dynamic SQL distinguishing identifier/literal/OID boundaries (S-1), emit runtime WARNING when source has RLS enabled at create_stream_table time (S-2), CI test inspecting SECURITY DEFINER trigger functions for SET search_path (S-3), cleanup chaos test forcing three consecutive DELETE failures with alert and status verification (D-3), dbt adapter compatibility matrix with alter/drop/rebuild flow and version matrix tests (T-5) | ✅ Released | Large | [Full details](roadmap/v0.79.0.md-full.md) |
 | [v0.80.0](roadmap/v0.80.0.md) | Operational Excellence, Documentation Completeness & Final v1.0 Gate: add DVM fallback/performance reason codes to refresh history and health output — CORRELATED_SUBQUERY_DELTA_QUADRATIC, CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK, REGEX_COMPLEXITY_CLASSIFIER_UNCERTAIN (O-1), add health_check() threshold alert when invalidation ring overflow count increases in recent time window (O-2), add cleanup backlog trend metrics integrated into pgt_metrics_summary (O-3), docs lint comparing #[pg_extern] exports with SQL_REFERENCE.md entries (DOC-1), create docs/DVM_SUPPORT_MATRIX.md with every query pattern, fallback behavior, IMMEDIATE restrictions, and known-unsupported forms including q12/q20 entries (DOC-2), operational rollback runbook (backup requirements, snapshot recommendation, restore path, why downgrades are unsafe) (U-1), document upgrade E2E cutoff policy prominently in CHANGELOG and release notes (U-2), CI gate documentation in CONTRIBUTING.md describing which workflows gate PRs (B-1), review-by dates on cargo-deny advisory suppressions and require cargo-deny in PR gates (B-2), fuzz test for DVM snapshot fingerprint cache stability under OpTree refactoring (P-5), document internal event trigger functions in ARCHITECTURE comments (A-3) | ✅ Released | Large | [Full details](roadmap/v0.80.0.md-full.md) |
 
-### Product Arc & Hardening Gate (v0.81.0 – v0.93.0)
+### Product Arc & Hardening Gate (v0.81.0 – v0.95.x)
 
 The core thing users are buying is not "distributed incremental computation".
 It is:
@@ -457,6 +457,30 @@ snapshot, publication, and pg_tide outbox gates. The
 [reimplementation plan](plans/pg_trickle_lifecycle_security_reimplementation_plan.md)
 defines the shared invariants and test matrix.
 
+#### Critical path to v1.0
+
+Release scope follows three priority tiers.
+
+| Tier | Commitment |
+|------|------------|
+| Mandatory | DVM correctness, lifecycle security, row identity, schema evolution, backup and restore, clone isolation, upgrades, CDC recovery, resource protection, diagnostics, monitoring, packages, soak tests, compatibility tests, and regression gates must finish before v1.0. |
+| Scope-flexible | Vectorized aggregates, delta-plan optimization, freshness-driven scheduling, and adaptive workers ship only where their release gates pass without delaying mandatory work. |
+| Optional | Broad incremental-window coverage, complex autonomous policy selection, and unvalidated operator-reordering rules may move past v1.0. Their correctness-preserving fallback remains supported and visible. |
+
+When schedule pressure appears, reduce incremental-window breadth first. Keep
+planner classes in shadow mode next, then reduce automatic controller decisions
+and defer optional performance work. Do not cut lifecycle tests, resource
+protections, diagnostics, soak duration, compatibility gates, or exact-oracle
+coverage.
+
+Every new execution path must pass the exact FULL oracle across INSERT, UPDATE,
+and DELETE histories. Persistent paths also cover restart, replay, relevant
+schema changes, upgrades, and interruption during the most dangerous state
+transition. Performance gates report throughput, median, p95, and p99 where useful,
+memory, WAL, CPU, and foreground write impact. Each feature defines its maximum
+acceptable worst-case regression. Every fallback has a stable reason code,
+diagnostics, and a support-matrix entry.
+
 | Version | Theme | User promise | Status | Scope | Full details |
 |---------|-------|--------------|--------|-------|--------------|
 | [v0.81.0](roadmap/v0.81.0.md) | Observability, Self-Tuning & Quick Wins: commit-to-visible latency metric using pg_xact_commit_timestamp (QW-1), configuration advisor function pgtrickle.tune_recommendations() (QW-2), preview/dry-run mode pgtrickle.preview_stream_table() (QW-3), OpenTelemetry trace spans on scheduler_tick/refresh_cycle/delta_execute/merge_apply with OTLP export (QW-4), bounded LRU eviction on thread-local L0/L1 template caches (QW-5), DeltaOperator trait for extensible operator dispatch (QW-6), split config.rs into config/scheduler.rs + config/cdc.rs + config/dvm.rs + config/monitoring.rs (QW-7), self-healing circuit breaker with auto-remediation for OOM/lock-timeout/sustained-lag (QW-8), chunked MERGE for large deltas with configurable merge_batch_size GUC (QW-9), stream table presets ('real-time'/'batch'/'cost-optimized') (QW-10) | — | ✅ Released | Large | [Full details](roadmap/v0.81.0.md) |
@@ -483,26 +507,26 @@ defines the shared invariants and test matrix.
 | [v0.87.15](roadmap/v0.87.15.md) | Versioned Row Identity V2 Contracts: normative canonical BYTEA wire format, identity-domain and type registry, typed datum encoder, validation, resource bounds, and independent golden vectors | "Every row identity is deterministic, exact, and portable across supported PostgreSQL environments." | ✅ Implemented | 7 pw | [Full details](roadmap/v0.87.15.md) |
 | [v0.87.16](roadmap/v0.87.16.md) | Versioned Row Identity V2 Engine Integration: BYTEA storage, direct bounded and expression-probe indexes, trigger/WAL CDC, DVM producers, exact matching, version guards, and replication compatibility | "The same exact row identity drives storage, capture, refresh, and matching." | ✅ Implemented | 12 pw | [Full details](roadmap/v0.87.16.md) |
 | [v0.87.17](roadmap/v0.87.17.md) | Versioned Row Identity V2 Hardening and Recreation: cross-path correctness, performance gates, non-destructive preflight, stream-table recreation, external resnapshot guidance, and privacy controls | "I can adopt exact row identities with a clear, repeatable rebuild and no silent compatibility trap." | ✅ Implemented | 9 pw | [Full details](roadmap/v0.87.17.md) |
-| [v0.88.0](roadmap/v0.88.0.md) | Vectorized Aggregates & Delta Planning: DiffContext decomposition into CdcContext/CacheContext/OptimizationContext first (ENG-1), a vectorized columnar path for pure-aggregate stream tables gated on an ADR that revisits the v0.76.0 Arrow dependency removal (MT-8), and cost-based operator scheduling reordering operators within delta queries based on estimated cardinality (LT-9) | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.88.0.md) |
-| [v0.89.0](roadmap/v0.89.0.md) | Incremental Window Functions: a bounded, crash-safe auxiliary state model (LT-7a), rank-family algorithms (LT-7b), offset and boundary algorithms (LT-7c), aggregate-over-window algorithms (LT-7d), and documented fallback with reason codes and support-matrix entries for uncovered frames (LT-7e) | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.89.0.md) |
-| [v0.90.0](roadmap/v0.90.0.md) | Freshness Controller & Self-Tuning: target_freshness becomes authoritative with every scheduler knob demoted to an optional override (SLA-1), a closed-loop controller choosing refresh timing, DIFFERENTIAL vs FULL, batch size, concurrency, priority and deferral from measured cost (SLA-2), adaptive worker pool sizing driven by CPU utilization, queue depth and SLA risk (SLA-3), pgtrickle.freshness() plus sla_status in pg_stat_pgtrickle, health_check() and Prometheus/OTel (SLA-4), continuous infeasible-SLA detection (SLA-5), and an audit that retires the knobs users should not need (SLA-6) | "Tell it how fresh I need data; it figures out the rest." | Planned | Large | [Full details](roadmap/v0.90.0.md) |
-| [v0.91.0](roadmap/v0.91.0.md) | Lifecycle & Schema Evolution: safe defining-query replacement with compatible/rebuildable/rejected classification and shadow-table swap (LC-1), automatic handling of additive source DDL with loud, actionable suspension for destructive changes (LC-2), tested pg_dump/pg_restore, PITR, pg_basebackup and replica promotion behavior (LC-3), database cloning that never steals the original's replication slots (LC-4), pgtrickle.preflight_upgrade() plus quiesce/resume (LC-5), pg_upgrade and extension-upgrade coverage in CI with active workloads (LC-6), and automatic CDC repair as the default path (LC-7) | "Production changes don't break my stream tables." | Planned | Very Large | [Full details](roadmap/v0.91.0.md) |
-| [v0.92.0](roadmap/v0.92.0.md) | Defaults, Bounds & Diagnosis: zero-config profile detection for laptop/managed/dedicated instances (PP-1), an enforced ceiling and alert for every resource including predictable disk usage (PP-2), pg_stat_progress-style progress reporting for long operations (PP-3), an audited error surface where every message carries SQLSTATE, DETAIL and an actionable HINT (PP-4), and a role-based privilege model packaging the v0.84.0 ACL matrix (PP-6) | "I can confidently run this for years." | Planned | Large | [Full details](roadmap/v0.92.0.md) |
-| [v0.93.0](roadmap/v0.93.0.md) | Monitoring, Assurance & Packaging: shipped Grafana dashboard, alert rules and collector-validated OTel spans (PP-5), 72-hour soak, upgrade compatibility matrix and performance regression gates on one commit (PP-7), one-command install verified by smoke tests on every package (PP-8), then **feature freeze** enforced by CI rather than intention | "I can confidently run this for years." | Planned | Large | [Full details](roadmap/v0.93.0.md) |
+| [v0.88.0](roadmap/v0.88.0.md) | Safe Engine Optimization Foundations: `DiffContext` decomposition, a narrowly eligible vectorized aggregate path, planner instrumentation, shadow planning, and automatic reordering only for validated operator classes | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.88.0.md) |
+| [v0.89.0](roadmap/v0.89.0.md) | Incremental Windows, Proven Subset: bounded crash-safe state, per-algorithm semantic and performance admission, and visible partition-recomputation fallback for every shape that does not pass | "One PostgreSQL instance can handle a lot." | Planned | Large | [Full details](roadmap/v0.89.0.md) |
+| [v0.90.0](roadmap/v0.90.0.md) | Freshness Controller in Advisory Mode: authoritative freshness measurement, reproducible recommendations, separate resource, scheduling, and per-stream layers, and evidence-gated automation | "Tell me whether my freshness target is feasible and how pg_trickle would meet it." | Planned | Large | [Full details](roadmap/v0.90.0.md) |
+| [v0.91.0](roadmap/v0.91.0.md) | Schema & Query Evolution: conservative defining-query classification, shadow rebuild and atomic swap, deterministic source-DDL handling, and explicit suspension for unsafe changes | "Production schema and query changes fail safely." | Planned | Large | [Full details](roadmap/v0.91.0.md) |
+| [v0.92.0](roadmap/v0.92.0.md) | Backup, Restore, Upgrade & CDC Recovery: tested logical and physical recovery, clone isolation, machine-readable upgrade preflight, major and extension upgrade coverage, and proof-based CDC recovery classes | "Backups, upgrades, clones, and capture failures preserve correctness." | Planned | Large | [Full details](roadmap/v0.92.0.md) |
+| [v0.93.0](roadmap/v0.93.0.md) | Defaults, Bounds & Diagnosis: resource-based defaults, honest hard-bound, throttled, and forecast-and-react guarantees, progress reporting, stable operational error identifiers, and predefined roles | "I can run this for years without hidden resource or repair behavior." | Planned | Large | [Full details](roadmap/v0.93.0.md) |
+| [v0.94.0](roadmap/v0.94.0.md) | Monitoring, Assurance & Packaging: tested Grafana and OTel contracts, same-commit soak and upgrade matrix, performance gates, a longevity environment, reproducible package smoke tests, and the feature freeze | "I can monitor, verify, install, and upgrade the supported build." | Planned | Large | [Full details](roadmap/v0.94.0.md) |
+| [v0.95.x](roadmap/v0.95.x.md) | Stabilization: blockers, compatibility, tests, diagnostics, packaging, documentation, dependency cleanup, and removal or narrowing of unproven optimizer and controller behavior | "The release candidate contains less risk, not more scope." | Planned | Variable | [Full details](roadmap/v0.95.x.md) |
 
 ### Toward v1.0
 
-After v0.93.0 the project stops adding features. The remaining pre-1.0 period
-is spent on **bugs → benchmarks → compatibility → upgrades → docs → real-world
-workloads → simplification**, and the real 1.0 gate is *no known correctness
-issues and boring upgrades*.
+After v0.94.0 the project stops adding features. v0.95.x is a stabilization-only
+series for bugs, benchmarks, compatibility, upgrades, documentation, real-world
+workloads, and simplification. Unproven optimizer or controller behavior is
+narrowed, disabled, or removed rather than carried into the stable contract.
 
-That period is a **release-candidate series**, not a gap: `v1.0.0-rc.N` ships
-first, and 1.0.0 is tagged only once a candidate has been in the field without
-a new blocker. PostgreSQL 19 support is explicitly **not** a 1.0 blocker — PG 19
-GA and pgrx's PG 19 support are outside this project's control, and holding the
-stability contract for finished PG 18 work hostage to someone else's schedule
-is not a plan.
+The release-candidate series follows v0.95.x. `v1.0.0-rc.N` ships first, and
+1.0.0 is tagged only after a candidate has been in the field without a new
+blocker. PostgreSQL 19 support is not a 1.0 blocker. PG 19 GA and pgrx support
+are outside this project's control and do not delay the finished PG 18 contract.
 
 > **On the version count.** The six v0.87.x correctness releases add about 42
 > person-weeks before v0.88.0, and v0.87.14 adds a further 6-7 to finish what
@@ -512,7 +536,9 @@ is not a plan.
 > they establish the execution boundary that later engine changes must
 > preserve. The three row-identity releases add 28 person-weeks for the exact
 > V2 encoding, engine integration, and intentional stream-table recreation
-> workflow before vectorized DVM changes begin.
+> workflow before vectorized DVM changes begin. v0.91.0 and v0.92.0 split
+> schema evolution from recovery and upgrade work; v0.94.0 and v0.95.x separate
+> the final assurance gate from the stabilization period.
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
@@ -674,17 +700,21 @@ v0.87.16 ─── Versioned row identity V2 engine integration: BYTEA storage, 
 
 v0.87.17 ─── Versioned row identity V2 hardening and recreation: cross-path gates, benchmarks, non-destructive preflight, stream-table rebuild workflow, consumer resnapshot and privacy controls
 
-v0.88    ─── Vectorized aggregates & delta planning: DiffContext split first, columnar aggregate path behind a dependency ADR, cost-based operator scheduling
+v0.88    ─── Safe engine optimization: DiffContext split, narrow vector path, planner instrumentation, shadow planning, evidence-gated reordering
     │
-v0.89    ─── Incremental window functions: bounded auxiliary state, rank/offset/aggregate-over-window algorithms, documented fallback with reason codes
+v0.89    ─── Incremental windows, proven subset: bounded crash-safe state, per-algorithm admission, visible recomputation fallback
     │
-v0.90    ─── Freshness controller & self-tuning: target_freshness becomes authoritative, closed-loop controller, adaptive workers, freshness() reporting
+v0.90    ─── Freshness controller: authoritative measurement, advisory decisions, layered resource/SLA/execution control, evidence-gated automation
     │
-v0.91    ─── Lifecycle & schema evolution: safe query replacement, auto schema evolution, PITR/dump/clone, preflight_upgrade(), automatic CDC repair
+v0.91    ─── Schema & query evolution: conservative compatibility proof, shadow rebuild, deterministic DDL outcomes
     │
-v0.92    ─── Defaults, bounds & diagnosis: zero-config profiles, bounded resources, progress reporting, error-message audit, role-based privileges
+v0.92    ─── Recovery & upgrades: backup/restore/promotion, clone isolation, upgrade preflight and matrix, proof-based CDC repair
     │
-v0.93    ─── Monitoring, assurance & packaging: Grafana/OTel validation, 72-hour soak, upgrade matrix, regression gates, install smoke tests, feature freeze
+v0.93    ─── Defaults, bounds & diagnosis: resource-based defaults, honest enforcement classes, progress, stable errors, roles
+    │
+v0.94    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, feature freeze
+    │
+v0.95.x  ─── Stabilization: blockers, compatibility, tests, docs, packaging, and removal or narrowing of unproven behavior
     │
 v1.0-rc  ─── Release candidates: blockers only, no new features
     │
@@ -987,7 +1017,7 @@ Operational runbooks for upgrade rollback and the upgrade E2E cutoff policy,
 CI gate documentation for contributors, and cargo-deny advisory review-by
 dates complete the pre-v1.0 checklist.
 
-**v0.81.0 through v0.93.0 form the Product Arc.** The engine is sound after 16
+**v0.81.0 through v0.95.x form the Product Arc.** The engine is sound after 16
 assessment arcs, though the post-v0.81.0 implementation audit found correctness
 and resilience gaps that require explicit closure first. What is missing beyond
 those gaps is not capability but product: the machinery is broad, and the
@@ -1054,21 +1084,19 @@ contracts, v0.87.16 carries them through storage, CDC, DVM, and matching, and
 v0.87.17 closes the cross-path, performance, privacy, and recreation-based
 upgrade gates. Existing source tables remain intact, but pre-1.0 stream-table
 state is deliberately dropped and recreated; external consumers resnapshot
-against the new contract. v0.88.0 and v0.89.0 then change engine internals: a
-vectorized aggregate path and cost-based delta planning first, followed by
-incremental window-function algorithms, with no deployment or API change.
+against the new contract. v0.88.0 adds a narrow vectorized aggregate path and
+validates delta-plan alternatives before enabling them. v0.89.0 establishes
+bounded window state, then admits only algorithms that match PostgreSQL and
+beat partition recomputation. Window breadth does not block v1.0.
 
-v0.90.0 makes freshness authoritative: the closed-loop controller derives the
-schedule, the DIFFERENTIAL/FULL decision, batch sizes, concurrency and priority
-from the target users already declared, and reports whether the SLA is being
-met. v0.91.0 makes lifecycle boring — safe query changes, automatic handling of
-compatible source-schema changes, tested PITR, dump/restore, cloning and major
-upgrades, and a `preflight_upgrade()` function that tells a DBA whether it is
-safe to proceed. v0.92.0 and v0.93.0 answer "would a DBA recommend this?":
-excellent defaults, bounded resources, progress reporting and error messages
-with remediation, then monitoring integration, soak and regression gates, and
-one-command install — followed by a feature freeze and a release-candidate
-series rather than a jump straight to 1.0.
+v0.90.0 makes freshness measurement authoritative and starts the controller in
+advisory mode. Each automatic decision earns authority separately. v0.91.0
+handles defining-query and source-schema evolution. v0.92.0 covers backup,
+restore, cloning, upgrades, and CDC recovery as a separate mandatory gate.
+v0.93.0 defines defaults, resource guarantees, progress, diagnostics, and
+roles. v0.94.0 closes monitoring, soak, compatibility, regression, and package
+gates on one candidate commit, then freezes features. v0.95.x removes risk
+before the release-candidate series.
 
 **The distributed work has moved past 1.0.** External workers, external CDC
 consumers, Kubernetes operators, distributed delta computation, cross-cluster

--- a/plans/PLAN_0_88_0.md
+++ b/plans/PLAN_0_88_0.md
@@ -1,10 +1,15 @@
 # v0.88.0 Implementation Plan: Vectorized Aggregates and Delta Planning
 
-> **Status:** Planned
+> **Status:** Needs roadmap alignment
 > **Target:** v0.88.0
 > **Baseline:** v0.87.6
 > **Roadmap:** [roadmap/v0.88.0.md](../roadmap/v0.88.0.md)
-> **Last updated:** 2026-08-24
+> **Last updated:** 2026-08-30
+
+> **Roadmap change:** The roadmap now requires plan instrumentation and shadow
+> validation before any operator class is enabled automatically. Treat the
+> implementation detail below as research input until this plan is revised to
+> match that gate.
 
 ## 1. Outcome
 

--- a/plans/PLAN_0_89_0.md
+++ b/plans/PLAN_0_89_0.md
@@ -1,10 +1,15 @@
 # v0.89.0 Implementation Plan: Incremental Window Functions
 
-> **Status:** Planned
+> **Status:** Needs roadmap alignment
 > **Target:** v0.89.0
 > **Baseline:** v0.88.0
 > **Roadmap:** [roadmap/v0.89.0.md](../roadmap/v0.89.0.md)
-> **Last updated:** 2026-08-23
+> **Last updated:** 2026-08-30
+
+> **Roadmap change:** The bounded state framework remains mandatory, but
+> algorithm breadth is now evidence-gated and does not block v1.0. Treat the
+> family-specific implementation detail below as research input until this plan
+> is revised around the admission gate.
 
 ## 1. Outcome
 

--- a/plans/PLAN_0_90_0.md
+++ b/plans/PLAN_0_90_0.md
@@ -1,10 +1,15 @@
 # v0.90.0 Implementation Plan: Freshness Controller and Self-Tuning
 
-> **Status:** Planned
+> **Status:** Needs roadmap alignment
 > **Target:** v0.90.0
 > **Baseline:** v0.89.0
 > **Roadmap:** [roadmap/v0.90.0.md](../roadmap/v0.90.0.md)
-> **Last updated:** 2026-08-23
+> **Last updated:** 2026-08-30
+
+> **Roadmap change:** v0.90.0 now requires authoritative freshness measurement
+> and advisory controller decisions. Each automatic decision class must earn
+> authority separately. Treat the authority-specific implementation detail
+> below as research input until this plan is revised to match that rollout.
 
 ## 1. Outcome
 
@@ -128,8 +133,8 @@ transaction, or frontier finalizer.
   sample. Missing CPU evidence is reported and the CPU resize signal is idle.
 - A new alert transport. Use health rows, logs, existing NOTIFY alerts,
   Prometheus, and OpenTelemetry.
-- Keeping compatibility aliases forever. v0.90 is the last planned removal
-  point before the v0.93 feature freeze.
+- Removing a control whose replacement remains advisory. Unproven replacements
+  keep their override through the v0.94 feature freeze.
 
 ## 2. Baseline and gap map
 

--- a/roadmap/v0.86.0.md
+++ b/roadmap/v0.86.0.md
@@ -20,11 +20,10 @@ here is user-facing: a standard statistics view and an `explain()` function
 that answers the questions users actually ask, in plain language, before and
 after they commit to a query.
 
-It also introduces `target_freshness` as an *accepted input* — deliberately
-four releases before the closed-loop controller in [v0.90.0](v0.90.0.md) is
-asked to honour it. The control that v1.0 freezes as the primary user-facing
-knob should have been in users' hands for several releases before the freeze,
-not introduced immediately before it.
+It also introduces `target_freshness` as an *accepted input* four releases
+before the advisory controller in [v0.90.0](v0.90.0.md) evaluates it. The
+control that v1.0 freezes as the primary user-facing knob stays in users' hands
+for several releases before the freeze.
 
 Work starts only after the v0.82.0–v0.85.0 pre-scaling gates prove the current
 frontier, DVM, catalog, privilege, upgrade, scheduler and resource contracts.
@@ -114,8 +113,8 @@ JOIN pgtrickle.pgt_stream_tables USING (pgt_id);
 
 `target_freshness_ms` reflects the declared target from UX-7 and is `NULL` when
 none is set. The SLA evaluation columns (`p95_freshness_ms`, `sla_status`) are
-added in [v0.90.0](v0.90.0.md) once there is a controller whose behaviour they
-can describe.
+added in [v0.90.0](v0.90.0.md) once exact freshness measurement and controller
+recommendations exist.
 
 Counters reset semantics follow PostgreSQL conventions
 (`pgtrickle.stat_reset(pgt_id)`, `pgtrickle.stat_reset_all()`).
@@ -155,8 +154,9 @@ In this release the target is **declared, stored, reported and validated — not
 yet controlled**. It is translated once into the existing schedule and mode
 settings, surfaced by `explain()` and `pg_stat_pgtrickle`, and checked for
 obvious infeasibility (SLA-5 from the original freshness-SLA plan) so users are
-told immediately when a target cannot be met. The closed-loop controller that
-owns the derived parameters continuously arrives in [v0.90.0](v0.90.0.md).
+told immediately when a target cannot be met. The advisory controller arrives
+in [v0.90.0](v0.90.0.md); each automatic decision remains gated by benchmark
+and soak evidence.
 
 Special values: `'on_commit'` (existing IMMEDIATE mode) and `'manual'` (refresh
 only when asked).
@@ -178,6 +178,6 @@ only when asked).
 - [ ] `EXPLAIN` annotation appears for stream-table scans when enabled, and is
       off by default
 - [ ] `target_freshness` accepted, stored, reported and infeasibility-checked;
-      documented as "declared now, controlled from v0.90.0"
+      documented as "declared now, evaluated from v0.90.0"
 - [ ] Docs: a "Understanding your stream table" guide built entirely around
       `explain()` output

--- a/roadmap/v0.88.0.md
+++ b/roadmap/v0.88.0.md
@@ -6,13 +6,17 @@
 > **Blocked by:** [v0.87.17](v0.87.17.md)
 > **Renumbered and split:** previously the first half of v0.84.0 "Fast
 > Incremental Engine". Incremental window functions moved to
-> [v0.89.0](v0.89.0.md); parallel delta fan-out moved past 1.0.
+> [v0.89.0](v0.89.0.md). Parallel delta fan-out moved past 1.0.
 
 ## Theme
 
 Make the delta path faster without changing what users see: a vectorized
 execution path for pure-aggregate stream tables, and cost-based operator
 ordering inside delta queries so intermediate results stay small.
+
+The release keeps narrow, proven fast paths. Unvalidated planner rules stay in
+shadow mode, and optional optimization breadth must not delay the lifecycle
+work in v0.91.0 and later.
 
 The v0.87.1 through v0.87.6 correctness program lands first. Its exact oracle,
 replay corpus, semantic coverage, schema contracts, snapshot plans, and release
@@ -74,23 +78,29 @@ answer is the dependency-free one until Arrow is shown to be worth it.
 
 ### LT-9: Cost-Based Operator Scheduling
 
-Reorder operators within a delta query's OpTree based on estimated cardinality
-to minimize intermediate result sizes:
+Develop cost-based operator scheduling in three stages.
 
-1. **Selectivity estimation:** Use PostgreSQL's `pg_statistic` to estimate
-   filter selectivity and join cardinality
-2. **Operator reordering rules:**
-   - Push high-selectivity filters before joins (existing P2-7, extended)
-   - Order join inputs by ascending estimated cardinality (smaller relation
-     as build side)
-   - Place DISTINCT before expensive projections
-3. **Cost model:** Estimate total intermediate tuples for each valid ordering;
-   choose minimum-cost plan
-4. **Safety:** Only reorder when semantically equivalent (respects NULL
-   handling, outer join placement constraints)
+1. **Plan instrumentation.** Record estimated and actual cardinalities,
+   intermediate-row counts, and runtime for the current plan. Record candidate
+   runtime when the benchmark or test environment can execute both plans.
+2. **Shadow planning.** Propose safe alternative orders without selecting them
+   by default. CI and benchmarks report prediction accuracy, expected wins,
+   regressions, and the worst regression.
+3. **Controlled enablement.** Select an alternative automatically only for an
+   operator class whose benchmark and soak evidence meets its regression
+   budget. Keep every other class on the existing planner.
 
-New diagnostic: `EXPLAIN (FORMAT JSON) SELECT pgtrickle.explain_delta_plan(pgt_id)`
-shows the estimated cost and chosen operator order.
+Candidate rules include selective-filter pushdown, inner-join input ordering,
+and moving `DISTINCT` across a proven one-to-one projection. NULL semantics and
+outer-join boundaries remain hard safety constraints.
+
+Before pg_trickle adds a custom cost optimizer, an ADR must explain why the
+delta query cannot be expressed in a relational form that lets PostgreSQL's
+optimizer make the same decision. A custom optimizer is justified only when
+delta semantics hide information from PostgreSQL.
+
+`pgtrickle.explain_delta_plan(pgt_id)` reports estimates, observations, the
+candidate order, its validation status, and the plan selected for execution.
 
 ### PERF-O4: Parallel Delta Computation Fan-Out — **moved past v1.0**
 
@@ -108,12 +118,19 @@ in this release depends on it.
 
 ## Exit criteria
 
-- [ ] `DiffContext` decomposed first; no behavioural change in the E2E suite
+- [ ] `DiffContext` decomposed first with no behavioural change in the E2E suite
 - [ ] ADR published deciding the vectorized-aggregate dependency question, and
       the v0.76.0 dependency-removal rationale explicitly addressed
-- [ ] Vectorized aggregate path active for pure-aggregate stream tables; ≥5×
+- [ ] Vectorized aggregate path active for pure-aggregate stream tables with ≥5×
       throughput on the aggregate benchmark versus v0.87.13, with identical
       results verified against the FULL oracle
-- [ ] Cost-based operator scheduling on by default; `explain_delta_plan()` shows
-      the chosen order; no plan regression on the TPC-H suite
+- [ ] End-to-end refresh throughput improves on representative workloads with
+      no meaningful write-path or memory regression
+- [ ] Planner estimates are compared with actual cardinalities and runtime.
+      `explain_delta_plan()` exposes both
+- [ ] Automatic reordering is enabled only for validated operator classes. An
+      unvalidated class keeps the existing plan
+- [ ] The target aggregate benchmark improves by at least 5×, and eligible
+      production-like workloads regress by no more than 10%. Otherwise, the
+      eligibility rule excludes the regressing shape
 - [ ] Both paths validated by the DVM delta-invariant validator from v0.77.0

--- a/roadmap/v0.89.0.md
+++ b/roadmap/v0.89.0.md
@@ -8,8 +8,9 @@
 
 ## Theme
 
-Replace partition-based recomputation for window functions with genuinely
-incremental algorithms.
+Establish a correct, bounded, crash-safe framework for incremental window
+maintenance, then admit only the function and frame combinations that show a
+measured benefit over partition recomputation.
 
 This is a release on its own, not a bullet point. Every entry in the table below
 is a distinct algorithm with its own auxiliary state, its own persistence and
@@ -18,11 +19,17 @@ own DIFFERENTIAL-versus-FULL proof obligation. Bundling it with the vectorized
 aggregate path and a delta-query cost model — as the original v0.84.0 did —
 produced a release that could not be scoped, reviewed or gated.
 
+The state framework is mandatory. Algorithm breadth is not a v1.0 blocker. Any
+shape that does not pass the admission gate keeps the existing, correct
+partition-recomputation path with a visible reason code.
+
 ## Non-Goals
 
 - No new window functions beyond those PostgreSQL already supports.
-- No change to the window semantics users see; only to how they are maintained.
+- No change to the window semantics users see. Only the maintenance strategy
+  changes.
 - No removal of the partition-recomputation path — it remains the fallback.
+- No requirement that every candidate family become incremental before v1.0.
 
 ## Items
 
@@ -41,38 +48,59 @@ Before any individual algorithm, define once:
 New metadata in `pgt_stream_tables`: `window_strategy JSONB` recording, per
 window function, the chosen strategy and its auxiliary state location.
 
-### LT-7b: Rank-family algorithms
+### LT-7b: Algorithm admission gate
 
-| Function | Current Strategy | New Strategy |
-|----------|-----------------|--------------|
-| `ROW_NUMBER()` | Recompute partition | Maintain sorted index; insert/delete at position |
-| `RANK()` / `DENSE_RANK()` | Recompute partition | Track rank counts per distinct value; adjust on delta |
+A function and frame combination becomes incremental only when it passes all
+of these checks:
+
+1. PostgreSQL semantics match exactly, including peers, NULL ordering,
+   collations, and frames.
+2. DIFFERENTIAL converges with FULL after INSERT, UPDATE, and DELETE histories.
+3. The auxiliary state survives restart, backup, restore, rebuild, and upgrade.
+4. State growth is bounded under the documented policy.
+5. Output amplification and the recomputation crossover are measured.
+6. A representative end-to-end workload shows a material speedup without
+   exceeding its regression budget.
+
+Failure of any check selects partition recomputation. The support matrix and
+diagnostics report the reason.
+
+### LT-7c: Rank-family candidates
+
+| Function | Current strategy | Admission target |
+|----------|------------------|------------------|
+| `ROW_NUMBER()` | Recompute partition | Update ordered per-partition state when cheaper than recomputation |
+| `RANK()` / `DENSE_RANK()` | Recompute partition | Update peer-aware rank state when cheaper than recomputation |
 
 Both must handle the case where one inserted row shifts every subsequent row's
 output — the delta is not proportional to the input change, and the release must
 document where the crossover to partition recomputation lies rather than
 pretending it does not exist.
 
-### LT-7c: Offset and boundary algorithms
+### LT-7d: Offset and boundary candidates
 
-| Function | Current Strategy | New Strategy |
-|----------|-----------------|--------------|
-| `LAG(col, N)` / `LEAD(col, N)` | Recompute partition | Ring buffer of N preceding/following values per partition |
-| `FIRST_VALUE()` / `LAST_VALUE()` | Recompute partition | Track min/max by sort key |
-| `NTH_VALUE()` | Recompute partition | Indexed array per partition |
+| Function | Current strategy | Admission target |
+|----------|------------------|------------------|
+| `LAG(col, N)` / `LEAD(col, N)` | Recompute partition | Maintain enough ordered state for bounded offsets |
+| `FIRST_VALUE()` / `LAST_VALUE()` | Recompute partition | Maintain exact frame-boundary state |
+| `NTH_VALUE()` | Recompute partition | Maintain indexed ordered state for the admitted frame |
 
-### LT-7d: Aggregate-over-window algorithms
+These are semantic and performance goals, not commitments to a ring buffer or
+another specific data structure. The implementation must handle insertion and
+deletion at arbitrary positions before an offset strategy is admitted.
 
-| Function | Current Strategy | New Strategy |
-|----------|-----------------|--------------|
-| `SUM() OVER (...)` | Recompute partition | Running sum with prefix-sum tree for range frames |
-| `COUNT() OVER (...)` | Recompute partition | Running count (algebraic) |
+### LT-7e: Aggregate-over-window candidates
+
+| Function | Current strategy | Admission target |
+|----------|------------------|------------------|
+| `SUM() OVER (...)` | Recompute partition | Maintain bounded algebraic state for admitted frames |
+| `COUNT() OVER (...)` | Recompute partition | Maintain bounded algebraic state for admitted frames |
 
 Non-invertible aggregates over windows (`MIN`/`MAX` with deletions) stay on the
 recomputation path unless a proof is available, consistent with the fail-closed
 rule established in [v0.83.0](v0.83.0.md).
 
-### LT-7e: Fallback, reason codes and the support matrix
+### LT-7f: Fallback, reason codes and the support matrix
 
 Frames that are not covered — `ROWS BETWEEN` / `RANGE BETWEEN` variants outside
 the algorithms above, `EXCLUDE` clauses, `GROUPS` mode — fall back to partition
@@ -85,12 +113,13 @@ answer from PostgreSQL.
 
 - [ ] Auxiliary state model shipped, bounded, crash-tested and covered by the
       backup/restore suite
-- [ ] Every function in LT-7b/c/d has an incremental algorithm, or an explicit
-      documented reason it stays on recomputation
+- [ ] Every candidate in LT-7c/d/e either passes the admission gate or has an
+      explicit reason for staying on recomputation
 - [ ] Property tests compare DIFFERENTIAL with FULL after every INSERT, UPDATE
-      and DELETE for each supported window shape
+      and DELETE for each admitted window shape, including peers, NULL ordering,
+      collations, and frame boundaries
 - [ ] Measured speed-up published per function family, including the crossover
-      point where recomputation is still faster
+      point and output amplification where recomputation is still faster
 - [ ] Unsupported frames fall back with a reason code and appear in
       `docs/DVM_SUPPORT_MATRIX.md`
 - [ ] Existing window stream tables upgrade without user action, or are flagged

--- a/roadmap/v0.90.0.md
+++ b/roadmap/v0.90.0.md
@@ -2,150 +2,118 @@
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"Tell it how fresh I need data; it figures out the rest."*
+> **User promise:** *"Tell me whether my freshness target is feasible and how pg_trickle would meet it."*
 > **Blocked by:** [v0.89.0](v0.89.0.md)
 > **Renumbered:** previously v0.85.0. The user-facing `target_freshness`
-> control moved forward to [v0.86.0](v0.86.0.md) so the knob v1.0 freezes gets
-> real usage before the freeze; this release makes it authoritative.
+> control moved forward to [v0.86.0](v0.86.0.md). This release makes the
+> measurement authoritative and introduces the controller in advisory mode.
 
 ## Theme
 
-Users do not want to reason about scheduler intervals, batch sizes, worker
-counts and fallback thresholds. They want to say how stale the answer is
-allowed to be. [v0.86.0](v0.86.0.md) started accepting that statement. This
-release makes pg_trickle act on it continuously and demotes every other knob to
-an override.
+Keep `target_freshness` as the primary product control, but make automation earn
+authority with benchmark and soak evidence. The first controller reports what
+it would do and why. It does not need to own every scheduling and execution
+choice before v1.0.
 
-> **"Tell pg_trickle how fresh you need the answer, not how to schedule it."**
+The operating objective is explicit:
 
-This mirrors where the surrounding ecosystem has landed — PostgreSQL's own
-materialized views still require explicit `REFRESH MATERIALIZED VIEW`, while
-Timescale exposes continuous-aggregate refresh policies and Materialize exposes
-freshness and lag as first-class concepts. Freshness is the concept users
-already have; pg_trickle should accept it directly.
+> Meet feasible p95 freshness targets while minimizing pg_trickle resource use
+> and preserving configured OLTP headroom. When all targets cannot be met,
+> minimize weighted SLA breach instead of increasing resource use without a
+> bound.
 
 ## Items
 
-### SLA-1: `target_freshness` becomes authoritative
+### SLA-1: Authoritative freshness measurement
 
-```sql
-SELECT pgtrickle.create_stream_table(
-    'sales_by_region',
-    $$SELECT region, SUM(amount) FROM orders GROUP BY region$$,
-    target_freshness => '2 seconds'
-);
+`target_freshness` keeps the interval, `on_commit`, and `manual` forms accepted
+in v0.86.0. For an interval target, pg_trickle reports the p95 age of visible
+data from source commit to refresh commit. Missing provenance is reported as
+missing evidence, not replaced with refresh duration.
 
-SELECT pgtrickle.alter_stream_table(
-    'sales_by_region', target_freshness => '1 minute'
-);
-```
+`pgtrickle.freshness()`, `pg_stat_pgtrickle`, `health_check()`, Prometheus, and
+OpenTelemetry expose the target, p50, p95, p99, breach duration, evidence age,
+and feasibility status.
 
-`target_freshness` is defined as the p95 age of the data visible in the stream
-table, measured commit-to-visible using the metric shipped in v0.81.0. In
-v0.86.0 it was translated once into the existing settings. From this release the
-scheduler owns every derived parameter continuously, and the explicit knobs
-(`refresh_interval`, batch sizes, concurrency) become optional overrides that
-are reported as such by `explain()`.
+### SLA-2: Reproducible advisory decisions
 
-Special values `'on_commit'` and `'manual'` keep the meaning defined in
-v0.86.0.
+For each stream table, the controller recommends:
 
-### SLA-2: The controller
+- refresh timing
+- DIFFERENTIAL or FULL
+- pipeline batch size
+- queue priority
+- worker demand
+- overload deferral
 
-A closed-loop controller per stream table decides, once per scheduler tick:
+`explain()` and internal telemetry show the recommendation, the input evidence,
+and the reason. The same input snapshot must produce the same recommendation.
+An advisory decision cannot mutate configuration or override an explicit user
+setting.
 
-- **when** to refresh (interval derived from observed refresh cost and inflow
-  rate, not a fixed timer)
-- **DIFFERENTIAL vs FULL**, using measured cost rather than a static delta-ratio
-  threshold
-- **batch size** for pipelined refresh, from observed row width and memory
-  budget
-- **concurrency**, within the global bound from v0.87.0
-- **priority**, so a 1-second SLA outranks a 1-hour SLA under contention
-- **whether to defer**, when the instance is overloaded (v0.87.0 backpressure)
+### SLA-3: Layered controller
 
-The controller uses hysteresis — a decision changes only after three consecutive
-consistent measurements — and its inputs and last decision are exposed in
-`explain()` so behaviour is never mysterious.
+The design has three layers with separate responsibilities.
 
-### SLA-3: Adaptive worker pool sizing
+| Layer | Responsibility |
+|-------|----------------|
+| Global resource controller | Determines the CPU, memory, worker, and connection capacity pg_trickle may use without violating the configured OLTP headroom. |
+| SLA scheduler | Allocates available capacity by target, current freshness, breach risk, priority, dependency order, and fairness. |
+| Per-stream execution controller | Recommends refresh mode, batch size, and other execution choices within the resource allocation. |
 
-Replace the static worker count with automatic sizing driven by real signals:
+One layer cannot compensate for another by exceeding its bound. Infeasible
+targets cannot monopolize workers or force the global controller into a resource
+race.
 
-- CPU utilisation > 70% → reduce workers by one (do not starve OLTP)
-- refresh queue depth > 2× workers → add one worker
-- all workers idle for three consecutive ticks → shrink to the configured floor
-- an SLA at risk of breach → add workers up to the configured ceiling
+### SLA-4: Authority rollout
 
-New GUCs: `pg_trickle.adaptive_workers = true`,
-`pg_trickle.adaptive_workers_min = 1`, `pg_trickle.adaptive_workers_max = 8`
-(bounded by `max_worker_processes` and by the authoritative cluster limit from
-[v0.85.0](v0.85.0.md) OPS-81-1).
+Automation advances in this order:
 
-> The names `pg_trickle.min_workers` / `pg_trickle.max_workers` are **not**
-> available: `pg_trickle.max_workers` is a retired GUC that `just docs-lint`
-> blocks in active documentation. Reusing a retired name with new semantics
-> would break the lint and mislead anyone upgrading from a version that had it.
+1. advisory decisions
+2. automatic refresh timing
+3. automatic priority
+4. automatic batch sizing
+5. adaptive worker allocation
+6. automatic FULL or DIFFERENTIAL selection
 
-### SLA-4: SLA reporting and alerting
+Advisory mode is mandatory for v0.90.0. A later stage may become authoritative
+in the same release only when burst, steady-state, restart, and mixed-SLA tests
+show stable behavior with no unsafe regression. Each decision class has its own
+enablement gate. A failed gate leaves that class advisory and does not block the
+v1.0 lifecycle critical path.
 
-Freshness becomes a reported, checkable status rather than something users infer
-from timestamps:
+### SLA-5: Feasibility, overload, and oscillation
 
-```
-SELECT * FROM pgtrickle.freshness();
-```
+The controller reports an infeasible target when measured work cannot meet it
+within the configured resource policy. Under overload, foreground PostgreSQL
+work wins. pg_trickle defers lower-risk refreshes, reports the expected breach,
+and keeps fairness and durability constraints intact.
 
-```
- stream_table      | target | p50    | p95    | p99    | status
--------------------+--------+--------+--------+--------+---------------
- sales_by_region   | 2s     | 310ms  | 730ms  | 1.4s   | meeting SLA
- customer_360      | 5s     | 4.1s   | 9.8s   | 21s    | BREACHING
-```
+Hysteresis or an equivalent bounded policy prevents repeated switching. Tests
+cover burst traffic, steady inflow, workload shifts, restart, and an infeasible
+mix of targets.
 
-- `pg_stat_pgtrickle` (shipped v0.86.0) gains `p95_freshness_ms` and
-  `sla_status`; `target_freshness_ms` is already there
-- `health_check()` reports sustained breaches with the controller's diagnosis
-  (for example: *"refresh cost 8.2s exceeds 5s target; consider a coarser
-  target or reducing join breadth"*)
-- Prometheus/OTel metrics expose target, actual and breach duration
+### SLA-6: Configuration audit
 
-### SLA-5: Continuous infeasible-SLA detection
-
-The creation-time check shipped in v0.86.0 (UX-7). This release adds the
-continuous half: a stream table whose workload has grown past feasibility is
-flagged in `health_check()` and by the controller instead of consuming
-resources in a losing race.
-
-```
-WARNING:  target_freshness '500 ms' is not achievable for this query
-DETAIL:   Minimum observed refresh cost is 3.4 s (dominated by orders → line_items join).
-HINT:     Use target_freshness >= '5 s', or narrow the defining query.
-```
-
-### SLA-6: Retire the knobs users should not need
-
-Every GUC and per-stream-table option is audited and classified as *user-facing*,
-*advanced override*, or *internal*. Internal knobs are removed or hidden;
-advanced overrides are documented as "only if the controller is wrong, and please
-tell us why". The documented configuration surface shrinks measurably, and the
-config advisor from v0.81.0 becomes a translator from workload description to
-`target_freshness` rather than a list of settings to hand-tune.
+Classify each scheduler and execution setting as a primary control, an advanced
+override, or internal state. Do not remove an override until the replacement
+decision class has earned authority. `explain()` reports both the recommendation
+and any override that prevents it.
 
 ## Exit criteria
 
-- [ ] The controller owns every derived parameter for stream tables with a
-      `target_freshness`; explicit knobs are reported as overrides by
-      `explain()`
-- [ ] Controller meets p95 targets for a mixed workload of 100 stream tables
-      across 1s/10s/1m targets in a soak test
-- [ ] Adaptive worker sizing demonstrated to shrink under OLTP load and grow
-      under SLA pressure, without oscillation, and never above the
-      authoritative cluster worker limit from v0.85.0
-- [ ] `pgtrickle.freshness()` and `sla_status` shipped, documented and exported
-      to Prometheus/OTel
-- [ ] Infeasible targets flagged continuously, not only at creation
-- [ ] Documented configuration surface reduced; every remaining user-facing GUC
-      justified in `docs/CONFIGURATION.md`
-- [ ] No GUC removed in SLA-6 without a deprecation entry in `UPGRADING.md`;
-      removals land here rather than after the v0.93.0 feature freeze
+- [ ] Freshness measurement is authoritative and preserves exact source commit
+      provenance through stream-table chains
+- [ ] Every controller recommendation is visible, reproducible, and backed by
+      current evidence
+- [ ] The three controller layers have independent bounds and tests
+- [ ] Burst, steady-state, restart, and mixed-SLA tests show no oscillation or
+      unbounded worker demand
+- [ ] OLTP headroom wins under overload. Infeasible targets are reported and do
+      not monopolize refresh capacity
+- [ ] Any automated decision class has its own benchmark, soak, rollback, and
+      inspection gate. Unvalidated classes remain advisory
+- [ ] `pgtrickle.freshness()` and `sla_status` are documented and exported to
+      Prometheus and OpenTelemetry
+- [ ] Configuration is classified without removing a control whose automated
+      replacement remains advisory

--- a/roadmap/v0.91.0.md
+++ b/roadmap/v0.91.0.md
@@ -1,142 +1,70 @@
-# v0.91.0 — Lifecycle & Schema Evolution
+# v0.91.0 — Schema & Query Evolution
 
 > **Status:** Planned
-> **Scope:** Very Large
-> **User promise:** *"Production changes don't break my stream tables."*
+> **Scope:** Large
+> **User promise:** *"Production schema and query changes fail safely."*
 > **Blocked by:** [v0.90.0](v0.90.0.md)
-> **Renumbered:** previously v0.86.0.
+> **Split:** backup, restore, cloning, upgrades, and CDC recovery moved to
+> [v0.92.0](v0.92.0.md).
 
 ## Theme
 
-An extension that works perfectly until the first PostgreSQL major upgrade is
-not production-ready. Neither is one that breaks when someone adds a column,
-restores a backup, clones a database into staging, or renames a schema.
+Give every defining-query and source-schema change one deterministic outcome:
+continue correctly, rebuild safely, or suspend explicitly. No change may leave
+a stream table in an ambiguous degraded state.
 
-This release is dedicated entirely to making the boring, unavoidable operations
-of a real production database boring for pg_trickle too. Nothing here is a
-feature users will brag about; all of it is the reason they will still be
-running pg_trickle in three years.
+This release is part of the mandatory v1.0 lifecycle critical path. It stays
+narrow so schema-state design and recovery-state design are reviewed and gated
+separately.
 
 ## Items
 
 ### LC-1: Safe defining-query replacement
 
-Changing the defining query today means dropping and recreating. Instead,
-`pgtrickle.alter_stream_table_query()` gains a classification and swap protocol:
+`pgtrickle.alter_stream_table_query()` classifies a proposed change as:
 
-1. Classify the change: **compatible** (same output schema and provably
-   compatible incremental plan), **rebuildable** (output schema changes, or the
-   plan changes such that existing state is invalid), or **rejected**
-2. Compatible changes swap the plan atomically, keeping existing state and
-   frontier — no repopulation, no visible gap
-3. Rebuildable changes populate a shadow table, then swap under a brief lock,
-   so readers never see a partially populated result
-4. `pgtrickle.explain_alter('st', $$new query$$)` reports the classification and
-   the estimated rebuild cost *before* the user runs it
+- **compatible** only when pg_trickle proves that the materialized result,
+  frontier, row identities, and auxiliary state remain valid
+- **rebuildable** when shadow state can be populated and swapped atomically
+- **rejected** when pg_trickle cannot preserve the stream table contract
 
-> This is a function-API change, not new DDL grammar. Declarative
-> `ALTER STREAM TABLE ... AS` was dropped from the product arc; the
-> `pgtrickle.exec_stream_ddl()` shim is unchanged by this release.
+If compatibility cannot be proved, the change is rebuildable. An unnecessary
+rebuild is safer than reusing invalid state.
 
-### LC-2: Automatic handling of compatible source-schema changes
+`pgtrickle.explain_alter()` reports the classification, proof or rejection
+reason, affected state, and estimated rebuild cost before any mutation. A
+rebuild uses shadow state and a brief atomic swap. Interrupted rebuilds resume
+or roll back without exposing a partial result.
 
-DDL event triggers detect source changes and act, controlled by
-`pg_trickle.auto_evolve` (default `true` for additive changes only):
+### LC-2: Source-schema evolution
 
-**Automatic:**
-- `ADD COLUMN` — propagate when the defining query uses `SELECT *`; otherwise
-  no-op
-- `ADD CONSTRAINT`, `CREATE INDEX`, `DROP INDEX`, `SET STATISTICS`, `COMMENT` —
-  no-op
-- source table rename, schema move, ownership change — catalog references
-  updated in place
+DDL event handling must cover:
 
-**Suspend with a clear diagnosis:**
-- `DROP COLUMN` used by the defining query
-- `ALTER COLUMN TYPE` on a column used by the defining query
-- replica identity or primary key removal on a source
+- transactional DDL and rollback
+- additive and destructive column changes
+- table, schema, and column rename chains
+- schema moves and ownership changes
+- dropped and recreated objects that reuse a name but have a new OID
+- dependency OID changes
+- refresh concurrent with DDL
+- an extension upgrade near source DDL
 
-Suspension is loud and actionable: `NOTIFY`, `health_check()` entry, an entry in
-refresh history with reason `SCHEMA_INCOMPATIBLE`, and a `HINT` naming the exact
-`pgtrickle.alter_stream_table_query()` call that would resolve it. A suspended
-stream table stops refreshing but never serves silently wrong data.
-
-### LC-3: Backup, restore and PITR
-
-- `pg_dump`/`pg_restore` round-trip for every catalog object, building on the
-  durable/derived catalog classification established in
-  [v0.84.0](v0.84.0.md) CAT-81-5, with a restore-time consistency check
-- documented and tested PITR behaviour: after a point-in-time restore, frontiers
-  are validated against the restored WAL position, and stream tables whose
-  frontier is ahead of the restored database are automatically marked for
-  reinitialisation rather than diverging silently
-- `pg_basebackup` and physical replica promotion covered by E2E tests
-- restoring a dump into a database without the extension yields ordinary tables
-  and a clear message, never a broken restore
-
-### LC-4: Database cloning and environment copies
-
-`CREATE DATABASE ... TEMPLATE`, dump/restore into staging, and logical copies
-are first-class: cloned stream tables detect that they are a clone (database
-identity changed), drop stale replication-slot bindings, and either resume with
-fresh CDC or suspend with an explicit message. No clone ever consumes the
-original's replication slots.
-
-### LC-5: `pgtrickle.preflight_upgrade()`
-
-One function a DBA runs before a PostgreSQL major upgrade or an extension
-upgrade, which answers "is this safe?":
-
-```sql
-SELECT * FROM pgtrickle.preflight_upgrade();
-```
-
-```
- check                            | status | detail
-----------------------------------+--------+-------------------------------------------
- extension version supported      | OK     | 0.91.0 → 1.0.0 upgrade path exists
- stream tables suspended          | WARN   | 1 suspended (customer_360) — resolve first
- in-flight refreshes              | OK     | none
- replication slots                | OK     | 3 slots, all active, max lag 1.2 MB
- change buffer backlog            | WARN   | orders backlog 2.1M rows — drain recommended
- catalog integrity                | OK     | 0 orphaned entries
- disk headroom for rebuild        | OK     | 41 GB free, 3.2 GB estimated
-```
-
-Backed by a documented drain-and-quiesce procedure
-(`pgtrickle.quiesce()` / `pgtrickle.resume_all()`) so an upgrade window can be
-entered cleanly.
-
-### LC-6: PostgreSQL major upgrades and extension upgrades
-
-- `pg_upgrade` across major versions covered end to end in CI, including a run
-  with active stream tables and a non-empty change buffer
-- extension upgrade E2E extended to cover every supported source version to the
-  release under test, with the existing cutoff policy documented in place
-- downgrade remains unsupported and is enforced with a clear error plus the
-  rollback runbook shipped in v0.80.0
-
-### LC-7: Automatic CDC repair
-
-When capture breaks — dropped replication slot, dropped trigger, a source
-restored out from under a stream table, WAL removed before it was consumed —
-pg_trickle detects it, reports it precisely, and where safe repairs it
-automatically by rebuilding capture and reinitialising affected stream tables.
-Where automatic repair is unsafe, it suspends and names the manual step. The
-existing repair tooling becomes the automatic path rather than a documented
-procedure the user has to find.
+An additive change may continue automatically only when the defining query and
+stored state remain valid. A destructive or ambiguous change suspends the
+stream table with a stable reason code, a `health_check()` entry, and an
+actionable repair command. No path serves silently stale or structurally invalid
+output.
 
 ## Exit criteria
 
-- [ ] `pgtrickle.alter_stream_table_query()` supports compatible and
-      rebuildable changes; `explain_alter()` classifies correctly for every DVM
-      support matrix entry
-- [ ] Additive source DDL flows through with no user action; destructive DDL
-      suspends with a named remediation; no path produces silently wrong data
-- [ ] PITR, `pg_basebackup`, replica promotion, `pg_dump`/`pg_restore` and
-      database cloning each covered by an E2E test
-- [ ] `preflight_upgrade()` shipped and referenced from the upgrade runbook
-- [ ] `pg_upgrade` major-version test green with active stream tables and a
-      non-empty change buffer
-- [ ] CDC break-and-repair chaos test: every injected failure is either
-      auto-repaired or suspended with an actionable message
+- [ ] Every supported query and DDL change has a deterministic classification
+- [ ] Compatible plan swaps are proven against the exact state oracle. An
+      unproven change is rebuildable or rejected
+- [ ] Rebuilds use shadow state and atomic replacement. Interruption tests
+      cover every state transition
+- [ ] No destructive DDL can produce silently stale or structurally invalid
+      output
+- [ ] Rename chains, schema moves, recreated objects, dependency OID changes,
+      and extension-upgrade overlap have deterministic tests
+- [ ] Concurrent DDL and refresh histories end by continuing correctly,
+      rebuilding safely, or suspending explicitly

--- a/roadmap/v0.92.0.md
+++ b/roadmap/v0.92.0.md
@@ -1,93 +1,90 @@
-# v0.92.0 — Defaults, Bounds & Diagnosis
+# v0.92.0 — Backup, Restore, Upgrade & CDC Recovery
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"I can confidently run this for years."*
+> **User promise:** *"Backups, upgrades, clones, and capture failures preserve correctness."*
 > **Blocked by:** [v0.91.0](v0.91.0.md)
-> **Renumbered and split:** previously the first half of v0.87.0 "Production
-> Polish". Monitoring integration, assurance testing and packaging moved to
-> [v0.93.0](v0.93.0.md).
+> **Split from:** the former v0.91.0 lifecycle release.
 
 ## Theme
 
-The first of the two final feature releases. The question it answers is not
-"what else can pg_trickle do?" but **"does it behave sensibly without being
-tuned, and does it tell me what went wrong?"**
+Define and test the behavior of persistent stream-table state through backup,
+restore, cloning, upgrade, promotion, and CDC failure. This release is a
+mandatory v1.0 blocker.
 
-Everything here is about defaults, bounds and diagnosis. No new capability, no
-new architecture, no distributed anything.
+Recovery means proving continuity or rebuilding from a known point. Recreating
+a trigger or replication slot is not recovery unless pg_trickle can prove the
+frontier remains valid.
 
 ## Items
 
-### PP-1: Defaults that are right without being tuned
+### LC-3: Backup, restore, and promotion
 
-Ship a zero-config adaptive mode that detects the environment on first start —
-available memory, `max_worker_processes`, CPU count, whether the instance looks
-like a laptop, a modest managed instance, or a large dedicated server — and
-selects a coherent configuration profile rather than a set of independent
-defaults.
+Test each path independently:
 
-The chosen profile is reported (`pgtrickle.active_profile()`), explained in
-`explain()`, and fully overridable. The design constraint: **the out-of-the-box
-configuration should be the right answer for the large majority of installs**,
-and the config advisor should usually have nothing to suggest.
+- `pg_dump` and `pg_restore`
+- `pg_basebackup` and physical restore
+- point-in-time recovery
+- physical replica promotion
+- restore to a host without pg_trickle
+- restore with a different extension version where supported
 
-### PP-2: Bounded resource consumption, proven
+After restore or promotion, pg_trickle validates every frontier and persistent
+operator state against the restored database. A frontier ahead of recoverable
+source history triggers protected reinitialization or suspension. It never
+resumes silently.
 
-Every resource pg_trickle consumes has a documented, enforced ceiling:
+### LC-4: Clone isolation
 
-| Resource | Bound |
-|----------|-------|
-| Memory | `pg_trickle.memory_budget_mb` (v0.87.0), enforced per component |
-| Background workers | `adaptive_workers_min`..`adaptive_workers_max` (v0.90.0) |
-| Disk (change buffers, history, state) | quota with retention policy and alert |
-| WAL generated | reported per source; capture-side reduction measured |
-| CPU share under load | bounded by the backpressure controller (v0.87.0) |
-| Connections | bounded, documented, PgBouncer-compatible |
+Store an explicit database-instance identity for capture ownership. A database
+created from a template, dump, physical copy, or logical copy must detect the
+new identity before capture resumes. A clone cannot consume, overwrite, or
+reuse capture infrastructure that belongs to the source database.
 
-Disk in particular becomes predictable: `pgtrickle.disk_usage()` reports current
-and projected usage per stream table, retention is enforced automatically, and
-`health_check()` warns before the trend crosses available headroom.
+### LC-5: Upgrade preflight and quiescence
 
-### PP-3: Progress reporting
+`pgtrickle.preflight_upgrade()` reports both human-readable details and stable
+machine-readable statuses:
 
-Long operations report progress the way PostgreSQL does, via a
-`pg_stat_progress_pgtrickle`-style view: initial population, FULL refresh,
-rebuild after `ALTER`, reinitialisation after repair. Each reports phase, rows
-processed, rows estimated, and elapsed time. No more staring at a query that
-might be five seconds or five hours from finishing.
+- `BLOCKER` for a condition that makes the upgrade unsafe
+- `DRAIN_RECOMMENDED` for pending work that should finish first
+- `WARNING` for a condition that needs review
+- `SAFE` when no action is required
 
-### PP-4: Error messages that tell you what to do
+The function covers suspended tables, in-flight refreshes, capture health,
+buffer backlog, catalog integrity, persistent state versions, and rebuild disk
+headroom. `pgtrickle.quiesce()` and `pgtrickle.resume_all()` provide a scripted
+upgrade boundary.
 
-An audit of every user-visible error and warning, held to a standard:
+### LC-6: PostgreSQL and extension upgrades
 
-- correct SQLSTATE (the rollout begun in earlier releases is completed)
-- `MESSAGE` states what failed, in the user's vocabulary
-- `DETAIL` gives the specific object, value or limit involved
-- `HINT` gives a concrete next action, and where possible the exact SQL
+CI tests PostgreSQL major upgrades with active stream tables and pending deltas.
+Extension upgrade E2E tests cover every supported source version. Downgrades
+remain unsupported and fail with the rollback runbook named in the error.
 
-Enforced by a CI lint over `ereport!` sites, and by a documented error-code
-reference generated from the source.
+### LC-7: CDC failure classification and recovery
 
-### PP-6: A simple, auditable privilege model
+Every detected capture failure enters one recovery class:
 
-One documented model for who can create, alter, refresh, pause and inspect
-stream tables, expressed with predefined roles (`pg_trickle_admin`,
-`pg_trickle_operator`, `pg_trickle_reader`) rather than a matrix of function
-grants. Includes the RLS interaction, `SECURITY DEFINER` boundaries, and what a
-non-superuser can and cannot do — with tests asserting each boundary.
+| Class | Required action |
+|-------|-----------------|
+| Self-repairable | Repair automatically only when continuity can be proved. |
+| Reinitialization required | Rebuild the result and capture state from a known point before resuming. |
+| Operator intervention required | Suspend with a stable reason code because automatic action could risk correctness or external state. |
 
-This is the user-facing packaging of the explicit ACL matrix enforced in
-[v0.84.0](v0.84.0.md) CAT-81-2, not a second privilege model. If the two
-disagree, v0.84.0 wins and the roles are adjusted to match.
+Tests inject missing triggers, missing slots, unavailable WAL, restored sources,
+corrupt or missing buffers, and interruption during repair. No repair may advance
+an unproven frontier.
 
 ## Exit criteria
 
-- [ ] Zero-config profile selection ships; the config advisor has no suggestions
-      for the standard benchmark environments
-- [ ] Every resource in the bounds table has an enforced ceiling and an alert
-- [ ] Progress view covers all four long operations
-- [ ] Error-message audit complete; CI lint blocks regressions; generated error
-      reference published
-- [ ] Predefined roles shipped, documented, and boundary-tested against the
-      v0.84.0 ACL matrix
+- [ ] Every supported backup, restore, promotion, and clone path has automated
+      E2E coverage
+- [ ] Clone isolation is proven with an explicit database-instance identity
+- [ ] PostgreSQL major-upgrade coverage includes active stream tables and
+      pending deltas
+- [ ] Extension upgrades are tested from every supported source version
+- [ ] Preflight, quiesce, and resume expose stable results suitable for scripted
+      DBA workflows
+- [ ] Every injected CDC failure enters one documented recovery class
+- [ ] No injected failure can resume with an unproven frontier

--- a/roadmap/v0.93.0.md
+++ b/roadmap/v0.93.0.md
@@ -1,78 +1,83 @@
-# v0.93.0 — Monitoring, Assurance & Packaging
+# v0.93.0 — Defaults, Bounds & Diagnosis
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"I can confidently run this for years."*
+> **User promise:** *"I can run this for years without hidden resource or repair behavior."*
 > **Blocked by:** [v0.92.0](v0.92.0.md)
-> **Split from:** the original v0.87.0 "Production Polish".
+> **Renumbered:** previously v0.92.0. Monitoring, assurance, and packaging are
+> in [v0.94.0](v0.94.0.md).
 
 ## Theme
 
-The last feature release before 1.0. The question it answers is **"would a DBA
-recommend this to another DBA?"** — which is decided by whether the thing can be
-monitored, whether it keeps working under sustained abuse, and whether it
-installs in one command.
+Make the default configuration derive from real resource constraints. Define
+which resources pg_trickle can bound, which it can throttle, and which it can
+only forecast and react to. Long operations, errors, and privilege decisions
+must be inspectable through stable interfaces.
 
-After this release the project stops adding features and spends the remaining
-pre-1.0 period on bugs, benchmarks, compatibility, upgrades, docs, real-world
-workloads and simplification.
-
-It is separated from [v0.92.0](v0.92.0.md) because its long-pole item is
-calendar time, not engineering time: a 72-hour soak and a full upgrade
-compatibility matrix cannot be compressed, and pairing them with feature work
-in one release guarantees that either the features or the assurance gets cut.
+This release is part of the mandatory v1.0 operational critical path.
 
 ## Items
 
-### PP-5: Monitoring integration that works out of the box
+### PP-1: Resource-based defaults
 
-- Prometheus exposition covering the full metric set, with a shipped, tested
-  Grafana dashboard and alerting rules for the conditions that actually matter
-  (SLA breach, suspended stream table, CDC lag growth, disk trend, repeated FULL
-  fallback, backlog growth)
-- OpenTelemetry traces (v0.81.0) validated end to end against a real collector
-  in CI, with documented span names and attributes treated as a stable contract
-- `health_check()` as the single "is everything fine?" entry point, with a
-  documented, stable output schema suitable for automation
+Automatic configuration uses available memory, PostgreSQL worker limits, CPU,
+container or cgroup limits when discoverable, connection limits, and the
+configured pg_trickle resource policy. Labels such as `laptop`, `managed`, and
+`dedicated` may explain the selected settings, but labels do not drive the
+decision.
 
-### PP-7: Soak, compatibility and regression gates
+`pgtrickle.active_profile()` and `explain()` report every detected constraint,
+selected value, override, and missing signal. Standard benchmark deployments
+must need no manual tuning.
 
-The testing that turns "it works" into "it keeps working":
+### PP-2: Honest resource guarantees
 
-- **Long-running soak:** 72-hour multi-database run with schema changes,
-  restarts, failure injection and mixed SLAs; zero correctness deviations, no
-  unbounded growth in memory, disk or catalog size
-- **Upgrade compatibility matrix:** every supported source version upgraded to
-  the release under test, on every supported PostgreSQL version, with active
-  workloads, using real old binaries as established in
-  [v0.84.0](v0.84.0.md) CAT-81-6
-- **Performance regression gates:** refresh throughput, write-path overhead
-  (v0.87.0) and TPC-H/Nexmark latencies gate PRs against published baselines
-- **Real-world workload suite:** a small set of realistic application schemas
-  and query shapes, run continuously, as the final sanity check that the
-  synthetic benchmarks are not lying
+Every resource has one documented enforcement class.
 
-The soak and the matrix must both be green on the *same* commit. A green soak
-from an earlier commit does not count.
+| Class | Resources | Behavior |
+|-------|-----------|----------|
+| Hard bound | Extension-managed memory, worker count, retained internal history, internal queue size | Reject or pause work before crossing the configured limit. |
+| Throttled | CPU use, concurrent refreshes, connections | Reduce admission and concurrency while preserving committed changes. |
+| Forecast and react | WAL volume and disk growth caused by continued source activity | Warn, throttle, suspend, or breach freshness deliberately before correctness is at risk. |
 
-### PP-8: Packaging and install experience
+`pgtrickle.disk_usage()` reports current and projected use by stream table.
+`health_check()` warns before forecast growth consumes the configured headroom.
+The documentation does not claim an absolute bound where PostgreSQL or source
+activity prevents one.
 
-Install should be one command on every supported platform, and the extension
-should work immediately afterwards with no configuration:
-PGXN, apt/rpm via PGDG, Docker/GHCR images, CloudNativePG extension image, and a
-documented build-from-source path. Every package is verified by an install-smoke
-test in CI that creates a stream table and asserts it refreshes.
+### PP-3: Progress reporting
+
+A `pg_stat_progress_pgtrickle`-style view reports initial population, FULL
+refresh, rebuild after `ALTER`, and reinitialization after repair. Each row has
+a stable operation identifier, phase, rows processed, estimated rows, elapsed
+time, and last progress timestamp.
+
+### PP-4: Stable error surface
+
+Audit every user-visible error and warning. Each operational condition has a
+stable machine-readable identifier, an accurate SQLSTATE, object-specific
+detail, and an actionable hint. Automation must not parse message text.
+
+A CI check prevents undocumented identifiers and errors without a documented
+remediation from entering SQL-facing code.
+
+### PP-6: Predefined roles
+
+Provide `pg_trickle_admin`, `pg_trickle_operator`, and `pg_trickle_reader` as a
+user-facing mapping onto the ACL and ownership model from v0.84.0. The roles do
+not create a second authorization layer. Positive and negative tests cover each
+lifecycle and diagnostic operation, including RLS and `SECURITY DEFINER`
+boundaries.
 
 ## Exit criteria
 
-- [ ] Grafana dashboard and alert rules shipped and tested; OTel spans validated
-      against a real collector in CI
-- [ ] 72-hour soak green on the release commit
-- [ ] Upgrade matrix green across every supported source version and PostgreSQL
-      version, with active workloads
-- [ ] Performance regression gates active and defended
-- [ ] Install-smoke test green for every published package
-- [ ] **Feature freeze declared.** From this point to v1.0 the project accepts
-      bug fixes, documentation, tests, compatibility work and simplification
-      only. The freeze is enforced by a PR label and a CHANGELOG check, not by
-      good intentions.
+- [ ] Standard benchmark deployments require no manual tuning, and every
+      automatic choice reports its resource evidence
+- [ ] Every resource has a documented enforcement class and a pressure test
+- [ ] Pressure tests degrade by throttling, explicit freshness breach, or
+      suspension without losing committed changes
+- [ ] Progress reporting covers every long-running lifecycle operation
+- [ ] User-facing errors have stable identifiers, SQLSTATEs, details, and
+      actionable hints
+- [ ] Predefined roles match the v0.84.0 ACL matrix and pass positive and
+      negative boundary tests

--- a/roadmap/v0.94.0.md
+++ b/roadmap/v0.94.0.md
@@ -1,0 +1,78 @@
+# v0.94.0 — Monitoring, Assurance & Packaging
+
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"I can monitor, verify, install, and upgrade the supported build."*
+> **Blocked by:** [v0.93.0](v0.93.0.md)
+> **Renumbered:** previously v0.93.0. This is the final feature release.
+
+## Theme
+
+Finish the monitoring contract, run release assurance on one candidate commit,
+and prove that each supported package can install and upgrade. After this
+release, CI enforces the feature freeze.
+
+The 72-hour soak is a release gate. A separate longevity environment looks for
+problems that take longer than one release run to appear. Package readiness is
+based on reproducible artifacts and smoke tests, not a third-party repository's
+acceptance schedule.
+
+## Items
+
+### PP-5: Monitoring integration
+
+- Prometheus exposes the full stable metric set. A shipped Grafana dashboard
+  and alert rules cover SLA breach, suspension, CDC lag growth, disk trend,
+  repeated FULL fallback, and backlog growth.
+- CI validates OpenTelemetry spans from v0.81.0 against a real collector. Span
+  names and attributes are a documented compatibility surface.
+- `health_check()` remains the single operational health entry point and has a
+  stable schema suitable for automation.
+
+### PP-7: Soak, compatibility, and regression gates
+
+- **Release soak:** Run 72 hours across multiple databases with schema changes,
+  restarts, injected failures, and mixed freshness targets. Require zero result
+  deviations and no unbounded memory, disk, or catalog growth.
+- **Upgrade matrix:** Upgrade every supported source version on every supported
+  PostgreSQL version with an active workload and real old binaries.
+- **Performance gates:** Enforce refresh throughput, write-path impact,
+  TPC-H/Nexmark latency, memory, WAL, and CPU regression budgets.
+- **Real workloads:** Run representative application schemas and query shapes
+  continuously so isolated benchmarks do not define release readiness.
+
+The 72-hour soak and upgrade matrix must pass on the same candidate commit.
+
+### PP-7b: Longevity environment
+
+Keep at least one longer-lived deployment running across candidate builds. It
+tracks catalog and retained-state growth, memory creep, repeated repair cycles,
+long-horizon scheduler behavior, WAL amplification, and disk amplification.
+
+The environment informs release readiness. It does not synchronously block
+every commit.
+
+### PP-8: Packaging and install experience
+
+Produce each supported package reproducibly, then run install and upgrade smoke
+tests that create and refresh a stream table. Publication automation must be
+ready for PGXN, apt/rpm via PGDG, Docker/GHCR, CloudNativePG, and source builds.
+
+Third-party repository acceptance may complete asynchronously. It does not
+delay the internal feature freeze when the artifact, smoke tests, and
+publication automation are ready.
+
+## Exit criteria
+
+- [ ] Grafana dashboard and alert rules ship with tests. CI validates OTel
+      against a real collector
+- [ ] The 72-hour soak and full upgrade matrix pass on the same candidate commit
+- [ ] Performance regression gates cover throughput, median, p95, and p99 where
+      useful, memory, WAL, CPU, and foreground write impact
+- [ ] The longevity environment reports no unexplained cumulative growth or
+      repeated recovery loop
+- [ ] Every supported artifact builds reproducibly and passes install and
+      upgrade smoke tests
+- [ ] Publication automation is ready. External repository acceptance is
+      tracked separately
+- [ ] CI enforces the feature freeze after this release

--- a/roadmap/v0.95.x.md
+++ b/roadmap/v0.95.x.md
@@ -1,0 +1,41 @@
+# v0.95.x — Stabilization
+
+> **Status:** Planned
+> **Scope:** Variable
+> **User promise:** *"The release candidate contains less risk, not more scope."*
+> **Blocked by:** [v0.94.0](v0.94.0.md)
+
+## Theme
+
+Hold a stabilization-only release series between the feature freeze and the
+v1.0 release candidates. The goal is to remove risk and prove compatibility.
+Deleting an unstable optimization or making a controller decision more
+conservative is a valid release outcome.
+
+## Allowed work
+
+- correctness and security fixes
+- bugs found by the soak, longevity environment, upgrade matrix, or users
+- compatibility, packaging, and documentation fixes
+- missing tests and clearer diagnostics
+- dependency cleanup and removal of unnecessary configuration
+- performance regression fixes
+- disabling or narrowing optimizer and controller rules that lack evidence
+- explicit rejection of combinations that cannot be supported safely
+
+New SQL functions, catalog capabilities, query coverage, and operational
+features wait until after v1.0.
+
+## Exit criteria
+
+- [ ] No known correctness or security blocker remains
+- [ ] The exact oracle, upgrade matrix, 72-hour soak, package smoke tests, and
+      performance regression gates pass on the release-candidate baseline
+- [ ] Every supported fallback and suspension has a stable reason code and a
+      support-matrix entry
+- [ ] Unstable optimizer or controller decisions are narrowed, disabled, or
+      removed
+- [ ] API, catalog, GUC, monitoring, and package contracts match the frozen
+      v0.94.0 feature surface
+- [ ] Remaining known limitations are documented as explicit v1.0 non-goals or
+      post-v1.0 work

--- a/roadmap/v1.0.0.md-full.md
+++ b/roadmap/v1.0.0.md-full.md
@@ -7,8 +7,17 @@
 **Goal:** First officially supported release. Semantic versioning locks in.
 API, catalog schema, and GUC names are considered stable. Focus is
 distribution and trust: getting pg_trickle onto package registries, shipping
-signed artifacts and SBOMs with provenance, and proving PostgreSQL 19
-forward-compatibility.
+signed artifacts and SBOMs with provenance, and proving the supported
+PostgreSQL 18 lifecycle paths.
+
+The stable contract is:
+
+> Supported query shapes either match PostgreSQL or fall back or suspend with
+> an explicit reason. Schema evolution, backup, restore, cloning, upgrade,
+> restart, and CDC failure have defined and tested behavior. Resource use is
+> bounded, throttled, or reported with a forecast and reaction. Stable
+> monitoring and diagnostic interfaces expose those decisions, and CI gates
+> correctness, upgrades, and performance.
 
 ### The real 1.0 gate
 
@@ -17,11 +26,10 @@ decides whether 1.0 ships is:
 
 > **No known correctness issues, and boring upgrades.**
 
-After the v0.93.0 feature freeze, the project accepts only bug fixes,
-documentation, tests, compatibility work and simplification. The pre-1.0 period
-is spent on **bugs → benchmarks → compatibility → upgrades → docs → real-world
-workloads → simplification** — deliberately not on inventing new feature
-releases to fill the space.
+After the v0.94.0 feature freeze, v0.95.x accepts only bug fixes,
+documentation, tests, compatibility work, packaging, performance regression
+fixes, and simplification. It also narrows or removes unproven optimizer and
+controller behavior before the release-candidate series.
 
 That period is a **release-candidate series**, not a gap. `v1.0.0-rc.1` ships
 when every gate below is believed met; each subsequent `rc.N` ships when a
@@ -38,8 +46,20 @@ promised not to have.
 | G4 | 72-hour soak with schema changes, restarts and failure injection — zero correctness deviations, no unbounded growth. |
 | G5 | Published benchmarks (write-path overhead, refresh throughput, TPC-H/Nexmark) enforced as blocking regression gates. |
 | G6 | Documentation matches reality: every `#[pg_extern]` documented, every user-facing GUC justified, every claim in the README reproducible from a shipped test. |
-| G7 | API, catalog schema and GUC surface frozen; a compatibility test asserts no breaking change versus v0.93.0. |
+| G7 | API, catalog schema, GUC, monitoring, and package surfaces remain compatible with the frozen v0.94.0 feature baseline. |
 | G8 | At least one release candidate has been published and used, with no unresolved blocker reported against it. |
+
+### Explicit non-goals
+
+v1.0 does not require:
+
+- incremental support for every PostgreSQL window frame
+- distributed execution or cross-cluster federation
+- external delta-compute fan-out or object-storage state
+- autonomous control of every execution setting
+- optimal cost-based planning for every DVM operator composition
+- support for every PostgreSQL extension interaction
+- removal of the correctness-preserving FULL fallback
 
 > **Note on effort estimates.** The hour figures below cover release
 > engineering only. G1–G8 are not estimated in hours because they are
@@ -117,4 +137,3 @@ promised not to have.
 - [ ] A3 / PG 19: tracked, but **not** blocking this release
 
 ---
-

--- a/roadmap/v1.7.0.md-full.md
+++ b/roadmap/v1.7.0.md-full.md
@@ -10,7 +10,7 @@
 > This was originally planned for v0.82.0–v0.83.0 (pre-resequencing) and has
 > been moved past 1.0 deliberately. Pre-1.0 effort is better spent making a
 > single PostgreSQL instance go surprisingly far (v0.88.0–v0.89.0) and making
-> the product trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.93.0) than on a second
+> the product trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.95.x) than on a second
 > process most users will never deploy. Everything here remains **strictly
 > optional**: a deployment without external processes continues to work exactly
 > as it does today.

--- a/roadmap/v1.9.0.md-full.md
+++ b/roadmap/v1.9.0.md-full.md
@@ -10,7 +10,7 @@
 > This is explicitly the least certain item on the roadmap. It is recorded here
 > because the design work exists, not because it is committed. It will only be
 > built if real users ask for it — a single PostgreSQL instance, made fast
-> (v0.88.0–v0.89.0) and trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.93.0), covers
+> (v0.88.0–v0.89.0) and trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.95.x), covers
 > the overwhelming majority of the problem pg_trickle exists to solve.
 
 ### Multi-cluster federation


### PR DESCRIPTION
## Summary

- Make lifecycle correctness, recovery, resource protection, and assurance the mandatory v1.0 critical path.
- Gate planner reordering, incremental window coverage, and controller authority on measured correctness and performance evidence.
- Split schema evolution from backup, upgrade, clone, and CDC recovery work.
- Add v0.94.0 as the final feature release and v0.95.x as a stabilization-only series.
- Update the v1.0 contract and mark the v0.88 through v0.90 implementation plans for alignment with the revised roadmap.

## Verification

- `just fmt`
- `just lint`
- `just docs-lint`
- `git diff --check`

No database tests were run because this change only updates planning documents.
