### PR TITLE
Separate the v1.0 lifecycle path from optional tracks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -518,6 +518,11 @@ diagnostics, and a support-matrix entry.
 
 ### Toward v1.0
 
+The mandatory lifecycle path is v0.87.17 → v0.88.0 → v0.91.0 → v0.92.0
+→ v0.93.0 → v0.94.0 → v0.95.x → release candidate → v1.0.0.
+v0.89.0 and v0.90.0 form a parallel performance and product track after
+v0.88.0. Their research and unproven automation do not block lifecycle work.
+
 After v0.94.0 the project stops adding features. v0.95.x is a stabilization-only
 series for bugs, benchmarks, compatibility, upgrades, documentation, real-world
 workloads, and simplification. Unproven optimizer or controller behavior is
@@ -701,25 +706,28 @@ v0.87.16 ─── Versioned row identity V2 engine integration: BYTEA storage, 
 v0.87.17 ─── Versioned row identity V2 hardening and recreation: cross-path gates, benchmarks, non-destructive preflight, stream-table rebuild workflow, consumer resnapshot and privacy controls
 
 v0.88    ─── Safe engine optimization: DiffContext split, narrow vector path, planner instrumentation, shadow planning, evidence-gated reordering
+    ├── Lifecycle critical path
+    │   │
+    │   v0.91    ─── Schema & query evolution: conservative compatibility proof, shadow rebuild, deterministic DDL outcomes
+    │   │
+    │   v0.92    ─── Recovery & upgrades: backup/restore/promotion, clone isolation, upgrade preflight and bounded matrix, proof-based CDC repair
+    │   │
+    │   v0.93    ─── Defaults, bounds & diagnosis: resource-based defaults, honest enforcement classes, progress, stable errors, roles
+    │   │
+    │   v0.94    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, feature freeze
+    │   │
+    │   v0.95.x  ─── Stabilization: blockers, compatibility, tests, docs, packaging, and removal or narrowing of unproven behavior
+    │   │
+    │   v1.0-rc  ─── Release candidates: blockers only, no new features
+    │   │
+    │   v1.0.0   ─── Stability contract: no known correctness issues, boring upgrades, package registries, signed artifacts, SBOMs
     │
-v0.89    ─── Incremental windows, proven subset: bounded crash-safe state, per-algorithm admission, visible recomputation fallback
-    │
-v0.90    ─── Freshness controller: authoritative measurement, advisory decisions, layered resource/SLA/execution control, evidence-gated automation
-    │
-v0.91    ─── Schema & query evolution: conservative compatibility proof, shadow rebuild, deterministic DDL outcomes
-    │
-v0.92    ─── Recovery & upgrades: backup/restore/promotion, clone isolation, upgrade preflight and matrix, proof-based CDC repair
-    │
-v0.93    ─── Defaults, bounds & diagnosis: resource-based defaults, honest enforcement classes, progress, stable errors, roles
-    │
-v0.94    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, feature freeze
-    │
-v0.95.x  ─── Stabilization: blockers, compatibility, tests, docs, packaging, and removal or narrowing of unproven behavior
-    │
-v1.0-rc  ─── Release candidates: blockers only, no new features
-    │
-v1.0.0   ─── Stability contract: no known correctness issues, boring upgrades, package registries, signed artifacts, SBOMs
-    │
+    └── Parallel performance and product track that does not gate lifecycle work
+        │
+        v0.89    ─── Incremental windows, proven subset: bounded crash-safe state, per-algorithm admission, visible recomputation fallback
+        │
+        v0.90    ─── Freshness controller: authoritative measurement, advisory decisions, layered resource/SLA/execution control, evidence-gated automation
+
 v1.6+    ─── Beyond 1.0 (optional/speculative): automatic query acceleration, decoupled compute, distributed deltas + Kubernetes, federation
 ```
 
@@ -1089,14 +1097,15 @@ validates delta-plan alternatives before enabling them. v0.89.0 establishes
 bounded window state, then admits only algorithms that match PostgreSQL and
 beat partition recomputation. Window breadth does not block v1.0.
 
-v0.90.0 makes freshness measurement authoritative and starts the controller in
-advisory mode. Each automatic decision earns authority separately. v0.91.0
-handles defining-query and source-schema evolution. v0.92.0 covers backup,
-restore, cloning, upgrades, and CDC recovery as a separate mandatory gate.
-v0.93.0 defines defaults, resource guarantees, progress, diagnostics, and
-roles. v0.94.0 closes monitoring, soak, compatibility, regression, and package
-gates on one candidate commit, then freezes features. v0.95.x removes risk
-before the release-candidate series.
+On the parallel product track, v0.90.0 makes freshness measurement authoritative
+and starts the controller in advisory mode. Each automatic decision earns
+authority separately. On the lifecycle critical path, v0.91.0 handles
+defining-query and source-schema evolution. v0.92.0 covers backup, restore,
+cloning, upgrades, and CDC recovery as a separate mandatory gate. v0.93.0
+defines defaults, resource guarantees, progress, diagnostics, and roles.
+v0.94.0 closes monitoring, soak, compatibility, regression, and package gates
+on one candidate commit, then freezes features. v0.95.x removes risk before the
+release-candidate series.
 
 **The distributed work has moved past 1.0.** External workers, external CDC
 consumers, Kubernetes operators, distributed delta computation, cross-cluster

--- a/roadmap/v0.88.0.md
+++ b/roadmap/v0.88.0.md
@@ -26,6 +26,13 @@ The v0.87.7 through v0.87.13 lifecycle-security program also lands first. Its
 stream-owner execution boundary applies to every new delta plan and physical
 execution path in this release.
 
+Before MT-8 implementation starts, commit the target benchmark workload, data
+generator and scale, v0.87.17 baseline, measurement method, repetition count,
+hardware profile, and memory and write-path regression budgets. A benchmark
+bug may be fixed later, but the fix requires review and a new baseline. The
+≥5× target applies to this frozen benchmark. Representative end-to-end
+workloads and their regression budgets remain the broader admission test.
+
 This is one of two places where deep complexity is justified, because all of it
 is **inside the engine**. Users get the same extension, the same PostgreSQL, the
 same SQL — just faster. Nothing here changes deployment, topology or the API.
@@ -121,9 +128,9 @@ in this release depends on it.
 - [ ] `DiffContext` decomposed first with no behavioural change in the E2E suite
 - [ ] ADR published deciding the vectorized-aggregate dependency question, and
       the v0.76.0 dependency-removal rationale explicitly addressed
-- [ ] Vectorized aggregate path active for pure-aggregate stream tables with ≥5×
-      throughput on the aggregate benchmark versus v0.87.13, with identical
-      results verified against the FULL oracle
+- [ ] Target benchmark contract committed before MT-8 implementation begins
+- [ ] Vectorized aggregate path active for pure-aggregate stream tables, with
+      identical results verified against the FULL oracle
 - [ ] End-to-end refresh throughput improves on representative workloads with
       no meaningful write-path or memory regression
 - [ ] Planner estimates are compared with actual cardinalities and runtime.

--- a/roadmap/v0.91.0.md
+++ b/roadmap/v0.91.0.md
@@ -3,7 +3,7 @@
 > **Status:** Planned
 > **Scope:** Large
 > **User promise:** *"Production schema and query changes fail safely."*
-> **Blocked by:** [v0.90.0](v0.90.0.md)
+> **Blocked by:** [v0.88.0](v0.88.0.md)
 > **Split:** backup, restore, cloning, upgrades, and CDC recovery moved to
 > [v0.92.0](v0.92.0.md).
 
@@ -15,7 +15,8 @@ a stream table in an ambiguous degraded state.
 
 This release is part of the mandatory v1.0 lifecycle critical path. It stays
 narrow so schema-state design and recovery-state design are reviewed and gated
-separately.
+separately. Incremental-window breadth in v0.89.0 and controller automation in
+v0.90.0 may proceed in parallel; neither blocks this release.
 
 ## Items
 

--- a/roadmap/v0.92.0.md
+++ b/roadmap/v0.92.0.md
@@ -62,6 +62,13 @@ CI tests PostgreSQL major upgrades with active stream tables and pending deltas.
 Extension upgrade E2E tests cover every supported source version. Downgrades
 remain unsupported and fail with the rollback runbook named in the error.
 
+The v1.0 support matrix is bounded to source extension versions v0.40.0 through
+the latest v0.95.x release, on PostgreSQL 18. Before LC-6 implementation starts,
+commit a manifest with every supported source-version and PostgreSQL-major pair.
+Older migration scripts remain chain-checked, but they do not receive full E2E
+support. Later releases publish a new bounded matrix instead of automatically
+carrying every historical source version forward.
+
 ### LC-7: CDC failure classification and recovery
 
 Every detected capture failure enters one recovery class:
@@ -83,7 +90,8 @@ an unproven frontier.
 - [ ] Clone isolation is proven with an explicit database-instance identity
 - [ ] PostgreSQL major-upgrade coverage includes active stream tables and
       pending deltas
-- [ ] Extension upgrades are tested from every supported source version
+- [ ] The checked-in v1.0 support manifest contains only v0.40.0 through the
+      latest v0.95.x release on PostgreSQL 18, and every listed pair passes E2E
 - [ ] Preflight, quiesce, and resume expose stable results suitable for scripted
       DBA workflows
 - [ ] Every injected CDC failure enters one documented recovery class

--- a/roadmap/v0.94.0.md
+++ b/roadmap/v0.94.0.md
@@ -34,8 +34,9 @@ acceptance schedule.
 - **Release soak:** Run 72 hours across multiple databases with schema changes,
   restarts, injected failures, and mixed freshness targets. Require zero result
   deviations and no unbounded memory, disk, or catalog growth.
-- **Upgrade matrix:** Upgrade every supported source version on every supported
-  PostgreSQL version with an active workload and real old binaries.
+- **Upgrade matrix:** Run every pair in the bounded v1.0 support manifest from
+  v0.92.0 with an active workload and real old binaries. For v1.0, this is
+  v0.40.0 through the latest v0.95.x release on PostgreSQL 18.
 - **Performance gates:** Enforce refresh throughput, write-path impact,
   TPC-H/Nexmark latency, memory, WAL, and CPU regression budgets.
 - **Real workloads:** Run representative application schemas and query shapes
@@ -66,7 +67,8 @@ publication automation are ready.
 
 - [ ] Grafana dashboard and alert rules ship with tests. CI validates OTel
       against a real collector
-- [ ] The 72-hour soak and full upgrade matrix pass on the same candidate commit
+- [ ] The 72-hour soak and every pair in the bounded v1.0 upgrade matrix pass on
+      the same candidate commit
 - [ ] Performance regression gates cover throughput, median, p95, and p99 where
       useful, memory, WAL, CPU, and foreground write impact
 - [ ] The longevity environment reports no unexplained cumulative growth or


### PR DESCRIPTION
## Summary

- make v0.91 depend on v0.88 so lifecycle work can proceed without waiting for the v0.89 window-function and v0.90 controller tracks
- freeze the v0.88 aggregate benchmark contract before implementation starts
- bound the v1.0 upgrade matrix to v0.40.0 through the latest v0.95.x release on PostgreSQL 18

## Validation

- `just fmt`
- `just lint`
