### PR TITLE
docs(integration): define refresh and prepared graph contracts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,7 +391,7 @@ and durability foundations that must be proven before v1.0.
 | [v0.79.0](roadmap/v0.79.0.md) | Code Quality, API Ergonomics & Security: remove unused-import suppressions in src/refresh/codegen.rs and src/refresh/merge/mod.rs module-by-module (Q-1), convert internal create/alter API implementations to typed parameter structs eliminating too-many-arguments in business logic (Q-2), replace global #![allow(dead_code)] with narrower per-module allowances on pgrx/export boundaries (Q-3), remove or #[deprecated] consume_slot_changes() replacing with clearly named status function (Q-4), add SQL convenience helpers create_stream_table_fast_append_only/set_stream_table_refresh_policy/set_stream_table_storage_policy (A-1), add first-class pause_stream_table/resume_stream_table wrappers (A-2), add/strengthen semgrep CI rules for dynamic SQL distinguishing identifier/literal/OID boundaries (S-1), emit runtime WARNING when source has RLS enabled at create_stream_table time (S-2), CI test inspecting SECURITY DEFINER trigger functions for SET search_path (S-3), cleanup chaos test forcing three consecutive DELETE failures with alert and status verification (D-3), dbt adapter compatibility matrix with alter/drop/rebuild flow and version matrix tests (T-5) | ✅ Released | Large | [Full details](roadmap/v0.79.0.md-full.md) |
 | [v0.80.0](roadmap/v0.80.0.md) | Operational Excellence, Documentation Completeness & Final v1.0 Gate: add DVM fallback/performance reason codes to refresh history and health output — CORRELATED_SUBQUERY_DELTA_QUADRATIC, CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK, REGEX_COMPLEXITY_CLASSIFIER_UNCERTAIN (O-1), add health_check() threshold alert when invalidation ring overflow count increases in recent time window (O-2), add cleanup backlog trend metrics integrated into pgt_metrics_summary (O-3), docs lint comparing #[pg_extern] exports with SQL_REFERENCE.md entries (DOC-1), create docs/DVM_SUPPORT_MATRIX.md with every query pattern, fallback behavior, IMMEDIATE restrictions, and known-unsupported forms including q12/q20 entries (DOC-2), operational rollback runbook (backup requirements, snapshot recommendation, restore path, why downgrades are unsafe) (U-1), document upgrade E2E cutoff policy prominently in CHANGELOG and release notes (U-2), CI gate documentation in CONTRIBUTING.md describing which workflows gate PRs (B-1), review-by dates on cargo-deny advisory suppressions and require cargo-deny in PR gates (B-2), fuzz test for DVM snapshot fingerprint cache stability under OpTree refactoring (P-5), document internal event trigger functions in ARCHITECTURE comments (A-3) | ✅ Released | Large | [Full details](roadmap/v0.80.0.md-full.md) |
 
-### Product Arc & Hardening Gate (v0.81.0 – v0.95.x)
+### Product Arc & Hardening Gate (v0.81.0 – v0.98.x)
 
 The core thing users are buying is not "distributed incremental computation".
 It is:
@@ -402,11 +402,11 @@ It is:
 
 pg_trickle already has unusually broad SQL coverage, automatic FULL fallback,
 DAGs, repair tooling, observability, PgBouncer support and Citus support. This
-arc stops broadening the feature surface and turns that machinery into a
-polished product, in the order users actually care about: correctness, low
-impact on the primary database, freshness, normal SQL, predictability, easy
-troubleshooting, easy lifecycle, performance, zero babysitting, and a stable
-1.0 API.
+arc turns that machinery into a polished product and adds one bounded
+extension-composition surface, in the order users actually care about:
+correctness, low impact on the primary database, freshness, normal SQL,
+predictability, easy troubleshooting, easy lifecycle, performance, zero
+babysitting, and a stable 1.0 API.
 
 An August 2026 implementation audit after v0.81.0 found unresolved single-node
 correctness and resilience risks. Four releases form a mandatory hardening
@@ -463,7 +463,7 @@ Release scope follows three priority tiers.
 
 | Tier | Commitment |
 |------|------------|
-| Mandatory | DVM correctness, lifecycle security, row identity, schema evolution, backup and restore, clone isolation, upgrades, CDC recovery, resource protection, diagnostics, monitoring, packages, soak tests, compatibility tests, and regression gates must finish before v1.0. |
+| Mandatory | DVM correctness, lifecycle security, row identity, schema evolution, backup and restore, clone isolation, Graph V1 contracts, strict transactional graph refresh, Delta V1, upgrades, CDC recovery, resource protection, diagnostics, monitoring, packages, soak tests, compatibility tests, and regression gates must finish before v1.0. |
 | Scope-flexible | Vectorized aggregates, delta-plan optimization, freshness-driven scheduling, and adaptive workers ship only where their release gates pass without delaying mandatory work. |
 | Optional | Broad incremental-window coverage, complex autonomous policy selection, and unvalidated operator-reordering rules may move past v1.0. Their correctness-preserving fallback remains supported and visible. |
 
@@ -512,23 +512,27 @@ diagnostics, and a support-matrix entry.
 | [v0.90.0](roadmap/v0.90.0.md) | Freshness Controller in Advisory Mode: authoritative freshness measurement, reproducible recommendations, separate resource, scheduling, and per-stream layers, and evidence-gated automation | "Tell me whether my freshness target is feasible and how pg_trickle would meet it." | Planned | Large | [Full details](roadmap/v0.90.0.md) |
 | [v0.91.0](roadmap/v0.91.0.md) | Schema & Query Evolution: conservative defining-query classification, shadow rebuild and atomic swap, deterministic source-DDL handling, and explicit suspension for unsafe changes | "Production schema and query changes fail safely." | Planned | Large | [Full details](roadmap/v0.91.0.md) |
 | [v0.92.0](roadmap/v0.92.0.md) | Backup, Restore, Upgrade & CDC Recovery: tested logical and physical recovery, clone isolation, machine-readable upgrade preflight, major and extension upgrade coverage, and proof-based CDC recovery classes | "Backups, upgrades, clones, and capture failures preserve correctness." | Planned | Large | [Full details](roadmap/v0.92.0.md) |
-| [v0.93.0](roadmap/v0.93.0.md) | Defaults, Bounds & Diagnosis: resource-based defaults, honest hard-bound, throttled, and forecast-and-react guarantees, progress reporting, stable operational error identifiers, and predefined roles | "I can run this for years without hidden resource or repair behavior." | Planned | Large | [Full details](roadmap/v0.93.0.md) |
-| [v0.94.0](roadmap/v0.94.0.md) | Monitoring, Assurance & Packaging: tested Grafana and OTel contracts, same-commit soak and upgrade matrix, performance gates, a longevity environment, reproducible package smoke tests, and the feature freeze | "I can monitor, verify, install, and upgrade the supported build." | Planned | Large | [Full details](roadmap/v0.94.0.md) |
-| [v0.95.x](roadmap/v0.95.x.md) | Stabilization: blockers, compatibility, tests, diagnostics, packaging, documentation, dependency cleanup, and removal or narrowing of unproven optimizer and controller behavior | "The release candidate contains less risk, not more scope." | Planned | Variable | [Full details](roadmap/v0.95.x.md) |
+| [v0.93.0](roadmap/v0.93.0.md) | Graph Contracts & External Ownership: capability discovery, canonical stream-table and graph contracts, durable `EXTERNAL` orchestration mode, and integration authorization | "Coordinating extensions can treat pg_trickle as a versioned incremental component." | Planned | Large | [Full details](roadmap/v0.93.0.md) |
+| [v0.94.0](roadmap/v0.94.0.md) | Strict Transactional Graph Refresh: atomic graph-wide validation, immutable source-boundary manifest, transactional complete graph refresh, and structured node results | "Refresh a private graph atomically inside one transaction with exact boundaries." | Planned | Large | [Full details](roadmap/v0.94.0.md) |
+| [v0.95.0](roadmap/v0.95.0.md) | Durable Typed Output Deltas: typed output-delta relation, consumer registration and cursors, exact-or-invalidation batches, retention and backpressure, and resnapshot | "Consume output changes without private buffers or expensive full scans." | Planned | Large | [Full details](roadmap/v0.95.0.md) |
+| [v0.96.0](roadmap/v0.96.0.md) | Defaults, Bounds & Diagnosis: resource-based defaults, honest hard-bound, throttled, and forecast-and-react guarantees, progress reporting, stable operational error identifiers, and predefined roles | "I can run this for years without hidden resource or repair behavior." | Planned | Large | [Full details](roadmap/v0.96.0.md) |
+| [v0.97.0](roadmap/v0.97.0.md) | Monitoring, Assurance & Packaging: tested Grafana and OTel contracts, same-commit soak and upgrade matrix, performance gates, a longevity environment, reproducible package smoke tests, and the feature freeze | "I can monitor, verify, install, and upgrade the supported build." | Planned | Large | [Full details](roadmap/v0.97.0.md) |
+| [v0.98.x](roadmap/v0.98.x.md) | Stabilization: blockers, compatibility, tests, diagnostics, packaging, documentation, dependency cleanup, and removal or narrowing of unproven optimizer and controller behavior | "The release candidate contains less risk, not more scope." | Planned | Variable | [Full details](roadmap/v0.98.x.md) |
 
 ### Toward v1.0
 
 The mandatory lifecycle path is v0.87.17 → v0.88.0 → v0.91.0 → v0.92.0
-→ v0.93.0 → v0.94.0 → v0.95.x → release candidate → v1.0.0.
+→ v0.93.0 → v0.94.0 → v0.95.0 → v0.96.0 → v0.97.0 → v0.98.x
+→ release candidate → v1.0.0.
 v0.89.0 and v0.90.0 form a parallel performance and product track after
 v0.88.0. Their research and unproven automation do not block lifecycle work.
 
-After v0.94.0 the project stops adding features. v0.95.x is a stabilization-only
+After v0.97.0 the project stops adding features. v0.98.x is a stabilization-only
 series for bugs, benchmarks, compatibility, upgrades, documentation, real-world
 workloads, and simplification. Unproven optimizer or controller behavior is
 narrowed, disabled, or removed rather than carried into the stable contract.
 
-The release-candidate series follows v0.95.x. `v1.0.0-rc.N` ships first, and
+The release-candidate series follows v0.98.x. `v1.0.0-rc.N` ships first, and
 1.0.0 is tagged only after a candidate has been in the field without a new
 blocker. PostgreSQL 19 support is not a 1.0 blocker. PG 19 GA and pgrx support
 are outside this project's control and do not delay the finished PG 18 contract.
@@ -542,8 +546,9 @@ are outside this project's control and do not delay the finished PG 18 contract.
 > preserve. The three row-identity releases add 28 person-weeks for the exact
 > V2 encoding, engine integration, and intentional stream-table recreation
 > workflow before vectorized DVM changes begin. v0.91.0 and v0.92.0 split
-> schema evolution from recovery and upgrade work; v0.94.0 and v0.95.x separate
-> the final assurance gate from the stabilization period.
+> schema evolution from recovery and upgrade work. v0.93.0 through v0.95.0
+> deliver separately gated Graph V1 and Delta V1 contracts; v0.97.0 and
+> v0.98.x separate the final assurance gate from the stabilization period.
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
@@ -712,11 +717,17 @@ v0.88    ─── Safe engine optimization: DiffContext split, narrow vector pa
     │   │
     │   v0.92    ─── Recovery & upgrades: backup/restore/promotion, clone isolation, upgrade preflight and bounded matrix, proof-based CDC repair
     │   │
-    │   v0.93    ─── Defaults, bounds & diagnosis: resource-based defaults, honest enforcement classes, progress, stable errors, roles
+    │   v0.93    ─── Graph contracts & external ownership: capability discovery, canonical contracts, EXTERNAL mode, authorization
     │   │
-    │   v0.94    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, feature freeze
+    │   v0.94    ─── Strict transactional graph refresh: atomic validation, source-boundary manifest, complete graph refresh, node results
     │   │
-    │   v0.95.x  ─── Stabilization: blockers, compatibility, tests, docs, packaging, and removal or narrowing of unproven behavior
+    │   v0.95    ─── Durable typed output deltas: typed batches, consumer cursors, exact-or-invalidation semantics, resnapshot
+    │   │
+    │   v0.96    ─── Defaults, bounds & diagnosis: resource-based defaults, honest enforcement classes, progress, stable errors, roles
+    │   │
+    │   v0.97    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, feature freeze
+    │   │
+    │   v0.98.x  ─── Stabilization: blockers, compatibility, tests, docs, packaging, and removal or narrowing of unproven behavior
     │   │
     │   v1.0-rc  ─── Release candidates: blockers only, no new features
     │   │
@@ -1025,7 +1036,7 @@ Operational runbooks for upgrade rollback and the upgrade E2E cutoff policy,
 CI gate documentation for contributors, and cargo-deny advisory review-by
 dates complete the pre-v1.0 checklist.
 
-**v0.81.0 through v0.95.x form the Product Arc.** The engine is sound after 16
+**v0.81.0 through v0.98.x form the Product Arc.** The engine is sound after 16
 assessment arcs, though the post-v0.81.0 implementation audit found correctness
 and resilience gaps that require explicit closure first. What is missing beyond
 those gaps is not capability but product: the machinery is broad, and the
@@ -1102,11 +1113,13 @@ On the parallel product track, v0.90.0 makes freshness measurement authoritative
 and starts the controller in advisory mode. Each automatic decision earns
 authority separately. On the lifecycle critical path, v0.91.0 handles
 defining-query and source-schema evolution. v0.92.0 covers backup, restore,
-cloning, upgrades, and CDC recovery as a separate mandatory gate. v0.93.0
-defines defaults, resource guarantees, progress, diagnostics, and roles.
-v0.94.0 closes monitoring, soak, compatibility, regression, and package gates
-on one candidate commit, then freezes features. v0.95.x removes risk before the
-release-candidate series.
+cloning, upgrades, and CDC recovery as a separate mandatory gate. v0.93.0 adds
+canonical contracts and durable external ownership; v0.94.0 completes Graph V1
+with strict transactional refresh. v0.95.0 independently gates durable typed
+output deltas. v0.96.0 defines defaults, resource guarantees, progress,
+diagnostics, and roles. v0.97.0 closes monitoring, soak, compatibility,
+regression, and package gates on one candidate commit, then freezes features.
+v0.98.x removes risk before the release-candidate series.
 
 **The distributed work has moved past 1.0.** External workers, external CDC
 consumers, Kubernetes operators, distributed delta computation, cross-cluster

--- a/plans/PLAN_0_90_0.md
+++ b/plans/PLAN_0_90_0.md
@@ -134,7 +134,7 @@ transaction, or frontier finalizer.
 - A new alert transport. Use health rows, logs, existing NOTIFY alerts,
   Prometheus, and OpenTelemetry.
 - Removing a control whose replacement remains advisory. Unproven replacements
-  keep their override through the v0.94 feature freeze.
+  keep their override through the v0.97 feature freeze.
 
 ## 2. Baseline and gap map
 

--- a/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
+++ b/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
@@ -1,0 +1,1220 @@
+# Proposal: V1 Composable Refresh and Durable Delta Contracts for `pg_trickle`
+
+## Strict transactional graph refresh and durable typed output deltas for coordinating PostgreSQL extensions
+
+**Status:** Proposed  
+**Scope:** V1 only. Appendix A is non-normative and does not affect V1 acceptance.  
+**Target:** Additive pre-1.0 integration contract  
+**Decision:** Add a small, versioned SQL surface that lets another PostgreSQL extension coordinate a private stream-table graph without depending on `pg_trickle` internals  
+**Compatibility:** Existing stream tables remain scheduler-managed by default, and existing public APIs retain their behavior  
+**Motivating consumer:** [`pg_mdm`](https://github.com/grove/pg-mdm), beginning with its V1 entity-resolution design  
+**Baseline reviewed:** `pg_trickle` 0.90.0 at commit [`a6a53e0`](https://github.com/trickle-labs/pg-trickle/commit/a6a53e0f6697eed4407a664b1af5172ca137fd9c)  
+**Last updated:** 2026-09-01
+
+---
+
+## Contents
+
+1. [Executive decision](#1-executive-decision)
+2. [V1 release boundary](#2-v1-release-boundary)
+3. [Motivation](#3-motivation)
+4. [Goals and non-goals](#4-goals-and-non-goals)
+5. [Relationship to `pg_mdm`](#5-relationship-to-pg_mdm)
+6. [Existing `pg_trickle` foundations](#6-existing-pg_trickle-foundations)
+7. [Terminology](#7-terminology)
+8. [Required invariants](#8-required-invariants)
+9. [Proposed V1 surface](#9-proposed-v1-surface)
+10. [Capability discovery](#10-capability-discovery)
+11. [Durable external orchestration](#11-durable-external-orchestration)
+12. [Canonical stream-table and graph contracts](#12-canonical-stream-table-and-graph-contracts)
+13. [Strict transactional graph refresh](#13-strict-transactional-graph-refresh)
+14. [Source-boundary manifest](#14-source-boundary-manifest)
+15. [Durable output-delta consumers](#15-durable-output-delta-consumers)
+16. [V1 end-to-end protocol](#16-v1-end-to-end-protocol)
+17. [Security and authorization](#17-security-and-authorization)
+18. [Concurrency and transaction semantics](#18-concurrency-and-transaction-semantics)
+19. [Failure and recovery behavior](#19-failure-and-recovery-behavior)
+20. [Stable errors](#20-stable-errors)
+21. [Suggested catalog and storage changes](#21-suggested-catalog-and-storage-changes)
+22. [Integration with the refresh engine](#22-integration-with-the-refresh-engine)
+23. [Lifecycle interactions](#23-lifecycle-interactions)
+24. [Observability and administration](#24-observability-and-administration)
+25. [Performance and resource behavior](#25-performance-and-resource-behavior)
+26. [Upgrade and compatibility policy](#26-upgrade-and-compatibility-policy)
+27. [Delivery plan](#27-delivery-plan)
+28. [Test plan](#28-test-plan)
+29. [Alternatives considered](#29-alternatives-considered)
+30. [Risks and open implementation choices](#30-risks-and-open-implementation-choices)
+31. [Acceptance criteria](#31-acceptance-criteria)
+32. [Recommended disposition](#32-recommended-disposition)
+33. [Appendix A: high-level V2 needs](#appendix-a-high-level-v2-needs)
+
+---
+
+## 1. Executive decision
+
+`pg_trickle` should expose a generic composition contract for trusted PostgreSQL extensions that use stream tables as a relational computation layer but must publish a larger domain result under their own transaction and governance rules. The first consumer is `pg_mdm`, which wants `pg_trickle` to maintain normalized values, candidate blocks, candidate pairs, pair evidence, and golden-value candidates while `pg_mdm` remains responsible for clustering, stewardship, stable entity identifiers, reviews, provenance, and public MDM publication. The contract is intentionally domain-neutral and should also be usable by graph resolvers, policy engines, feature stores, search-index coordinators, and other extensions that need incrementally maintained relational facts without surrendering their own publication boundary.
+
+The V1 contract contains six closely related capabilities. `pg_trickle` advertises integration capabilities and their versions; exposes canonical stream-table and graph contracts with stable digests; provides a durable `EXTERNAL` orchestration mode that excludes private graphs from the ordinary scheduler; refreshes a complete graph synchronously and strictly inside the caller's PostgreSQL transaction; returns one coherent source-boundary manifest for that refresh; and exposes durable, acknowledged, typed output deltas for selected terminal stream tables. Together, these capabilities let another extension refresh relational evidence, consume exactly what changed, update its own durable state, acknowledge the evidence, and commit or roll back all effects together.
+
+This proposal does not add MDM concepts to `pg_trickle`, and it does not expose private `pg_trickle` implementation state. `pg_trickle` continues to own source capture, safe frontiers, differential view maintenance, full fallback, stream-table storage, row identity, dependency ordering, and refresh finalization. The coordinating extension continues to own domain-specific decisions and public outputs. No supported integration path reads or mutates private catalogs, scheduler jobs, change buffers, generated columns, internal frontier encodings, or storage naming conventions.
+
+---
+
+## 2. V1 release boundary
+
+This document is a V1 proposal. Its acceptance boundary is a synchronous, single-database composition path in which the coordinating extension keeps one PostgreSQL transaction open while `pg_trickle` refreshes the private graph and the coordinator publishes its own result. V1 supports acyclic local stream-table graphs, complete source-boundary proofs for the source kinds accepted by the graph, exact output deltas when available, explicit full invalidation when an exact output delta is unavailable, owner-controlled durable cursors, and fail-closed behavior under concurrency, recovery, schema change, or retention loss.
+
+The following capabilities are required for V1 and form one compatibility promise:
+
+| Capability | V1 purpose |
+|---|---|
+| Versioned capability discovery | Refuse unsupported extension combinations before state is created or refreshed |
+| Canonical stream-table and graph contracts | Prove that the graph being refreshed is the graph the coordinator compiled and approved |
+| Durable `EXTERNAL` orchestration | Prevent independent scheduler advancement of a privately coordinated graph |
+| Strict transactional graph refresh | Refresh the complete graph in dependency order with no notice-and-skip outcome |
+| Source-boundary manifest | Name the exact, coherent source positions represented by the refreshed graph |
+| Durable typed output deltas | Let a coordinator consume and acknowledge changed terminal rows without private-buffer access |
+
+V1 does not include multi-transaction graph computation, resumable graph refresh, concurrent immutable graph states, background graph execution, cross-database graphs, distributed transaction coordination, arbitrary post-refresh callbacks, semantic business events, a stable Rust ABI, or external message delivery. Appendix A describes the V2 multi-transaction need at a high level so that V1 choices do not accidentally block it, but none of that appendix is normative and none of it may delay V1 acceptance.
+
+---
+
+## 3. Motivation
+
+The current `pg_trickle` public API is designed primarily for users who create a stream table and allow `pg_trickle` to keep it fresh. That remains the correct ordinary product. The API is not quite sufficient when another extension creates several private stream tables as one internal graph and must coordinate that graph with additional domain state in the same transaction.
+
+The existing [`refresh_stream_table()`](../src/api/refresh_ops.rs) function refreshes one stream table and returns `void`. A concurrent refresh becomes a `RefreshSkipped` condition that the human-facing wrapper turns into a notice and a successful no-op. That behavior is convenient for an operator issuing an opportunistic refresh, but it is unsafe for a coordinating extension. Such a caller must distinguish “the complete graph was refreshed at this exact boundary” from “another operation was busy and nothing happened,” and it needs a stable group identifier, actual graph digest, source-boundary manifest, per-node result, and terminal delta positions rather than reconstructing those facts from private tables.
+
+The existing [`pause_scheduler()`](../src/api/scheduler_control.rs) function is also not a durable orchestration contract. It is an operational drain control whose state and purpose are separate from stream-table semantic ownership. A graph coordinated by another extension must remain outside scheduler dispatch after process restart, scheduler restart, failover, backup, restore, and extension upgrade. An accidental independent refresh is not merely a freshness difference: it can separate relational evidence from the higher-level membership, policy, or publication revision that is supposed to consume it.
+
+The existing [`stream_table_spec()`](../src/api/spec.rs) function provides useful tooling metadata, but its present projection is not a complete semantic compatibility artifact. A coordinator must pin every result-affecting property, including defining-query semantics, output schema, owner execution identity, defining search path, dependency shape, source bindings, function dependencies, collations, row-identity and probe versions, and versioned semantic plans. It needs a canonical digest that changes when meaning changes but remains stable when only indexes, statistics, worker counts, or other physical choices change.
+
+Finally, `pg_trickle` already computes logical output changes internally for stream-table-to-stream-table dependencies. The current architecture captures differential output and can compute a before-and-after logical difference for supported full paths so downstream stream tables remain incremental. Those internal buffers are deliberately private. A coordinating extension needs the same logical information through a supported contract: complete old and new rows grouped into immutable batches, a durable consumer cursor, transactional acknowledgement, and an explicit `FULL_INVALIDATION` marker when an exact delta is not available.
+
+The missing feature is therefore not another dataflow engine. It is a narrow, stable composition boundary around machinery that already exists inside `pg_trickle`.
+
+---
+
+## 4. Goals and non-goals
+
+### 4.1 Goals
+
+The contract should let a trusted coordinating extension treat a `pg_trickle` graph as a versioned incremental component. A successful operation must answer four questions precisely: which graph was executed, which source state it represents, what each graph node did, and which terminal output changes remain for the coordinator to consume. The coordinator must then be able to write its own state and acknowledge those changes in the same PostgreSQL transaction.
+
+The contract must preserve encapsulation. Public consumers should not know whether source changes came from statement triggers, row triggers, WAL decoding, snapshot comparison, or a later capture adapter. They should not know whether output deltas are stored in a dedicated heap, a partitioned relation, or a future log representation. They should observe versioned contracts, a strict graph result, an opaque but complete boundary manifest, a typed logical delta relation, and durable acknowledgements.
+
+The contract must fail closed. A busy graph, stale contract digest, incomplete source boundary, missing output history, incompatible output schema, unknown row-identity version, authorization failure, or invalid acknowledgement must raise a stable error before the coordinator can mistake incomplete work for a valid refresh. Operational limits may block or reject work, but they may not silently skip evidence or advance a consumer cursor.
+
+The contract should remain useful beyond `pg_mdm`. Its nouns are stream table, graph, contract, boundary, output delta, batch, and consumer. It does not mention entities, matches, golden records, clusters, or any other domain-specific concept.
+
+### 4.2 Non-goals
+
+V1 does not allow a caller to construct, edit, advance, or repair a source frontier. `pg_trickle` remains the sole authority for source visibility and completeness. The caller receives a source-boundary manifest as evidence of what was consumed, but cannot feed arbitrary positions back as refresh instructions.
+
+V1 does not expose private change-buffer relations. The implementation may reuse them, replace them, partition them, compact them, or introduce a different representation. Only the logical batch, typed row relation, acknowledgement, and gap behavior are public.
+
+V1 does not execute arbitrary extension callbacks from the refresh engine. The coordinator invokes `pg_trickle` through SQL and remains responsible for its subsequent domain work. This avoids an open-ended callback ABI, recursion policy, security boundary, and failure-isolation problem.
+
+V1 does not publish domain events, deliver messages to external systems, replace PostgreSQL logical replication, or provide a Kafka, NATS, HTTP, or outbox transport. A coordinating extension may publish its completed domain result through another mechanism after its local transaction commits.
+
+V1 does not support circular integration graphs, cross-database graphs, distributed transaction coordination, or multi-transaction graph execution. Those capabilities require separate semantics and proofs rather than hidden expansion of this contract.
+
+---
+
+## 5. Relationship to `pg_mdm`
+
+The motivating architecture has a simple responsibility boundary:
+
+> **`pg_trickle` maintains changing relational facts; `pg_mdm` decides identity.**
+
+A `pg_mdm` definition compiles into private stream tables that project source records, normalize fields, create bounded candidate blocks, produce canonical candidate pairs, compare those pairs, maintain structured pair evidence, and maintain golden-value candidates. `pg_mdm` then consumes changes from the terminal evidence relations, computes the complete affected identity closure, applies manual decisions and component rules, reconciles durable `mdm_id` values, selects golden values, creates review items, and publishes its own output tables.
+
+The V1 dependency maps directly to this proposal:
+
+| `pg_mdm` requirement | `pg_trickle` contract |
+|---|---|
+| Verify that the installed substrate supports the required behavior | Capability discovery |
+| Pin the private evidence graph to the compiled entity definition | Stream-table and graph contracts |
+| Prevent evidence from advancing independently of MDM publication | `EXTERNAL` orchestration |
+| Refresh the complete evidence graph inside `mdm.refresh()` | Strict transactional graph refresh |
+| Explain which source state the publication represents | Source-boundary manifest |
+| Recompute only affected identity components when safe | Durable typed output deltas |
+| Broaden safely when exact incremental impact is unavailable | `FULL_INVALIDATION` |
+| Roll everything back if MDM validation or publication fails | Shared outer transaction and transactional acknowledgement |
+
+Nothing in the SQL surface assumes that `pg_mdm` is installed. `pg_mdm` is a conformance consumer and a useful end-to-end test, not a dependency of `pg_trickle`.
+
+---
+
+## 6. Existing `pg_trickle` foundations
+
+This proposal is feasible because most of the difficult engine behavior already exists. `pg_trickle` maintains stream tables from declarative SQL, captures source changes through trigger and WAL paths, computes differential or full results, orders dependent stream tables through a graph, retains version frontiers, and finalizes output, frontiers, downstream change capture, cleanup, and refresh history transactionally. The current architecture also executes defining SQL under the stored stream-table owner and search-path contract, which is essential when a privileged coordinator invokes the engine.
+
+Stream-table-to-stream-table propagation already creates logical delete and insert rows for downstream consumers. A differential upstream refresh can expose its computed delta, while a supported full upstream refresh can compare old and new contents before propagating a minimal downstream difference. The V1 output-delta contract should reuse that logical algebra, but it must not make the current private buffer schema or naming convention public.
+
+The versioned row-identity work also provides a strong foundation. A public output delta needs an opaque identity that is exact, deterministic, and consistent across full and differential paths. The integration contract should expose the active row-identity version and complete identity bytes for comparison and ordering while leaving parsing optional and separately versioned.
+
+The main implementation work is therefore orchestration and stabilization: expose canonical contracts, add durable external ownership, refactor graph refresh into a strict structured path, and create a supported durable cursor over logical output changes.
+
+---
+
+## 7. Terminology
+
+A **coordinating extension** is a trusted PostgreSQL extension or database component that owns or has owner-equivalent authority over a set of stream tables and invokes this contract through SQL. PostgreSQL roles, object ownership, grants, and extension membership remain the security boundary; the contract does not attempt to authenticate a shared-library filename.
+
+A **stream-table contract** is the canonical, versioned description of one stream table's result-affecting semantics and execution identity. It is distinct from operational status, recent timings, planner statistics, scheduler tier, physical indexes, and other tuning state.
+
+A **refresh graph** is the transitive closure of stream-table dependencies reachable upstream from one or more named root stream tables. Base tables, materialized views, foreign or polled relations, and other non-stream sources appear in the graph contract as sources, but they are not refreshable graph members.
+
+A **graph contract** is the canonical description and digest of the roots, member stream tables, dependency edges, deterministic topological order, output schemas, semantic versions, execution identities, and external source bindings that form one refresh graph.
+
+A **source-boundary manifest** is an immutable, machine-readable statement of the lower and upper positions, snapshot tokens, upstream stream-table revisions, completeness classes, and source-contract digests consumed by one graph refresh. Position payloads are versioned and may remain opaque to callers.
+
+A **strict graph refresh** is one synchronous execution of a refresh graph against one immutable source-boundary decision. It may use differential, full, scoped-recomputation, reinitialization, or no-data paths per member, but every member result belongs to the same graph refresh and outer transaction.
+
+An **output-delta batch** is the logical change in one stream table's visible contents produced by one committed refresh. An exact batch contains complete deleted rows and inserted rows. An update is represented as deletion of the complete old row followed by insertion of the complete new row. A full-invalidation batch states that the consumer must read the complete current stream table because an exact logical delta is unavailable.
+
+An **output-delta consumer** is a durable, role-owned cursor over the output-delta batches of one stream table. Reading is side-effect free. Acknowledgement is explicit, monotonic, validated, and transactional.
+
+---
+
+## 8. Required invariants
+
+The V1 contract is governed by the following invariants. These are stronger than any suggested catalog layout, function spelling, or Rust module structure.
+
+1. **One outer transaction.** `refresh_graph_strict()` performs no internal commit. Graph contents, node frontiers, refresh history, output-delta batches, the coordinator's own writes, and consumer acknowledgements commit or roll back with the caller's PostgreSQL transaction.
+
+2. **Graph-wide validation before mutation.** The complete stream-table closure is resolved, authorized, locked, reloaded, and compared with the expected graph digest before any member is refreshed.
+
+3. **One immutable source-boundary decision.** Every graph member receives positions derived from the same graph-refresh context. No node may independently reread and substitute a newer upper boundary.
+
+4. **Strict concurrency.** A competing refresh, query alteration, storage recreation, repair, or drop operation on any graph member produces an error or waits according to ordinary PostgreSQL lock policy. It is never converted into a successful skipped refresh.
+
+5. **Semantic contract pinning.** A refresh result names the graph digest and each member contract digest actually used. Unknown contract, semantic-plan, output-schema, row-identity, row-probe, or source-boundary versions fail closed.
+
+6. **Exact delta or explicit invalidation.** A consumer receives either the complete logical output difference for a batch or an explicit `FULL_INVALIDATION` marker. Missing rows, truncated rows, expired rows, and fallback paths never masquerade as an empty exact batch.
+
+7. **Transactional acknowledgement.** A delta cursor advances only when `ack_output_delta()` commits. If the coordinator later raises an error, both its domain publication and the acknowledgement roll back.
+
+8. **Retention follows the slowest consumer.** Exact delta rows remain available until every active external consumer has acknowledged them or has been explicitly moved to a resynchronization-required state. Resource pressure cannot silently advance a cursor.
+
+9. **External means externally orchestrated.** The ordinary scheduler does not queue, inline, fuse, or execute a stream table whose orchestration mode is `EXTERNAL`. This remains true across process restart and database recovery.
+
+10. **Owner-equivalent execution.** Defining SQL continues to execute under the stored stream-table owner and defining search-path contract. The integration API grants no authority over source data, current output, or retained deleted rows beyond the authority explicitly checked for the caller.
+
+11. **Public contract, private implementation.** A caller may use only the documented capability, contract, refresh, boundary, consumer, batch, and acknowledgement APIs, together with the generated read-only delta relation returned by registration. It may not derive or depend on private relation names, internal catalog identifiers, LSN placeholders, frontier JSON, or change-buffer schemas.
+
+12. **No silent recovery.** If crash recovery, backup restore, PITR, manual DDL, storage loss, or an unsupported upgrade makes exact output history unverifiable, the consumer becomes `RESNAPSHOT_REQUIRED`. Repair may reconstruct infrastructure, but it may not invent a continuous exact history that no longer exists.
+
+13. **Full and differential equivalence.** For the same starting output, defining contracts, source boundary, and row-identity versions, any exact output delta must transform the prior stream-table multiset into the same result as complete evaluation of the defining query at that boundary.
+
+---
+
+## 9. Proposed V1 surface
+
+The exact SQL spelling may change during implementation review, but the following behavior is the proposal. Once capability major version 1 is declared stable, changing these semantics requires a new capability version rather than an undocumented function change.
+
+| Extension point | Purpose |
+|---|---|
+| `pgtrickle.integration_capabilities()` | Discover independently versioned integration contracts |
+| `pgtrickle.stream_table_contract()` | Return the canonical contract and digest for one stream table |
+| `pgtrickle.graph_contract()` | Return the canonical closure and digest for one refresh graph |
+| `pgtrickle.set_orchestration_mode()` | Persist `MANAGED` or `EXTERNAL` ownership of refresh scheduling |
+| `pgtrickle.refresh_graph_strict()` | Refresh a complete external graph synchronously and transactionally |
+| `pgtrickle.register_output_delta_consumer()` | Register a durable cursor over one stream table's logical output changes |
+| `pgtrickle.output_delta_batches()` | Inspect the continuous batch sequence after the acknowledged cursor |
+| Returned typed delta relation | Read complete old and new rows for exact batches |
+| `pgtrickle.ack_output_delta()` | Acknowledge an exact or resynchronized range transactionally |
+| `pgtrickle.output_delta_consumer_status()` | Inspect lag, retention, contract, and recovery state |
+| Resnapshot helpers | Establish a new full baseline under a transaction-scoped output lock |
+
+---
+
+## 10. Capability discovery
+
+A coordinating extension should negotiate behavior by capability rather than parsing the `pg_trickle` package version. Release versions remain useful for support, but one release may add several independent contracts, a distribution may backport one capability, and a later release may preserve an older contract alongside a newer one.
+
+The proposed API is:
+
+```sql
+SELECT *
+FROM pgtrickle.integration_capabilities();
+```
+
+An illustrative result is:
+
+```text
+capability                       major_version  minor_version  enabled  details
+-------------------------------  -------------  -------------  -------  --------------------
+stream_table_contract            1              0              true     {...}
+graph_contract                   1              0              true     {...}
+external_orchestration           1              0              true     {...}
+transactional_graph_refresh      1              0              true     {...}
+source_boundary_manifest         1              0              true     {...}
+output_delta_consumer            1              0              true     {...}
+```
+
+The function returns one row per capability:
+
+```sql
+pgtrickle.integration_capabilities()
+RETURNS TABLE (
+    capability       text,
+    major_version    smallint,
+    minor_version    smallint,
+    enabled          boolean,
+    details          jsonb
+)
+```
+
+A major version changes normative behavior or representation and requires explicit consumer support. A minor version is additive: it may add optional fields, supported source kinds, diagnostics, or admission limits without changing existing required fields or guarantees. A caller requires an exact supported major and may require a minimum minor. An absent or disabled capability is unsupported even when the package version appears recent enough.
+
+The `details` object may report supported PostgreSQL majors, row-identity versions, maximum graph members, accepted source kinds, typed-delta encoding versions, and whether exact full-refresh deltas are available on particular execution paths. Normative behavior belongs in the capability version and documentation, not in free-form details. The function should be inexpensive, side-effect free, and executable by `PUBLIC` because it reveals product capabilities rather than protected relation definitions or data.
+
+---
+
+## 11. Durable external orchestration
+
+### 11.1 Catalog-backed mode
+
+Every stream table gains a durable orchestration mode:
+
+```text
+MANAGED   ordinary pg_trickle scheduler behavior
+EXTERNAL  the ordinary scheduler never dispatches this stream table
+```
+
+`MANAGED` remains the default so existing installations behave exactly as before. `EXTERNAL` is orthogonal to lifecycle status. An external stream table may be active, suspended, initializing, or in error, but an active external table advances only through the strict graph API defined here. The ordinary human-oriented `refresh_stream_table()` function should reject an external table with a stable externally-managed error rather than bypass the coordinator.
+
+An illustrative dedicated API is:
+
+```sql
+SELECT pgtrickle.set_orchestration_mode(
+    stream_table => 'mdm_internal.customer_pair_evidence_v3'::regclass,
+    mode         => 'EXTERNAL'
+);
+```
+
+Creation and bulk creation should also accept the mode through their structured options so a private graph is never briefly scheduler-managed between creation and alteration. The exact parameter placement is not normative; the durable catalog value and scheduler semantics are.
+
+### 11.2 Transition behavior
+
+Changing from `MANAGED` to `EXTERNAL` acquires the normal lifecycle and refresh locks. It waits for or conflicts with in-flight work according to the caller's `lock_timeout`, and the scheduler rechecks orchestration mode under the same row-lock discipline used to claim a refresh. Once the mode change commits, no scheduler job accepted under stale managed state may remain able to publish afterward.
+
+Changing from `EXTERNAL` to `MANAGED` is rejected while a strict graph refresh holds the node, while an output resnapshot lock is active, or while schedule configuration is invalid for managed execution. The operation does not acknowledge external consumers, drop retained history, or imply that an external coordinator has accepted the latest output.
+
+### 11.3 Relationship to scheduler pause
+
+`pause_scheduler()` remains a transient operational control. It is useful for draining or maintenance but is not a correctness mechanism for extension composition. An external stream table may still appear in global drain and health reporting, but it is already ineligible for scheduler dispatch because of durable catalog state.
+
+### 11.4 Immediate mode
+
+Capability version 1 rejects `EXTERNAL` orchestration for `IMMEDIATE` stream tables. Immediate maintenance is driven by source DML triggers inside source transactions and cannot be placed under a separate graph coordinator without a different consistency model. Coordinating extensions should use differential or full-capable modes and invoke strict graph refresh explicitly.
+
+---
+
+## 12. Canonical stream-table and graph contracts
+
+### 12.1 Stream-table contract API
+
+The proposed stream-table contract API is:
+
+```sql
+SELECT *
+FROM pgtrickle.stream_table_contract(
+    'mdm_internal.customer_pair_evidence_v3'::regclass
+);
+```
+
+```sql
+pgtrickle.stream_table_contract(stream_table regclass)
+RETURNS TABLE (
+    contract_version smallint,
+    contract_digest  bytea,
+    contract         jsonb
+)
+```
+
+The contract contains everything that can change the logical contents of the stream table, the interpretation of its row identity, or the database identity under which defining SQL runs. At minimum it includes the schema-qualified stream-table identity and current relation binding; normalized defining-query and original-query digests; owner role, defining search path, and result-affecting row-security execution policy; ordered output schema with PostgreSQL type, typmod, collation, and nullability; row-identity and row-probe versions; versioned rewrite and DVM strategies that can affect logical output; tracked function and extension dependencies; source and stream-table dependencies; source schema or contract fingerprints; and the durable orchestration mode.
+
+The contract excludes physical indexes, planner statistics, recent costs, worker counts, scheduler tier, batch sizes, cached plans, and other choices that may affect performance but are not allowed to affect meaning. A storage or plan optimization may therefore preserve the digest when it provably enumerates the same logical result.
+
+An illustrative object is:
+
+```json
+{
+  "contract_version": 1,
+  "stream_table": "mdm_internal.customer_pair_evidence_v3",
+  "relation_identity": {"oid": 48122, "database_lineage": "sha256:..."},
+  "execution_identity": {
+    "owner": "mdm_owner",
+    "defining_search_path_digest": "sha256:...",
+    "row_security_policy": "OWNER_EQUIVALENT"
+  },
+  "query": {
+    "original_digest": "sha256:...",
+    "normalized_digest": "sha256:...",
+    "semantic_plan_digest": "sha256:..."
+  },
+  "output_schema": {
+    "digest": "sha256:...",
+    "columns": [
+      {"name": "left_record_id", "type": "bytea", "nullable": false},
+      {"name": "right_record_id", "type": "bytea", "nullable": false},
+      {"name": "evidence", "type": "jsonb", "nullable": false}
+    ]
+  },
+  "row_identity_version": 2,
+  "row_probe_version": 1,
+  "dependency_digest": "sha256:...",
+  "function_dependency_digest": "sha256:...",
+  "orchestration_mode": "EXTERNAL",
+  "contract_digest": "sha256:..."
+}
+```
+
+Every canonicalization rule and digest algorithm is part of the contract version. Human-readable optional fields may be added, but the document must identify which fields are normative digest inputs.
+
+### 12.2 Graph contract API
+
+The proposed graph API is:
+
+```sql
+SELECT *
+FROM pgtrickle.graph_contract(
+    roots => ARRAY[
+        'mdm_internal.customer_pair_evidence_v3'::regclass,
+        'mdm_internal.customer_golden_candidates_v3'::regclass
+    ]
+);
+```
+
+```sql
+pgtrickle.graph_contract(roots regclass[])
+RETURNS TABLE (
+    contract_version smallint,
+    graph_digest      bytea,
+    contract          jsonb
+)
+```
+
+The graph object contains the canonical root set, complete upstream stream-table closure, each member contract digest, dependency edges, deterministic topological order, external source descriptors, and one digest of the complete graph contract. Duplicate roots are rejected. Capability version 1 rejects cycles even when ordinary `pg_trickle` supports a separately governed monotone-cycle mode, because a strict external contract needs explicit fixed-point and delta semantics before cycles can be admitted.
+
+The graph digest changes when a root or member is added, removed, replaced, rebound, or semantically altered. It does not change merely because an index is rebuilt, statistics change, or a different worker count would be used by ordinary managed scheduling. A graph contract is descriptive rather than a lock. `refresh_graph_strict()` re-resolves and revalidates the graph under the locks it acquires; a digest read earlier is an optimistic expectation, not permission to skip current validation.
+
+---
+
+## 13. Strict transactional graph refresh
+
+### 13.1 Proposed API
+
+The core refresh API is:
+
+```sql
+SELECT *
+FROM pgtrickle.refresh_graph_strict(
+    roots                       => ARRAY[
+        'mdm_internal.customer_pair_evidence_v3'::regclass,
+        'mdm_internal.customer_golden_candidates_v3'::regclass
+    ],
+    expected_graph_digest       => decode(:graph_digest_hex, 'hex'),
+    require_complete_boundaries => true,
+    full_policy                 => 'ALLOW'
+);
+```
+
+An illustrative signature is:
+
+```sql
+pgtrickle.refresh_graph_strict(
+    roots                       regclass[],
+    expected_graph_digest       bytea,
+    require_complete_boundaries boolean DEFAULT true,
+    full_policy                 text DEFAULT 'ALLOW'
+)
+RETURNS pgtrickle.graph_refresh_result
+```
+
+The returned composite contains at least:
+
+```text
+contract_version        smallint
+graph_refresh_id        bigint
+graph_digest            bytea
+source_boundary         jsonb
+source_boundary_digest  bytea
+node_results            jsonb
+terminal_delta_tokens   jsonb
+```
+
+`full_policy` has two initial values. `ALLOW` permits any correct full or reinitialization fallback selected by the existing engine. `ERROR` rejects a member that cannot remain on an incremental or scoped-recomputation path and is intended for diagnostics or tightly controlled workloads. The policy never forces an unsafe incremental plan.
+
+### 13.2 Resolution and locking
+
+The implementation performs the following logical sequence:
+
+1. Resolve the roots and compute the complete upstream stream-table closure.
+2. Reject duplicate roots, unsupported cycles, temporary relations, cross-database references, `IMMEDIATE` members, and members not in `EXTERNAL` orchestration mode.
+3. Verify that the caller is authorized to refresh every member.
+4. Sort members by a canonical database-local lock key and acquire every advisory, lifecycle, and catalog-row lock before refreshing any member.
+5. Reload every member under lock, recompute the graph contract, and compare it with `expected_graph_digest`.
+6. Allocate one graph-refresh identifier and one immutable graph-refresh context.
+7. Compute one source-boundary decision for every external source used by the graph.
+8. Refresh members synchronously in deterministic topological order, passing the immutable context to each member.
+9. Finalize node state and output-delta batches through the same transactional finalizer used by ordinary refresh paths.
+10. Return the structured result while transaction-scoped locks remain held.
+
+Any failure raises an error. The API never returns a partial list of successful members. The first implementation executes in the calling backend and does not dispatch work to independent background workers. It may reuse bounded internal batching and temporary relations as long as all effects remain within the caller's outer transaction.
+
+### 13.3 Transaction semantics
+
+The function performs no commit. Calling it in autocommit mode is valid, but a coordinating extension obtains composition semantics by invoking it inside its own function or explicit transaction and performing domain work before commit. Stream-table data changes, frontiers, history, output-delta batches, cleanup, group metadata, the coordinator's writes, and acknowledgements therefore commit or roll back together.
+
+The function returns only after every member has completed and finalized or one member has caused the call to fail. Internal savepoints may be used for bounded cleanup, but they do not create progressive visibility or an independently committed successful subset. A no-data path remains a strict execution: it validates contracts, locks, source boundaries, and output-log health before returning `NO_DATA`.
+
+### 13.4 Coherent source boundary
+
+The graph-refresh context contains one immutable upper-bound decision for local CDC sources and one validated position or snapshot token for every other supported source. A source shared by several graph members appears once in the manifest, and every member consumes the same upper boundary. No member may call a current-position helper again and substitute a newer value.
+
+For local trigger or WAL sources, the position is the safe durable boundary already governed by `pg_trickle` frontier invariants. For an upstream stream table inside the graph, the downstream member consumes the output state and delta produced earlier in the same topological refresh. For a materialized view or polling source, the manifest identifies the snapshot-comparison boundary and its completeness. A remote or distributed source is accepted only when its provider can prove that data and position belong to one complete boundary.
+
+When `require_complete_boundaries` is true, an unknown, partial, unverifiable, or missing boundary aborts the graph refresh. A later minor contract may permit explicitly non-proven boundaries for generic consumers, but a consumer that requests complete boundaries must never receive a successful result with hidden uncertainty.
+
+### 13.5 Result schema
+
+An illustrative `node_results` entry is:
+
+```json
+{
+  "mdm_internal.customer_pair_evidence_v3": {
+    "refresh_id": 8124,
+    "contract_digest": "sha256:...",
+    "action": "DIFFERENTIAL",
+    "result_class": "INCREMENTAL",
+    "rows_inserted": 41,
+    "rows_deleted": 7,
+    "data_timestamp": "2026-09-01T18:02:11.531Z",
+    "frontier": {"version": 1, "opaque": "..."},
+    "row_identity_version": 2,
+    "row_probe_version": 1,
+    "output_delta": {
+      "batch_token": 5502,
+      "mode": "EXACT",
+      "row_count": 48
+    }
+  }
+}
+```
+
+`result_class` is a small stable normalization such as `NO_DATA`, `INCREMENTAL`, or `FULL`. `action` may expose a more specific versioned engine path such as differential, full, reinitialize, TopK, or partition recomputation. Consumers should use the stable class for control flow and retain the detailed action for diagnosis.
+
+Reported row counts are exact or `NULL` with a machine-readable quality field. An estimate must never be presented as an exact inserted or deleted count. A no-data member may still advance a validated observation frontier, but its exact output-delta batch contains zero rows.
+
+### 13.6 Busy behavior
+
+The strict API never converts a lock conflict into a notice and successful return. If another refresh, alteration, repair, restore, or drop operation owns any member, the call waits according to PostgreSQL lock rules or raises a stable graph-busy error when the caller's `lock_timeout` or no-wait policy is reached. The ordinary `refresh_stream_table()` API may retain its existing notice-and-skip behavior for backward compatibility.
+
+---
+
+## 14. Source-boundary manifest
+
+The source-boundary manifest is a first-class versioned result rather than an informal timestamp. A suggested shape is:
+
+```json
+{
+  "manifest_version": 1,
+  "graph_refresh_id": 1208,
+  "captured_at": "2026-09-01T18:02:10.992Z",
+  "database_identity": {
+    "system_identifier_digest": "sha256:...",
+    "database_oid": 16384
+  },
+  "completeness": "PROVEN",
+  "sources": [
+    {
+      "relation": "crm.customer",
+      "kind": "LOCAL_TABLE",
+      "source_contract_digest": "sha256:...",
+      "capture_mode": "TRIGGER",
+      "position": {
+        "version": 1,
+        "kind": "WAL_LSN_RANGE",
+        "lower": "0/16B6A90",
+        "upper": "0/16D0200"
+      },
+      "completeness": "PROVEN"
+    },
+    {
+      "relation": "registry.company_snapshot",
+      "kind": "MATERIALIZED_VIEW",
+      "source_contract_digest": "sha256:...",
+      "capture_mode": "SNAPSHOT_COMPARE",
+      "position": {
+        "version": 1,
+        "kind": "SNAPSHOT_TOKEN",
+        "token": "opaque-provider-value"
+      },
+      "completeness": "PROVEN"
+    }
+  ]
+}
+```
+
+The manifest has an authoritative digest returned separately. Callers store the object for explanation but treat individual source positions as opaque unless another capability explicitly documents them. A caller may not construct a replacement manifest, edit an upper position, or feed historical boundary JSON back into ordinary refresh as an instruction.
+
+The database identity binds graph results and delta tokens to one database lineage so a token copied from a restored clone or another database cannot be mistaken for live state in the current database. The exact lineage identifier may be protected or hashed, but token validation must include it.
+
+A boundary manifest states completeness, not merely recency. A timestamp saying when a refresh ran is not proof that every relevant source change was included. When a source cannot provide a complete boundary under the requested contract, the graph refresh fails before publication.
+
+---
+
+## 15. Durable output-delta consumers
+
+### 15.1 Overview
+
+A terminal stream table is useful to another extension only when the extension can identify its logical changes without querying private `changes_pgt_*` relations. The V1 consumer contract records one shared logical output log per opted-in stream table and one durable acknowledgement position per consumer. The log is created only when at least one external consumer exists, so ordinary stream tables pay no output-log storage or write cost.
+
+The output delta describes changes to the stream table itself, not raw source events. It is independent of whether the producing refresh was differential, scoped recomputation, reinitialization, or full. An exact batch transforms the previous visible stream-table multiset into the new visible multiset. If row identity remains the same while non-identity values change, the batch contains a `DELETE` carrying the complete old row followed by an `INSERT` carrying the complete new row.
+
+### 15.2 Registration
+
+The proposed registration API is:
+
+```sql
+SELECT *
+FROM pgtrickle.register_output_delta_consumer(
+    stream_table             => 'mdm_internal.customer_pair_evidence_v3'::regclass,
+    consumer_name            => 'pg_mdm/customer/v3/pair-evidence',
+    expected_contract_digest => decode(:stream_contract_digest_hex, 'hex'),
+    start_position           => 'CURRENT'
+);
+```
+
+```sql
+pgtrickle.register_output_delta_consumer(
+    stream_table             regclass,
+    consumer_name            text,
+    expected_contract_digest bytea,
+    start_position           text DEFAULT 'CURRENT'
+)
+RETURNS pgtrickle.output_delta_consumer_registration
+```
+
+The registration result contains:
+
+```text
+consumer_id                uuid
+stream_table               regclass
+consumer_name              text
+delta_relation             regclass
+acknowledged_batch_token   bigint
+output_contract_digest     bytea
+row_identity_version       smallint
+state                      text
+```
+
+`CURRENT` creates the cursor at the latest completed batch and claims no earlier history. It is appropriate when the coordinator already has a matching baseline or when the stream table is newly created and unpopulated. A coordinator that does not already possess a matching baseline registers in `RESNAPSHOT_REQUIRED` mode and establishes one through the resnapshot protocol before claiming current state.
+
+Registration is transactional and idempotent for `(stream_table, owner_role, consumer_name)` only when the expected digest and options are identical. A conflicting registration raises an error rather than silently altering an existing cursor. The function creates or references one shared typed output log for the stream table and returns a read-only relation through which the consumer can read exact rows. Callers use the returned `regclass`; they do not derive its physical name.
+
+### 15.3 Typed delta relation
+
+The generated relation has this logical schema:
+
+```text
+batch_token       bigint   NOT NULL
+ordinal           bigint   NOT NULL
+action            text     NOT NULL  -- DELETE | INSERT
+row_identity      bytea    NOT NULL
+<stream-table output columns, preserving PostgreSQL types>
+```
+
+The relation preserves the stream table's user-visible PostgreSQL types and contains complete old values for `DELETE` and complete new values for `INSERT`. Private generated columns are not exposed, except for the opaque canonical `row_identity` needed to pair and order changes. The relation is read only. Its physical name and implementation are not stable; the returned relation identity and logical schema remain valid for the lifetime of the consumer contract.
+
+Rows are ordered by `(batch_token, ordinal)`. Ordinals are deterministic within a batch, and deletion precedes insertion for a same-identity update. Consumers may page within the relation, but acknowledgement remains batch-granular so a partially read batch cannot be discarded accidentally.
+
+The recommended initial implementation uses one protected typed output-log table per stream table and one security-controlled read-only view per consumer. The output log is distinct from the private stream-table-to-stream-table buffer so this public contract does not freeze an existing internal schema. A later physical implementation may share storage when it preserves the same public behavior, types, retention, and upgrade boundary.
+
+### 15.4 Batch metadata
+
+Consumers inspect batches through:
+
+```sql
+SELECT *
+FROM pgtrickle.output_delta_batches(
+    consumer_id   => :consumer_id,
+    through_token => :terminal_batch_token
+);
+```
+
+```sql
+pgtrickle.output_delta_batches(
+    consumer_id   uuid,
+    through_token bigint DEFAULT NULL
+)
+RETURNS TABLE (
+    batch_token             bigint,
+    producing_refresh_id    bigint,
+    graph_refresh_id        bigint,
+    mode                    text,
+    row_count               bigint,
+    rows_inserted           bigint,
+    rows_deleted            bigint,
+    output_contract_digest  bytea,
+    row_identity_version    smallint,
+    source_boundary_digest  bytea,
+    created_at              timestamptz
+)
+```
+
+The result begins after the consumer's acknowledged token and ends at `through_token`, or at the newest retained token when no upper token is supplied. It returns a continuous ordered sequence or raises a delta-gap error. It never silently omits an unavailable batch.
+
+The initial modes are:
+
+| Mode | Meaning |
+|---|---|
+| `EXACT` | The typed delta relation contains the complete logical delete and insert rows for the batch; an exact batch may contain zero rows |
+| `FULL_INVALIDATION` | An exact logical row delta is unavailable; the consumer must read the complete current stream table at the transactionally stable graph result before acknowledging |
+
+A differential refresh produces an exact batch when the output log is healthy. A full refresh produces an exact batch when the refresh path already has a complete before-and-after logical difference. Otherwise it produces `FULL_INVALIDATION`. V1 does not require `pg_trickle` to perform an additional unbounded full-table diff solely to satisfy an external consumer. Initial population may be represented as exact insertions when already materialized, but invalidation is always a permitted truthful result.
+
+### 15.5 Reading and acknowledgement
+
+A V1 coordinator reads the graph result, selects batch metadata through the terminal token returned for the relevant root, and follows one of two paths. If every batch in the range is exact, it reads the typed relation through that token and applies the logical changes. If the range contains a full invalidation, it reads the complete current terminal stream table while the strict graph transaction still holds a stable graph state and runs its full reference computation.
+
+Acknowledgement is explicit:
+
+```sql
+SELECT pgtrickle.ack_output_delta(
+    consumer_id   => :consumer_id,
+    through_token => :terminal_batch_token,
+    disposition   => 'APPLIED'
+);
+```
+
+`disposition` is `APPLIED` when all acknowledged batches were exact and the consumer applied their rows. It is `RESYNCHRONIZED` when the range contained an invalidation and the consumer rebuilt from the complete terminal table. `APPLIED` is rejected for a range containing `FULL_INVALIDATION`. The acknowledgement is monotonic, validates the output contract and row-identity version, and updates the durable cursor in the caller's transaction.
+
+Reading never acknowledges. Acknowledging an already acknowledged token is an idempotent no-op only when it belongs to the same consumer, output contract, and database lineage. Acknowledging beyond the newest visible token, across a gap, across an invalid contract, or out of order raises a stable error.
+
+### 15.6 Resnapshot protocol
+
+A consumer that lacks a matching baseline or loses exact history enters `RESNAPSHOT_REQUIRED`. It establishes a new baseline through a transaction-scoped protocol:
+
+```sql
+SELECT *
+FROM pgtrickle.begin_output_delta_resnapshot(:consumer_id);
+
+-- Read the complete stream table returned by the status record and rebuild
+-- consumer-owned state while the transaction-scoped output lock is held.
+
+SELECT pgtrickle.ack_output_delta_resnapshot(
+    consumer_id    => :consumer_id,
+    resnapshot_token => :resnapshot_token
+);
+```
+
+The begin call returns the stream table, stable output batch token, contract digest, row-identity version, and one-use token. It locks the output against refresh or semantic change until transaction end. The acknowledgement advances the cursor to that stable token and moves the consumer to `ACTIVE`. A rollback leaves the cursor and consumer state unchanged.
+
+### 15.7 Consumer lifecycle
+
+A consumer has one of these states:
+
+```text
+ACTIVE
+PAUSED
+RESNAPSHOT_REQUIRED
+INVALIDATED
+DROPPED
+```
+
+`ACTIVE` means a continuous exact-or-invalidation sequence exists after the cursor. `PAUSED` retains history but rejects acknowledgement and is an operator control. `RESNAPSHOT_REQUIRED` means exact retained history was lost, deliberately expired, or made unverifiable by recovery. `INVALIDATED` means the stream-table semantic or output contract changed and the consumer must be recreated or explicitly rebound after a new baseline. `DROPPED` may remain only in audit history.
+
+A semantic or output-changing `ALTER QUERY` is rejected while active consumers exist under capability version 1. `pg_mdm` avoids in-place mutation by creating a new private graph for each entity-definition version. Dropping a stream table requires dropping or explicitly cascading its consumers. Dropping a consumer is authorization-checked and may allow retained rows to be cleaned immediately.
+
+### 15.8 Retention and backpressure
+
+The output log is retained through the minimum acknowledged batch among active consumers. Internal downstream stream-table consumers continue to use their private frontier contract; an implementation may combine retention minima physically, but neither public cursor is represented as the other.
+
+The default V1 retention behavior is fail closed. A slow consumer may retain substantial data, and `pg_trickle` must expose row, byte, batch, and age lag. If writing another exact batch would exceed a configured hard resource limit, the refresh fails before unacknowledged history is lost. An administrator may explicitly move a consumer to `RESNAPSHOT_REQUIRED`, record the gap boundary and reason, and then permit cleanup. Silent expiration is never allowed.
+
+Output logs required by active consumers are logged and crash-safe. Loss of a log sentinel, batch metadata, typed relation, or continuity proof changes affected consumers to `RESNAPSHOT_REQUIRED`; it is never interpreted as no changes.
+
+---
+
+## 16. V1 end-to-end protocol
+
+The complete composition pattern is:
+
+```sql
+BEGIN;
+
+-- The coordinating extension stored this digest when it created or activated
+-- its private graph definition.
+SELECT *
+INTO TEMP TABLE _graph_result
+FROM pgtrickle.refresh_graph_strict(
+    roots                       => ARRAY[
+        'mdm_internal.customer_pair_evidence_v3'::regclass,
+        'mdm_internal.customer_golden_candidates_v3'::regclass
+    ],
+    expected_graph_digest       => decode(:expected_graph_digest, 'hex'),
+    require_complete_boundaries => true,
+    full_policy                 => 'ALLOW'
+);
+
+-- Inspect the exact batch sequence through the terminal token returned above.
+SELECT *
+FROM pgtrickle.output_delta_batches(
+    consumer_id   => :pair_consumer_id,
+    through_token => :pair_terminal_token
+)
+ORDER BY batch_token;
+
+-- Read exact typed rows from the consumer's returned delta relation, or scan
+-- the complete terminal stream table when FULL_INVALIDATION is present.
+
+-- Perform domain-specific work. pg_trickle does not know this schema.
+SELECT mdm_internal.resolve_and_publish_customer(
+    graph_refresh_id       => :graph_refresh_id,
+    source_boundary        => :source_boundary,
+    source_boundary_digest => :source_boundary_digest
+);
+
+-- Acknowledge only after the domain result has been validated and written.
+SELECT pgtrickle.ack_output_delta(
+    consumer_id   => :pair_consumer_id,
+    through_token => :pair_terminal_token,
+    disposition   => :pair_disposition
+);
+
+SELECT pgtrickle.ack_output_delta(
+    consumer_id   => :golden_consumer_id,
+    through_token => :golden_terminal_token,
+    disposition   => :golden_disposition
+);
+
+COMMIT;
+```
+
+If domain resolution, clustering, validation, public-table DML, or acknowledgement raises an error, the transaction rolls back. Private stream tables return to their previous contents, node frontiers do not advance, graph and node refresh records do not commit, newly written output-delta batches disappear, and consumer cursors remain unchanged. The next invocation can repeat the complete operation without reconciling a half-published boundary.
+
+The coordinator does not need to block new source writes for the duration of the transaction. `pg_trickle` captures a safe upper boundary and leaves later committed changes pending for the next refresh. The important property is not that the database stops changing; it is that every graph member and every domain output in this transaction refers to the same named boundary.
+
+---
+
+## 17. Security and authorization
+
+The composition API is intended for trusted in-database coordinators, but it must not create a privilege-escalation path. Mutating functions should not be executable by `PUBLIC` by default. Installation may create a predefined integration role, or administrators may grant the relevant functions directly to the dedicated owner role used by the coordinating extension.
+
+`refresh_graph_strict()` must verify ownership or a narrowly documented owner-equivalent maintenance privilege for every member in the graph closure. Capability version 1 should require one effective owner across the graph because mixed-owner execution complicates authorization, RLS, retained deleted rows, and lifecycle coordination. Defining queries continue to execute under each stream table's stored owner identity and defining search path rather than the invoker's accidental session context.
+
+Output-delta registration, reading, resnapshot, acknowledgement, pause, and deletion should be restricted to the stream-table owner or superuser in V1. This avoids a subtle information leak from deleted rows retained in output history, because ordinary table RLS cannot reliably be reevaluated against a row that no longer exists. A later delegated-consumer design would require explicit row filters, masking rules, and retained-row policy rather than an informal grant.
+
+Every `SECURITY DEFINER` entry point must use a fixed safe `search_path`, resolve objects through PostgreSQL catalogs, distinguish identifiers from values in generated SQL, and avoid exposing private relation names to unauthorized callers. Consumer and resnapshot tokens are references only after authorization; knowledge of a UUID is not authority.
+
+---
+
+## 18. Concurrency and transaction semantics
+
+### 18.1 Lock ordering
+
+Strict graph refresh resolves the complete closure and acquires all graph-member locks in one canonical order before executing the first member. The order must be independent of root-array order and shared with alter, repair, drop, resnapshot, and orchestration-mode transitions so that callers do not create lock-order cycles. Source relation locks required by a full baseline follow the existing source-lock protocol and are acquired in deterministic relation order.
+
+### 18.2 Scheduler interaction
+
+An `EXTERNAL` member is ineligible for scheduler dispatch. The scheduler must inspect the durable mode under the same lock discipline used to claim work so an already queued stale job cannot publish after a mode transition. Global drain or shutdown may observe external work, but it does not take ownership of the graph.
+
+### 18.3 Source writes
+
+Ordinary source writes continue while strict graph refresh runs unless an existing full-refresh path deliberately acquires source locks for snapshot alignment. The immutable source-boundary context determines which committed changes belong to the current refresh. Later changes remain in source capture for the next operation.
+
+### 18.4 Caller transaction
+
+The first implementation is synchronous in the caller's backend. It does not detach work into a background process and does not release graph locks before the caller either commits or rolls back. The coordinator must therefore size V1 entities for the documented single-transaction operating envelope and set `statement_timeout`, `lock_timeout`, memory, and temporary-space policy knowingly.
+
+### 18.5 Isolation level
+
+The API must work correctly under PostgreSQL's documented transaction isolation behavior and must not assume that a caller happened to start `REPEATABLE READ`. `pg_trickle` owns source-boundary construction and uses its required snapshots and locks internally. If a particular source adapter requires a stronger isolation or snapshot capability, admission fails unless the engine can establish it safely.
+
+---
+
+## 19. Failure and recovery behavior
+
+A failed strict graph refresh leaves no committed member subset, frontier advancement, output batch, cleanup, or successful group record. A failure later in the coordinator's transaction also rolls those effects back. The ordinary PostgreSQL error becomes the synchronization mechanism: there is no second compensation protocol for a transaction that never committed.
+
+A backend crash or server restart during an uncommitted strict refresh relies on PostgreSQL crash recovery. After recovery, graph storage and frontiers reflect the last committed state. Any stale operational `RUNNING` marker used for diagnosis may be marked failed by existing startup logic, but it must not be treated as evidence that output or frontiers committed.
+
+Output-log integrity is durable control state. On startup, restore, or repair, `pg_trickle` validates consumer catalog rows, output-log relation identity, required columns and types, contract versions, sentinels, batch continuity, and acknowledged positions. Missing or unverifiable history moves the consumer to `RESNAPSHOT_REQUIRED`. The system does not synthesize an empty batch or silently jump the cursor.
+
+A semantic contract change invalidates active consumers rather than reinterpreting retained rows. A physical-only change may preserve the contract and consumer continuity when validation proves the typed output relation and logical ordering remain unchanged. A dropped and recreated database clone has a different lineage identity, so copied tokens are rejected even when relation OIDs happen to match.
+
+`repair_stream_table()` may rebuild triggers, buffers, or derived storage, but it cannot repair an exact external history that has been lost. Its result must state whether consumers remain active, require resnapshot, or were invalidated by the repair.
+
+---
+
+## 20. Stable errors
+
+The integration API should use `pg_trickle`'s structured error machinery and expose a stable integration identifier in diagnostic detail. Callers must not parse free-form English messages. The precise SQLSTATE may follow the extension's established policy, but the following identifiers should be stable within capability major version 1:
+
+| Error identifier | Meaning |
+|---|---|
+| `PGT_EXT_CONTRACT_UNSUPPORTED` | A required capability or contract version is unavailable |
+| `PGT_EXT_GRAPH_INVALID` | Roots do not form a supported externally orchestrated graph |
+| `PGT_EXT_CONTRACT_MISMATCH` | Current stream-table or graph contract differs from the expected digest |
+| `PGT_EXT_REFRESH_BUSY` | Another operation owns a required graph member |
+| `PGT_EXT_BOUNDARY_UNAVAILABLE` | A complete coherent source boundary cannot be proved |
+| `PGT_EXT_NODE_FAILED` | One graph member could not produce a complete result |
+| `PGT_EXT_CONSUMER_BLOCKED` | Consumer integrity, schema, authorization, or retention state prevents consumption |
+| `PGT_EXT_DELTA_GAP` | The requested continuous batch range is not retained or cannot be proved |
+| `PGT_EXT_TOKEN_INVALID` | Consumer, batch, or resnapshot token is unknown, altered, cross-database, or belongs to another object |
+| `PGT_EXT_ACK_OUT_OF_ORDER` | Acknowledgement would move backward, skip an unapproved range, or use the wrong disposition |
+| `PGT_EXT_AUTHORIZATION` | Caller is not authorized for the graph or consumer |
+| `PGT_EXT_RESNAPSHOT_REQUIRED` | Exact history is unavailable and a full baseline is required |
+| `PGT_EXT_ORCHESTRATION_MODE` | The requested operation conflicts with `MANAGED` or `EXTERNAL` ownership |
+
+Each error names the affected graph, stream table, source, or consumer when disclosure is authorized, states the consequence, and includes one concrete next action. A strict refresh error is never downgraded to a notice. A retention or continuity error is never represented as an empty exact batch.
+
+---
+
+## 21. Suggested catalog and storage changes
+
+This section is illustrative rather than a required physical schema. The public behavior above is normative; internal names and normalization may change.
+
+### 21.1 Stream-table orchestration
+
+A durable column on the stream-table catalog records the mode:
+
+```sql
+ALTER TABLE pgtrickle.pgt_stream_tables
+ADD COLUMN orchestration_mode text NOT NULL DEFAULT 'MANAGED'
+    CHECK (orchestration_mode IN ('MANAGED', 'EXTERNAL'));
+```
+
+The catalog should also retain the contract version or enough semantic metadata to build and validate the contract deterministically. A cached digest may be stored as an optimization, but it must be invalidated by every result-affecting DDL, function, owner, search-path, source-binding, and semantic-plan change.
+
+### 21.2 Graph refresh records
+
+A graph refresh needs one identity that links member refreshes and output batches:
+
+```text
+pgt_graph_refreshes
+  graph_refresh_id
+  owner_role
+  graph_digest
+  source_boundary
+  source_boundary_digest
+  roots
+  started_at
+  completed_at
+  status
+  error_code
+```
+
+Successful rows commit with the graph transaction. A failed transaction may leave no durable row because rollback is authoritative; failures remain visible to the caller and logs, and the coordinating extension may record them in its own operation history.
+
+### 21.3 Output consumers and batches
+
+A small logged catalog records consumer state:
+
+```text
+pgt_output_delta_consumers
+  consumer_id
+  stream_table_id
+  owner_role
+  consumer_name
+  output_contract_digest
+  row_identity_version
+  acknowledged_batch_token
+  state
+  resnapshot_reason
+  created_at
+  acknowledged_at
+```
+
+Batch metadata is also logged:
+
+```text
+pgt_output_delta_batches
+  stream_table_id
+  batch_token
+  producing_refresh_id
+  graph_refresh_id
+  mode
+  row_count
+  rows_inserted
+  rows_deleted
+  output_contract_digest
+  row_identity_version
+  source_boundary_digest
+  created_at
+```
+
+The payload is stored once per opted-in stream table in a protected typed relation. Consumer-specific views or access predicates may expose the shared rows without duplicating payload. Batch tokens are monotonically increasing within one stream-table output log and remain opaque outside the documented ordering and acknowledgement contract.
+
+### 21.4 Resnapshot state
+
+A resnapshot token may be represented as a signed or catalog-backed one-use record bound to consumer, database lineage, stream-table identity, output contract, stable batch token, owner, and transaction. Its implementation must prevent replay against another consumer or later incompatible contract. No long-lived application secret is required; PostgreSQL authorization remains primary.
+
+---
+
+## 22. Integration with the refresh engine
+
+The strict graph API should call the same validated execution and common-finalizer code used by scheduler and manual refresh paths. The main refactoring is to separate the engine result from the current human-facing wrapper so a strict caller receives `Result<GraphRefreshResult, PgTrickleError>` rather than a notice on `RefreshSkipped`.
+
+The scheduler already computes dependency-aware execution units and database-local source bounds. The strict path can create one execution unit for the requested closure, capture one immutable boundary context, acquire deterministic locks, and invoke existing member refresh machinery in topological order. It should not synthesize sequential calls to the public `refresh_stream_table()` wrapper because that would repeat boundary decisions, lose group identity, and retain notice-and-skip semantics.
+
+The contract builder can reuse stream-table metadata, dependency catalogs, defining-query hashes, owner execution state, row-identity and row-probe versions, function fingerprints, collation validation, source schema fingerprints, and versioned strategy fields already present in the system. A dedicated canonicalization module should define digest inputs, with independent fixtures so an incidental JSON serialization refactor cannot change a contract silently.
+
+Output-delta batch creation belongs in the common finalizer. A member frontier must not commit without the corresponding promised batch metadata and exact payload or `FULL_INVALIDATION` marker. Differential output can reuse the logical D+I relation already produced by the engine. Supported full paths can reuse their existing before-and-after diff. Other full paths write invalidation metadata rather than an incomplete payload.
+
+The external output log should remain distinct from private downstream buffers in capability version 1. This slightly increases write amplification for opted-in stream tables but preserves a clean public boundary and permits private buffer evolution. Shared physical storage may be considered later only after the public cursor, type, retention, and upgrade semantics are fixed.
+
+---
+
+## 23. Lifecycle interactions
+
+### 23.1 Create and bulk create
+
+A coordinating extension normally creates an immutable private graph with `orchestration_mode = 'EXTERNAL'` and `initialize = false`, computes and stores its graph digest, registers consumers on terminal nodes, and performs first population through `refresh_graph_strict()`. Bulk creation should validate all names, ownership, modes, and graph constraints before making any member visible.
+
+### 23.2 Alter query and storage recreation
+
+A stream table with active output consumers cannot undergo a semantic or output-contract change in place under capability version 1. The caller creates a new stream table or graph version, registers new consumers, establishes a new baseline, activates the corresponding higher-level definition, and later removes the old graph after its audit or explanation horizon is satisfied.
+
+Operational alterations that do not change the stream-table contract, such as supported index maintenance or statistics updates, may proceed when they do not conflict with an active refresh. The contract digest remains unchanged only when semantic equivalence is proven.
+
+### 23.3 Suspend, resume, and repair
+
+Suspending an external stream table blocks strict graph refresh but does not transfer it to the scheduler. Resuming makes it explicitly refreshable again. Repair validates contracts and output-log continuity and reports whether consumers remain active or require resnapshot. It never acknowledges on behalf of a coordinator.
+
+### 23.4 Drop
+
+Dropping a stream table fails while output consumers exist unless the caller uses a documented cascade operation. A privileged cascade explicitly invalidates or drops consumers, records the consequence, removes generated views and payload storage, and then follows ordinary dependency cleanup. It may not leave another extension believing that its acknowledged cursor has a continuous future stream.
+
+### 23.5 Orchestration-mode changes
+
+Returning a table to `MANAGED` mode does not consume or delete pending external output history. Administrators must explicitly decide whether consumers are retained, resnapshotted, or dropped. A mode change is a lifecycle operation, not an acknowledgement shortcut.
+
+---
+
+## 24. Observability and administration
+
+The new contract should add concise supported status functions rather than require operators to join private catalogs:
+
+```sql
+SELECT * FROM pgtrickle.external_graph_status(roots => ARRAY[...]::regclass[]);
+SELECT * FROM pgtrickle.output_delta_consumer_status();
+```
+
+Graph status should report graph digest, member count, orchestration eligibility, current busy state, most recent graph refresh, source-boundary completeness, and terminal batch positions. Consumer status should report owner, stream table, state, acknowledged and newest batch token, retained rows and bytes, batch lag, age lag, contract digest, row-identity version, and resnapshot reason.
+
+`health_check()` should warn when an external consumer needs resnapshot, is invalidated, retains more than configured advisory thresholds, references missing storage, or blocks refresh because a hard limit is near; when an external graph contains a managed or unsupported member; or when a graph contract can no longer be computed. Warnings are operational and do not change truth or advance state.
+
+Refresh history should identify `initiated_by = 'EXTERNAL_GRAPH'`, the graph refresh identifier, and the graph digest. Existing timeline and metrics surfaces may aggregate graph duration and output-log overhead while preserving per-member history. Useful counters include strict refresh totals and failures, busy conflicts, exact and invalidation batches, output rows and retained bytes, consumer gaps, resnapshots, and acknowledgement latency.
+
+---
+
+## 25. Performance and resource behavior
+
+The integration contract should add no output-delta overhead to a stream table that remains `MANAGED` and has no registered external consumer. Capability discovery is constant-size metadata. Contract digests may be cached by a complete semantic cache key and invalidated by the same catalog and function-dependency mechanisms that invalidate query plans.
+
+A strict graph refresh may be cheaper than repeated single-node public refreshes because it computes one closure, one lock plan, one source-boundary context, and one topological traversal. It should not repeatedly probe the same source, parse the same contract, or rebuild identical dependency state. The locked database catalog remains authoritative even when a cached DAG is reused.
+
+Output-delta capture adds one shared write per logical changed row, regardless of the number of external consumers. Per-consumer cost is a cursor row and access view rather than duplicate payload. Batch metadata adds one row per opted-in stream-table refresh, including no-data batches where a stable token is useful.
+
+A slow consumer can retain substantial output history. Advisory limits must be observable. Hard limits may block a refresh before history is lost or may require an administrator to move the consumer explicitly to `RESNAPSHOT_REQUIRED`; they may not truncate the current exact batch. If a complete exact batch cannot be written, the finalizer either writes an allowed invalidation marker or aborts.
+
+The initial contract should publish conservative admission bounds for root count, graph members, dependency edges, consumers per stream table, generated views, contract size, and batch pagination. Exceeding an admission bound fails before refresh and does not process an arbitrary graph prefix. V1 does not promise resumability; callers must operate within documented transaction, WAL, lock, memory, and temporary-space limits.
+
+---
+
+## 26. Upgrade and compatibility policy
+
+The proposal is additive. Existing stream tables receive `orchestration_mode = 'MANAGED'`. Existing APIs, including the human-friendly notice-and-skip behavior of `refresh_stream_table()`, remain unchanged. No external output log exists until a consumer registers.
+
+Capability major versions are independent of the extension package version. A storage-only or physical-plan upgrade may preserve capability majors and contract digests. A change to canonical contract encoding, graph closure, source-boundary meaning, output-delta row semantics, acknowledgement rules, token validation, or resnapshot behavior requires a new capability major and either side-by-side support or an explicit integrator migration.
+
+A mandatory correctness repair that changes logical semantics must change the relevant semantic-plan version and therefore the contract digest. A coordinating extension then refuses to refresh the old graph until it creates or explicitly adopts a new definition. A repair must not claim compatibility merely because the output column list is unchanged.
+
+Upgrade scripts preserve durable orchestration mode, consumer registrations and cursors, batch metadata, output-log payload, contract versions, and graph refresh identities. `pg_dump`, physical backup, PITR, and failover treat those objects as durable state. Generated consumer views may be recreated deterministically from the consumer catalog, but missing payload history moves the consumer to `RESNAPSHOT_REQUIRED`.
+
+The V1 contract is SQL-facing. Coordinating extensions must not link to private Rust modules or assume a stable Rust ABI. Runtime capability negotiation is authoritative even when package dependencies pin a supported release line.
+
+---
+
+## 27. Delivery plan
+
+The work should be delivered in three phases while keeping capability versions experimental until transaction, crash, and upgrade proofs pass.
+
+### Phase 1: contracts and external ownership
+
+Add capability discovery, canonical stream-table contracts, graph contracts, graph digests, and durable orchestration mode. Extend create, bulk-create, status, scheduler admission, lifecycle locks, dump, restore, and upgrade handling. This phase has no external output log and can be tested independently.
+
+### Phase 2: strict graph refresh
+
+Extract or reuse one structured internal graph-refresh context, acquire all external-member locks before execution, compute one immutable source boundary, execute members synchronously in topological order, and return a typed graph result. Wire every member through the common transactional finalizer and add stable busy, contract, completeness, and mode errors. At the end of this phase, a consumer may safely coordinate a graph but may still scan terminal relations completely after every refresh.
+
+### Phase 3: durable typed output deltas
+
+Add consumer registration, shared typed output logs, batch metadata, generated read-only consumer relations, exact differential capture, full invalidation, transactional acknowledgement, resnapshot, retention, status, and repair behavior. Integrate batch creation into the common finalizer so frontier advancement cannot commit without the corresponding promised batch. This phase completes the V1 dependency.
+
+Operational documentation, metrics, capacity guidance, backup and restore verification, upgrade matrix tests, and an example coordinating test extension are required before capability major version 1 is advertised as stable. During implementation, discovery should report an experimental version or `enabled = false` until each phase's complete contract is available.
+
+---
+
+## 28. Test plan
+
+### 28.1 Unit and property tests
+
+Canonical contract tests must prove deterministic ordering, exclusion of operational fields, inclusion of every result-affecting field, digest changes for semantic mutations, and digest stability for physical tuning. Graph tests should generate DAGs with duplicate roots, shared upstream members, diamonds, unsupported cycles, renames, object recreation, owner changes, and dependency changes and verify one canonical closure and lock order.
+
+Output-delta algebra tests must compare the old and new stream-table multisets with every exact batch after inserts, deletes, same-identity updates, key-changing updates, duplicates, aggregates, joins, set operations, TopK paths, no-op changes, and full fallback. Consumer state-machine tests cover registration idempotency, monotonic acknowledgement, invalidation disposition, resnapshot, gap handling, pause and resume, multiple consumers, drop, and contract change.
+
+### 28.2 PostgreSQL integration tests
+
+At minimum, integration tests must cover:
+
+1. A one-node external graph refreshed inside a transaction that later commits.
+2. The same refresh followed by a coordinator error, proving stream output, frontier, output batch, and acknowledgement all roll back.
+3. A chain of stream tables refreshed in dependency order against one boundary.
+4. A diamond graph in which both branches observe one shared upstream result and the terminal sees a coherent fan-in.
+5. A concurrent strict refresh producing `PGT_EXT_REFRESH_BUSY` or bounded lock wait, never successful skip.
+6. A concurrent `ALTER QUERY`, repair, mode change, and drop against a strict refresh, proving compatible lock behavior.
+7. A graph-contract change between initial inspection and locked refresh, producing contract mismatch before committed mutation.
+8. Concurrent source writers before and after the safe boundary, proving no lost or double-consumed changes.
+9. Exact differential output with inserts, deletes, and updates represented as delete plus insert.
+10. Full refresh with an exact before-and-after delta.
+11. Full refresh without exact delta support, producing one `FULL_INVALIDATION` and no partial payload.
+12. Multiple external consumers at different cursors, proving cleanup follows the slowest consumer.
+13. Acknowledgement followed by transaction rollback, proving the batch remains pending.
+14. A hard retention limit, proving refresh blocks before exact history is lost.
+15. Explicit resnapshot, proving full-table read and cursor reset commit together.
+16. Output-schema or semantic change with active consumers, proving rejection or explicit invalidation rather than silent reinterpretation.
+17. External orchestration across scheduler restart and PostgreSQL restart.
+18. Missing or corrupted output-log state after restore, proving `RESNAPSHOT_REQUIRED` rather than an empty delta.
+19. Ownership and RLS cases proving owner-equivalent defining-query execution and no deleted-row leak.
+20. Cross-database or restored-clone token reuse, proving database-lineage validation.
+
+### 28.3 Full and differential equivalence
+
+For every supported query family used by the contract, a reference harness should begin from one committed stream-table state, apply a generated source-change sequence, run differential refresh with exact output logging, and compare the resulting multiset with full query evaluation at the same source boundary. It should also verify that applying the exposed delete and insert rows to the old multiset produces the new multiset exactly. This is the central semantic proof for the public delta contract.
+
+### 28.4 Security tests
+
+Security tests cover function grants, unauthorized graph members, mixed owners, hostile `search_path`, RLS-enabled sources, guessed consumer tokens, guessed resnapshot tokens, private relation disclosure, direct DML attempts against generated delta relations, and deleted-row access. SQL-reachable Rust paths must not panic on malformed input or unexpected catalog state.
+
+### 28.5 Recovery and upgrade tests
+
+Physical restart, crash during refresh, PITR-style restore, logical dump and restore, extension upgrade, relation recreation, missing payload relations, and damaged sentinels must be tested. Machine-readable status must distinguish active, pending, invalidated, and resnapshot-required consumers. Compatibility fixtures should pin capability results, contract canonicalization, graph digest behavior, batch ordering, and token validation across every supported upgrade path.
+
+### 28.6 Performance tests
+
+Benchmarks should measure strict graph overhead against repeated single-node refresh, contract-digest cache cost, exact output-log write amplification, typed consumer-view scan throughput, batch metadata cost, cleanup with several consumers, and zero-cost behavior when no external consumer exists. Performance gates must never weaken exactness or failure behavior.
+
+---
+
+## 29. Alternatives considered
+
+### 29.1 Call `refresh_stream_table()` repeatedly
+
+A coordinator could sort its own graph and invoke the current public refresh once per node. This is rejected because each call may select a separate boundary, concurrency may become a notice-and-skip success, graph membership can change between calls, and the coordinator receives no graph contract or structured group result. Reimplementing `pg_trickle`'s DAG and lock logic in another extension would create two authorities for the same graph.
+
+### 29.2 Use `pause_scheduler()` as durable ownership
+
+Temporary pause is not a catalog-backed semantic declaration and is not intended to survive every restart and lifecycle transition. Correctness should not depend on shared-memory timing or an operator remembering to reapply pause state.
+
+### 29.3 Read private change buffers
+
+A coordinator could query `pgtrickle_changes.*` and maintain its own frontier. This would freeze private relation names, schemas, cleanup rules, catalog identifiers, and position semantics as an accidental public API. It would also allow the caller to bypass the validation that protects completeness.
+
+### 29.4 Install row triggers on terminal stream tables
+
+Triggers can copy differential changes into a consumer-owned relation in the same transaction, but they do not provide a supported graph cutoff, durable consumer cursor, minimum-retention coordination, contract verification, or reliable baseline semantics across every full and schema-changing path. They remain a useful user-space technique, not the extension-to-extension compatibility boundary.
+
+### 29.5 Use logical replication
+
+Logical replication is appropriate for an external downstream system. It is not an adequate in-database composition boundary because subscriber acknowledgement is not committed with the coordinator's local publication transaction, and WAL events do not directly provide the graph contract and source-boundary result required here.
+
+### 29.6 Use `pg_tide`
+
+`pg_tide` is an event outbox and delivery boundary. It does not provide a typed relational before-and-after delta whose cursor participates in `pg_trickle` output retention. A coordinator may publish its final domain events through `pg_tide`, but that occurs after it consumes local evidence and decides domain meaning.
+
+### 29.7 Always scan the terminal stream table
+
+A full scan is correct and can be the first milestone after strict graph refresh. It discards the principal performance benefit of incremental evidence maintenance for large terminal relations. The completed V1 contract therefore includes durable deltas, while full scan remains the explicit invalidation and resnapshot fallback.
+
+### 29.8 Add an arbitrary post-refresh callback
+
+A callback that invokes another extension after each refresh creates difficult transaction, authorization, recursion, error-isolation, resource, and versioning questions. It also makes the `pg_trickle` scheduler the owner of the higher-level workflow. The explicit SQL coordinator model is easier to test and leaves domain semantics with the domain extension.
+
+### 29.9 Link to or fork private Rust modules
+
+PostgreSQL extensions do not have a stable Rust ABI, and a fork would duplicate the most difficult CDC, DVM, frontier, and upgrade work. A small SQL compatibility surface is a cleaner long-term boundary.
+
+---
+
+## 30. Risks and open implementation choices
+
+The largest risk is that a public output-delta contract constrains internal cleanup and storage. The mitigation is to stabilize logical batch tokens, ordering, typed relations, acknowledgement, and gap behavior rather than the private buffer layout. The output log may be a separate relation initially and can evolve physically behind the contract.
+
+A second risk is unbounded retention caused by a failed coordinator. The mitigation is explicit lag status, alerts, conservative hard bounds, blocking before data loss, and an administrator-controlled transition to `RESNAPSHOT_REQUIRED`. Availability must not be obtained by silently discarding exact history.
+
+A third risk is API growth in an already broad extension. The mitigation is a focused integration namespace with independently versioned capabilities and a small number of functions. Ordinary users never need these functions to create and query a normal stream table.
+
+A fourth risk is overclaiming source coherence. The mitigation is a typed source-boundary manifest and failure when the graph cannot obtain one complete proof. Several incomparable source positions must not be reduced to a reassuring but meaningless timestamp.
+
+A fifth risk is security leakage from retained deleted rows. The initial owner-only consumer policy avoids delegated access until a complete filtering and masking design exists.
+
+Several implementation choices remain open without changing the proposal's semantics. Capability discovery may return rows or one versioned JSON document. Graph and refresh results may use named composite types or versioned JSON subdocuments. The typed delta surface may be a protected table, view, or set-returning function backed by one shared log. Lock behavior may rely on ordinary `lock_timeout` rather than a separate API option. Batch tokens may be per stream table or globally allocated, provided ordering, continuity, and validation remain exactly defined. These choices should be resolved in implementation review and recorded before capability major version 1 is frozen.
+
+---
+
+## 31. Acceptance criteria
+
+The V1 proposal is complete when a small conformance extension can perform the following operations using only supported SQL APIs:
+
+1. Discover and require the six V1 integration capabilities by major and minimum minor version.
+2. Create an acyclic private stream-table graph durably in `EXTERNAL` orchestration mode.
+3. Obtain canonical stream-table and graph contracts whose digests change for semantic or binding changes and remain stable for physical-only changes.
+4. Register durable typed output consumers on terminal stream tables without learning private buffer names.
+5. Refresh the complete graph synchronously against one coherent, complete source-boundary decision and receive one structured graph result.
+6. Observe a busy, altered, unsupported, incomplete, unauthorized, or failed graph as a stable error with no committed member subset.
+7. Read an immutable continuous exact batch, apply it to coordinator-owned state, acknowledge it, and commit all effects together.
+8. Roll back after graph refresh or acknowledgement and observe graph contents, frontiers, output batches, coordinator state, and cursor all unchanged.
+9. Receive `FULL_INVALIDATION` rather than a partial row set when exact output change cannot be supplied, then resynchronize from the complete stable terminal relation.
+10. Retain independent cursors for multiple consumers and clean payload only through the slowest acknowledged position or an explicit resnapshot transition.
+11. Survive PostgreSQL restart, backup and restore, failover, and supported extension upgrade without losing external orchestration or silently skipping a delta gap.
+12. Observe owner checks, safe search paths, row-identity and contract validation, bounded inputs, stable errors, lag status, and health diagnostics.
+13. Prove through differential/full tests that every exact batch transforms the prior output multiset into the complete query result at the named source boundary.
+14. Implement the complete `pg_mdm` V1 refresh and publication transaction without reading or writing a private `pg_trickle` catalog, buffer, frontier, scheduler table, or generated implementation column.
+
+Nothing in Appendix A is part of these acceptance criteria.
+
+---
+
+## 32. Recommended disposition
+
+Adopt the V1 composition contract as a focused pre-1.0 extension boundary. Deliver durable external orchestration and canonical contracts first, strict transactional graph refresh second, and durable typed output deltas third. Keep the surface experimental until transaction, concurrency, crash, security, and upgrade proofs pass, then advertise capability major version 1.
+
+The proposed boundary preserves the responsibilities of both projects:
+
+> **`pg_trickle` owns complete incremental relational facts and their source boundaries. A coordinating extension owns the higher-level decisions made from those facts. PostgreSQL owns the transaction that commits them together.**
+
+---
+
+# Appendix A: high-level V2 needs
+
+**This appendix is non-normative. It summarizes the `pg_mdm` V2 need only. It is not part of the V1 decision, delivery plan, implementation estimate, or acceptance criteria, and every capability described here requires a separate proposal before implementation.**
+
+The V1 contract keeps graph refresh, domain computation, domain publication, and delta acknowledgement inside one PostgreSQL transaction. That is the simplest and strongest model for small and medium workloads, but a higher-level resolver may eventually need minutes or hours of component analysis, stable-identity reconciliation, validation, or preview work. Holding one database transaction and one set of graph locks for that entire period may become operationally unacceptable.
+
+A later capability would therefore need an immutable prepared graph result at a named source boundary. `pg_trickle` would refresh the graph, commit the private relational state, and seal the exact member contracts, source-boundary manifest, terminal output state, and delta positions. The coordinating extension could then perform deterministic checkpointed work across several transactions while source changes beyond the sealed boundary continued to accumulate for a later refresh.
+
+Final publication would still need one short atomic transaction. In that transaction, the coordinator would verify that the prepared graph remains valid, publish its domain result, acknowledge the prepared terminal deltas, and promote or consume the prepared state. If the transaction rolled back, the prepared state and unacknowledged deltas would remain available. An explicitly abandoned preparation would release its graph lease without acknowledging that the higher-level domain accepted it.
+
+That capability introduces concerns that are deliberately absent from V1: immutable generation identity, graph-member leases, prepared-state recovery after restart, promotion and abandonment, source-buffer retention while a graph is frozen, output-delta continuity across several transactions, storage cleanup, and the choice between freezing one physical graph or maintaining multiple physical generations. It may also require progress reporting, resumable work allocation, and stronger resource governance.
+
+The V1 design is intended to leave room for that later work. Graph contracts already name a complete semantic closure. Graph refreshes already have stable identifiers and source-boundary manifests. Output consumers already use durable cursors rather than assuming that the current private frontier equals the last accepted domain publication. Capability discovery can add a separately versioned future feature without changing any V1 major contract.
+
+The later design should not be inferred from this appendix. In particular, V1 does not promise a `prepare_graph()` function, generation-specific storage, concurrent preparations, asynchronous workers, checkpoint formats, or promotion semantics. Those decisions require a dedicated proposal and a full crash, upgrade, retention, and transaction proof matrix.

--- a/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
+++ b/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
@@ -4,7 +4,7 @@
 
 **Status:** Proposed  
 **Scope:** Two independently versioned V1 capability contracts. Appendix A is non-normative and does not affect either V1 acceptance gate.
-**Target:** Additive graph-coordination contract before 1.0; separately gated durable output-delta contract
+**Target:** v0.93.0 for Graph V1 contracts, v0.94.0 for strict graph refresh, and v0.95.0 for separately gated Delta V1, all before v1.0
 **Decision:** Add a small, versioned SQL API that lets another PostgreSQL extension coordinate a private stream-table graph without depending on `pg_trickle` internals. Stabilize durable output consumption only after its separate retention, recovery, and upgrade gates pass.
 **Compatibility:** Existing stream tables remain scheduler-managed by default, and existing public APIs retain their behavior  
 **Motivating consumer:** [`pg_mdm`](https://github.com/grove/pg-mdm), beginning with its V1 entity-resolution design  
@@ -57,7 +57,7 @@
 
 The proposal defines two independent capability contracts. `external_graph_refresh` advertises integration support, exposes versioned stream-table and graph execution contracts, persists `EXTERNAL` orchestration, refreshes a complete graph strictly inside the caller's PostgreSQL transaction, and returns one coherent source-boundary manifest. This contract is sufficient for a coordinator to scan terminal stream tables, publish its own result, and commit or roll back everything together.
 
-`output_delta_consumer` is a separate optimization contract for coordinators that have proven that complete terminal scans are too expensive. It adds durable acknowledged typed output deltas, retention, resnapshot, recovery, and backpressure. Delta V1 requires a compatible enabled Graph V1, but Graph V1 does not require Delta V1. The contracts do not share a capability version or acceptance gate. A failure to stabilize output deltas must not delay or weaken graph coordination.
+`output_delta_consumer` is a separate optimization contract for coordinators that have proven that complete terminal scans are too expensive. It adds durable acknowledged typed output deltas, retention, resnapshot, recovery, and backpressure. Delta V1 requires a compatible enabled Graph V1, but Graph V1 does not require Delta V1. The contracts do not share a capability version or acceptance gate. A failure to stabilize output deltas must not delay or weaken the Graph V1 release, but the pre-1.0 roadmap now blocks v1.0 until Delta V1 passes its independent v0.95.0 gate.
 
 This proposal does not add MDM concepts to `pg_trickle`, and it does not expose private `pg_trickle` implementation state. `pg_trickle` continues to own source capture, safe frontiers, differential view maintenance, full fallback, stream-table storage, row identity, dependency ordering, and refresh finalization. The coordinating extension continues to own domain-specific decisions and public outputs. No supported integration path reads or mutates private catalogs, scheduler jobs, change buffers, generated columns, internal frontier encodings, or storage naming conventions.
 
@@ -69,7 +69,7 @@ This document contains two V1 proposals with separate acceptance boundaries.
 
 Graph V1 is a synchronous, single-database composition path in which the coordinating extension keeps one PostgreSQL transaction open while `pg_trickle` refreshes a private graph and the coordinator publishes its own result. It supports acyclic local stream-table graphs, complete source-boundary proofs for explicitly admitted source kinds, stable execution-contract digests, complete terminal-table reads, and fail-closed behavior under concurrency or schema change.
 
-Delta V1 adds exact output deltas when available, explicit full invalidation when an exact output delta is unavailable, owner-controlled durable cursors, and fail-closed behavior under retention loss, recovery, restore, and upgrade. A release may advertise Graph V1 while reporting Delta V1 as absent, disabled, or experimental.
+Delta V1 adds exact output deltas when available, explicit full invalidation when an exact output delta is unavailable, owner-controlled durable cursors, and fail-closed behavior under retention loss, recovery, restore, and upgrade. v0.94.0 may advertise Graph V1 while reporting Delta V1 as absent, disabled, or experimental; v1.0 may not ship until Delta V1 is stable.
 
 | Capability contract | Required components | Purpose |
 |---|---|---|
@@ -1215,7 +1215,7 @@ Nothing in Appendix A is part of either acceptance gate.
 
 Adopt Graph V1 as a focused pre-1.0 extension boundary. Deliver durable external orchestration and execution contracts first, then strict transactional graph refresh. Advertise `external_graph_refresh` major version 1 when its acceptance gate passes.
 
-Pursue Delta V1 as a separate optimization. Keep `output_delta_consumer` absent, disabled, or experimental until its own algebra, transaction, retention, crash, security, clone, and upgrade proofs pass. Delta V1 must not delay Graph V1 or weaken its complete terminal-read path.
+Pursue Delta V1 as a separate optimization. Keep `output_delta_consumer` absent, disabled, or experimental until its own algebra, transaction, retention, crash, security, clone, and upgrade proofs pass. Delta V1 must not delay Graph V1 or weaken its complete terminal-read path, but its independent v0.95.0 gate must pass before v1.0.
 
 The proposed boundary preserves the responsibilities of both projects:
 

--- a/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
+++ b/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
@@ -625,7 +625,7 @@ row_identity      bytea    NOT NULL
 <stream-table output columns, preserving PostgreSQL types>
 ```
 
-The relation preserves the stream table's user-visible PostgreSQL types and contains complete old values for `DELETE` and complete new values for `INSERT`. Private generated columns are not exposed, except for the opaque canonical `row_identity` needed to pair and order changes. The relation is read only. Its physical name and implementation are not stable; the returned relation identity and logical schema remain valid for the lifetime of the consumer contract.
+The relation preserves the stream table's user-visible PostgreSQL types and contains complete old values for `DELETE` and complete new values for `INSERT`. Private generated columns are not exposed, except for the opaque canonical `row_identity` needed to pair and order changes. The relation is read only. Its physical name, relation OID, and implementation are not stable. The logical schema and lookup contract remain stable for the lifetime of the consumer contract, but a returned `regclass` is only the current binding. `output_delta_consumer_status()` returns that binding, and callers must rediscover it after extension upgrade, logical restore, repair, or any reported storage recreation rather than persisting the OID as durable identity.
 
 `ordinal` is unique within a batch, starts at zero, and is immutable once stored. A `DELETE` precedes the matching `INSERT` for a same-identity update. Order between distinct row identities has no public meaning. Consumers apply every row as a multiset operation and must not infer source transaction order from the ordinal. Consumers may page within the relation, but acknowledgement remains batch-granular so a partially read batch cannot be discarded accidentally.
 
@@ -665,7 +665,7 @@ RETURNS TABLE (
 
 Batch tokens are positive, monotonically increasing integers scoped to one stream table's output log and database-instance identity. The log head is a catalog counter locked and incremented in the same transaction that inserts batch metadata and payload. PostgreSQL sequences must not allocate these tokens because sequence increments do not roll back. Every committed refresh of an opted-in stream table records exactly one metadata row, including exact zero-row and invalidation batches. Token zero denotes the pristine empty origin and never has payload.
 
-The result begins after the consumer's acknowledged token and ends at `through_token`, or at the current log head when no upper token is supplied. It must return every metadata token in that closed range in order. A missing token, payload relation, required payload row, or continuity sentinel changes the consumer to `RESNAPSHOT_REQUIRED` with reason `LOG_INCOMPLETE` and raises a delta-gap error. It never treats missing history as no changes.
+The result begins after the consumer's acknowledged token and ends at `through_token`, or at the current log head when no upper token is supplied. It must return every metadata token in that closed range in order. A missing token, payload relation, required payload row, or continuity sentinel is treated immediately as `RESNAPSHOT_REQUIRED` with reason `LOG_INCOMPLETE` and raises a delta-gap error. The failing request does not claim to persist that state transition because PostgreSQL rolls back statement changes when it raises the error. Startup recovery, repair, or an explicit non-throwing validation operation must acquire the consumer lock and commit the transition in a separate transaction. Until that succeeds, every read continues to fail closed on the same integrity check. Missing history is never treated as no changes.
 
 The initial modes are:
 
@@ -739,17 +739,17 @@ State transitions record one stable reason code:
 | `CONTRACT_CHANGED` | `INVALIDATED` | The stream-table or output contract no longer matches registration |
 | `ADMIN_RESET` | `RESNAPSHOT_REQUIRED` | An administrator explicitly requested a new baseline |
 
-An execution-contract or output-contract-changing `ALTER QUERY` is rejected while active consumers exist under Delta V1. `pg_mdm` avoids in-place mutation by creating a new private graph for each entity-definition version. Dropping a stream table requires dropping or explicitly cascading its consumers. Dropping a consumer is authorization-checked and may allow retained rows to be cleaned immediately.
+An execution-contract or output-contract-changing `ALTER QUERY` is rejected while any nonterminal consumer remains registered under Delta V1, including `ACTIVE`, `PAUSED`, `RESNAPSHOT_REQUIRED`, and `INVALIDATED`. `pg_mdm` avoids in-place mutation by creating a new private graph for each entity-definition version. Dropping a stream table requires dropping or explicitly cascading its consumers. Dropping a consumer is authorization-checked and may allow retained rows to be cleaned immediately.
 
 ### 15.8 Retention and backpressure
 
-The output log is retained through the minimum acknowledged batch among active consumers. Internal downstream stream-table consumers continue to use their private frontier contract; an implementation may combine retention minima physically, but neither public cursor is represented as the other.
+The output log is retained through the minimum acknowledged batch among every consumer whose state still claims continuity. `ACTIVE` and `PAUSED` consumers both pin history. `RESNAPSHOT_REQUIRED`, `INVALIDATED`, and `DROPPED` consumers stop pinning discarded history only after the transaction that records their discarded-through token or terminal state commits. A future prepared binding also participates in this minimum while active. Internal downstream stream-table consumers continue to use their private frontier contract; an implementation may combine retention minima physically, but neither public cursor is represented as the other.
 
 The default V1 retention behavior is fail closed. A slow consumer may retain substantial data, and `pg_trickle` must expose row, byte, batch, and age lag. Soft limits warn but do not delete history. If finalizing a new exact batch would cross an enabled hard limit, the refresh raises `PGT_EXT_CONSUMER_BLOCKED` before inserting batch metadata, payload, or advancing the transactional log head. The outer refresh transaction then rolls back.
 
 An administrator may explicitly move one or more blocking consumers to `RESNAPSHOT_REQUIRED` with reason `HISTORY_EXPIRED` or `ADMIN_RESET`. That transaction records the discarded-through token before cleanup becomes eligible. The administrator then retries the refresh. Delta V1 never expires history, truncates the current batch, or changes consumer state automatically merely because a size or age threshold elapsed.
 
-Output logs required by active consumers are logged and crash-safe. Loss of a log sentinel, batch metadata, typed relation, or continuity proof changes affected consumers to `RESNAPSHOT_REQUIRED`; it is never interpreted as no changes.
+Output logs required by continuity-pinning consumers are logged and crash-safe. Loss of a log sentinel, batch metadata, typed relation, or continuity proof is treated as `RESNAPSHOT_REQUIRED`; it is never interpreted as no changes. Request paths raise without claiming a durable state change, while startup recovery, repair, or explicit validation records the transition in its own committing transaction.
 
 ---
 
@@ -826,6 +826,8 @@ The composition API is intended for trusted in-database coordinators, but it mus
 
 Output-delta registration, reading, resnapshot, acknowledgement, pause, and deletion should be restricted to the stream-table owner or superuser in V1. This avoids a subtle information leak from deleted rows retained in output history, because ordinary table RLS cannot reliably be reevaluated against a row that no longer exists. A later delegated-consumer design would require explicit row filters, masking rules, and retained-row policy rather than an informal grant.
 
+Any durable consumer row that stores a PostgreSQL role OID must register a PostgreSQL shared dependency on that role, or use an equivalent mechanism that prevents the role from being dropped while the consumer exists. A dangling owner OID is invalid state, and later OID reuse must never transfer consumer authority to an unrelated role. Reassignment or removal therefore uses an explicit authorization-checked consumer lifecycle operation rather than raw catalog mutation.
+
 Every `SECURITY DEFINER` entry point must use a fixed safe `search_path`, resolve objects through PostgreSQL catalogs, distinguish identifiers from values in generated SQL, and avoid exposing private relation names to unauthorized callers. Consumer and resnapshot tokens are references only after authorization; knowledge of a UUID is not authority.
 
 ---
@@ -834,7 +836,7 @@ Every `SECURITY DEFINER` entry point must use a fixed safe `search_path`, resolv
 
 ### 18.1 Lock ordering
 
-Strict graph refresh resolves the complete closure and acquires all graph-member locks in one canonical order before executing the first member. The order must be independent of root-array order and shared with alter, repair, drop, resnapshot, and orchestration-mode transitions so that callers do not create lock-order cycles. Source relation locks required by a full baseline follow the existing source-lock protocol and are acquired in deterministic relation order.
+Strict graph refresh resolves the complete closure and acquires all graph-member locks in one canonical order before executing the first member. The order must be independent of root-array order and shared with alter, repair, drop, resnapshot, and orchestration-mode transitions so that callers do not create lock-order cycles. One shared lock-plan helper must define the canonical member key and acquire, for each complete member set, refresh or lifecycle locks before catalog-row locks, followed by required member storage locks. A path may omit a lock class it does not need, but it may not invert the remaining order. Multi-member lifecycle operations lock the complete set before mutating any prefix. Source relation locks required by a full baseline follow the existing source-lock protocol and are then acquired in ascending relation OID. Delta V1 consumer locks follow member and source locks in ascending UUID byte order, followed by batch and payload relations. The strict API uses blocking locks governed by `lock_timeout`, or an explicit no-wait variant, and never uses `SKIP LOCKED`.
 
 ### 18.2 Scheduler interaction
 
@@ -862,7 +864,7 @@ A backend crash or server restart during an uncommitted strict refresh relies on
 
 Output-log integrity is durable control state. On startup, restore, or repair, `pg_trickle` validates consumer catalog rows, output-log relation identity, required columns and types, contract versions, sentinels, batch continuity, and acknowledged positions. Missing or unverifiable history moves the consumer to `RESNAPSHOT_REQUIRED`. The system does not synthesize an empty batch or silently jump the cursor.
 
-An execution-contract change invalidates active consumers rather than reinterpreting retained rows. A contract-neutral physical change may preserve the contract and consumer continuity. Clone activation assigns and validates a different database-instance identity, so copied tokens are rejected even when relation OIDs happen to match.
+An execution-contract change discovered through recovery, unsupported mutation, or mandatory correctness repair invalidates affected consumers rather than reinterpreting retained rows. Supported contract-changing lifecycle operations are rejected while any nonterminal consumer remains registered. A contract-neutral physical change may preserve the contract and consumer continuity. Clone activation assigns and validates a different database-instance identity, so copied tokens are rejected even when relation OIDs happen to match.
 
 `repair_stream_table()` may rebuild triggers, buffers, or derived storage, but it cannot repair an exact external history that has been lost. Its result must state whether consumers remain active, require resnapshot, or were invalidated by the repair.
 
@@ -942,6 +944,7 @@ pgt_output_delta_consumers
   output_contract_digest
   row_identity_version
   acknowledged_batch_token
+  discarded_through_token
   state
   state_reason
   created_at
@@ -1054,7 +1057,7 @@ Capability major versions are independent of each other and of the extension pac
 
 A mandatory correctness repair that changes tracked logical behavior increments the relevant rewrite or DVM contract version and the stream-table contract generation. A coordinating extension then refuses to refresh the old graph until it creates or explicitly adopts a new definition. A repair must not claim compatibility merely because the output column list is unchanged.
 
-Graph V1 upgrade scripts preserve durable orchestration mode, contract generations, contract versions, and graph refresh identities. Delta V1 scripts additionally preserve consumer registrations and cursors, the transactional log head, batch metadata, and output-log payload. `pg_dump`, physical backup, PITR, and failover treat enabled capability state as durable. The shared typed view may be recreated deterministically from catalog state, but missing payload history moves affected consumers to `RESNAPSHOT_REQUIRED`.
+Graph V1 upgrade scripts preserve durable orchestration mode, contract generations, contract versions, and graph refresh identities. Delta V1 scripts additionally preserve consumer registrations and cursors, the transactional log head, batch metadata, and output-log payload. `pg_dump`, physical backup, PITR, and failover treat enabled capability state as durable. The shared typed view may be recreated deterministically from catalog state, and status returns its current `regclass` binding after recreation. Callers must not treat a prior relation OID as durable. Missing payload history requires resnapshot under the separate-transition rule in Section 15.4.
 
 Both V1 contracts are SQL-facing. Coordinating extensions must not link to private Rust modules or assume a stable Rust ABI. Runtime capability negotiation is authoritative even when package dependencies pin a supported release line.
 
@@ -1101,7 +1104,7 @@ At minimum, Graph V1 tests cover:
 
 ### 28.3 Delta V1 unit and property tests
 
-Output-delta algebra tests compare old and new stream-table multisets with every exact batch after inserts, deletes, same-identity updates, key-changing updates, duplicates, aggregates, joins, set operations, TopK paths, no-op changes, and full fallback. Applying all exposed deletes and inserts must produce the full query result at the same source boundary. State-machine tests cover default registration, pristine `CURRENT`, idempotency, transactional token allocation, acknowledgement, invalidation disposition, resnapshot, gaps, pause and resume, multiple consumers, drop, and contract change.
+Output-delta algebra tests compare old and new stream-table multisets with every exact batch after inserts, deletes, same-identity updates, key-changing updates, duplicates, aggregates, joins, set operations, TopK paths, no-op changes, and full fallback. Applying all exposed deletes and inserts must produce the full query result at the same source boundary. State-machine tests cover default registration, pristine `CURRENT`, idempotency, transactional token allocation, acknowledgement, invalidation disposition, resnapshot, gaps, pause and resume, multiple consumers, drop, and contract change. They also prove that an error cannot claim a committed state transition and that non-throwing validation can persist the same transition.
 
 ### 28.4 Delta V1 integration tests
 
@@ -1109,11 +1112,11 @@ At minimum, Delta V1 tests cover:
 
 1. Exact differential output and exact full output, including delete-plus-insert updates and zero-row batches.
 2. Full refresh without an exact diff, producing one `FULL_INVALIDATION` and no partial payload.
-3. Several consumers sharing one typed relation while cleanup follows the slowest cursor.
+3. Several consumers sharing one typed relation while cleanup follows the slowest `ACTIVE` or `PAUSED` cursor, plus any active prepared binding.
 4. Refresh and acknowledgement rollback, proving the log head, payload, and cursor all return to their prior state without a token gap.
 5. Hard retention backpressure before metadata, payload, or log-head mutation.
 6. Explicit resnapshot, proving the complete read and cursor activation commit together.
-7. Contract change, missing storage, damaged continuity, recovery rollback, and clone activation, proving the documented state and reason code.
+7. Contract change, missing storage, damaged continuity, recovery rollback, role drop, relation rebinding, and clone activation, proving the documented state and reason code.
 8. Registration rejection for managed stream tables and non-pristine `CURRENT` requests.
 
 ### 28.5 Security and compatibility tests

--- a/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
+++ b/plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md
@@ -3,9 +3,9 @@
 ## Strict transactional graph refresh and durable typed output deltas for coordinating PostgreSQL extensions
 
 **Status:** Proposed  
-**Scope:** V1 only. Appendix A is non-normative and does not affect V1 acceptance.  
-**Target:** Additive pre-1.0 integration contract  
-**Decision:** Add a small, versioned SQL surface that lets another PostgreSQL extension coordinate a private stream-table graph without depending on `pg_trickle` internals  
+**Scope:** Two independently versioned V1 capability contracts. Appendix A is non-normative and does not affect either V1 acceptance gate.
+**Target:** Additive graph-coordination contract before 1.0; separately gated durable output-delta contract
+**Decision:** Add a small, versioned SQL API that lets another PostgreSQL extension coordinate a private stream-table graph without depending on `pg_trickle` internals. Stabilize durable output consumption only after its separate retention, recovery, and upgrade gates pass.
 **Compatibility:** Existing stream tables remain scheduler-managed by default, and existing public APIs retain their behavior  
 **Motivating consumer:** [`pg_mdm`](https://github.com/grove/pg-mdm), beginning with its V1 entity-resolution design  
 **Baseline reviewed:** `pg_trickle` 0.90.0 at commit [`a6a53e0`](https://github.com/trickle-labs/pg-trickle/commit/a6a53e0f6697eed4407a664b1af5172ca137fd9c)  
@@ -53,9 +53,11 @@
 
 ## 1. Executive decision
 
-`pg_trickle` should expose a generic composition contract for trusted PostgreSQL extensions that use stream tables as a relational computation layer but must publish a larger domain result under their own transaction and governance rules. The first consumer is `pg_mdm`, which wants `pg_trickle` to maintain normalized values, candidate blocks, candidate pairs, pair evidence, and golden-value candidates while `pg_mdm` remains responsible for clustering, stewardship, stable entity identifiers, reviews, provenance, and public MDM publication. The contract is intentionally domain-neutral and should also be usable by graph resolvers, policy engines, feature stores, search-index coordinators, and other extensions that need incrementally maintained relational facts without surrendering their own publication boundary.
+`pg_trickle` should expose a generic composition contract for trusted PostgreSQL extensions that use stream tables as a relational computation layer but must publish a larger domain result under their own transaction and governance rules. The first consumer is `pg_mdm`, which wants `pg_trickle` to maintain normalized values, candidate blocks, candidate pairs, pair evidence, and golden-value candidates while `pg_mdm` remains responsible for clustering, stewardship, stable entity identifiers, reviews, provenance, and public MDM publication. The contract is domain-neutral and should also work for graph resolvers, policy engines, feature stores, search-index coordinators, and other extensions that need incrementally maintained relational facts without surrendering their own publication boundary.
 
-The V1 contract contains six closely related capabilities. `pg_trickle` advertises integration capabilities and their versions; exposes canonical stream-table and graph contracts with stable digests; provides a durable `EXTERNAL` orchestration mode that excludes private graphs from the ordinary scheduler; refreshes a complete graph synchronously and strictly inside the caller's PostgreSQL transaction; returns one coherent source-boundary manifest for that refresh; and exposes durable, acknowledged, typed output deltas for selected terminal stream tables. Together, these capabilities let another extension refresh relational evidence, consume exactly what changed, update its own durable state, acknowledge the evidence, and commit or roll back all effects together.
+The proposal defines two independent capability contracts. `external_graph_refresh` advertises integration support, exposes versioned stream-table and graph execution contracts, persists `EXTERNAL` orchestration, refreshes a complete graph strictly inside the caller's PostgreSQL transaction, and returns one coherent source-boundary manifest. This contract is sufficient for a coordinator to scan terminal stream tables, publish its own result, and commit or roll back everything together.
+
+`output_delta_consumer` is a separate optimization contract for coordinators that have proven that complete terminal scans are too expensive. It adds durable acknowledged typed output deltas, retention, resnapshot, recovery, and backpressure. Delta V1 requires a compatible enabled Graph V1, but Graph V1 does not require Delta V1. The contracts do not share a capability version or acceptance gate. A failure to stabilize output deltas must not delay or weaken graph coordination.
 
 This proposal does not add MDM concepts to `pg_trickle`, and it does not expose private `pg_trickle` implementation state. `pg_trickle` continues to own source capture, safe frontiers, differential view maintenance, full fallback, stream-table storage, row identity, dependency ordering, and refresh finalization. The coordinating extension continues to own domain-specific decisions and public outputs. No supported integration path reads or mutates private catalogs, scheduler jobs, change buffers, generated columns, internal frontier encodings, or storage naming conventions.
 
@@ -63,20 +65,18 @@ This proposal does not add MDM concepts to `pg_trickle`, and it does not expose 
 
 ## 2. V1 release boundary
 
-This document is a V1 proposal. Its acceptance boundary is a synchronous, single-database composition path in which the coordinating extension keeps one PostgreSQL transaction open while `pg_trickle` refreshes the private graph and the coordinator publishes its own result. V1 supports acyclic local stream-table graphs, complete source-boundary proofs for the source kinds accepted by the graph, exact output deltas when available, explicit full invalidation when an exact output delta is unavailable, owner-controlled durable cursors, and fail-closed behavior under concurrency, recovery, schema change, or retention loss.
+This document contains two V1 proposals with separate acceptance boundaries.
 
-The following capabilities are required for V1 and form one compatibility promise:
+Graph V1 is a synchronous, single-database composition path in which the coordinating extension keeps one PostgreSQL transaction open while `pg_trickle` refreshes a private graph and the coordinator publishes its own result. It supports acyclic local stream-table graphs, complete source-boundary proofs for explicitly admitted source kinds, stable execution-contract digests, complete terminal-table reads, and fail-closed behavior under concurrency or schema change.
 
-| Capability | V1 purpose |
-|---|---|
-| Versioned capability discovery | Refuse unsupported extension combinations before state is created or refreshed |
-| Canonical stream-table and graph contracts | Prove that the graph being refreshed is the graph the coordinator compiled and approved |
-| Durable `EXTERNAL` orchestration | Prevent independent scheduler advancement of a privately coordinated graph |
-| Strict transactional graph refresh | Refresh the complete graph in dependency order with no notice-and-skip outcome |
-| Source-boundary manifest | Name the exact, coherent source positions represented by the refreshed graph |
-| Durable typed output deltas | Let a coordinator consume and acknowledge changed terminal rows without private-buffer access |
+Delta V1 adds exact output deltas when available, explicit full invalidation when an exact output delta is unavailable, owner-controlled durable cursors, and fail-closed behavior under retention loss, recovery, restore, and upgrade. A release may advertise Graph V1 while reporting Delta V1 as absent, disabled, or experimental.
 
-V1 does not include multi-transaction graph computation, resumable graph refresh, concurrent immutable graph states, background graph execution, cross-database graphs, distributed transaction coordination, arbitrary post-refresh callbacks, semantic business events, a stable Rust ABI, or external message delivery. Appendix A describes the V2 multi-transaction need at a high level so that V1 choices do not accidentally block it, but none of that appendix is normative and none of it may delay V1 acceptance.
+| Capability contract | Required components | Purpose |
+|---|---|---|
+| `external_graph_refresh` V1 | Capability discovery, execution contracts, durable `EXTERNAL` orchestration, strict graph refresh, source-boundary manifest | Prove and refresh the graph the coordinator compiled, then let it read terminal state in the same transaction |
+| `output_delta_consumer` V1 | Registration, typed output batches, acknowledgement, retention, resnapshot, lineage validation | Let a coordinator consume changed terminal rows without private-buffer access or a complete terminal scan |
+
+Neither V1 contract includes multi-transaction graph computation, resumable graph refresh, concurrent immutable graph states, background graph execution, cross-database graphs, distributed transaction coordination, arbitrary post-refresh callbacks, semantic business events, a stable Rust ABI, or external message delivery. Appendix A describes the later multi-transaction need at a high level so that V1 choices do not accidentally block it, but none of that appendix is normative and none of it may delay either V1 acceptance gate.
 
 ---
 
@@ -84,15 +84,15 @@ V1 does not include multi-transaction graph computation, resumable graph refresh
 
 The current `pg_trickle` public API is designed primarily for users who create a stream table and allow `pg_trickle` to keep it fresh. That remains the correct ordinary product. The API is not quite sufficient when another extension creates several private stream tables as one internal graph and must coordinate that graph with additional domain state in the same transaction.
 
-The existing [`refresh_stream_table()`](../src/api/refresh_ops.rs) function refreshes one stream table and returns `void`. A concurrent refresh becomes a `RefreshSkipped` condition that the human-facing wrapper turns into a notice and a successful no-op. That behavior is convenient for an operator issuing an opportunistic refresh, but it is unsafe for a coordinating extension. Such a caller must distinguish “the complete graph was refreshed at this exact boundary” from “another operation was busy and nothing happened,” and it needs a stable group identifier, actual graph digest, source-boundary manifest, per-node result, and terminal delta positions rather than reconstructing those facts from private tables.
+The existing [`refresh_stream_table()`](../src/api/refresh_ops.rs) function refreshes one stream table and returns `void`. A concurrent refresh becomes a `RefreshSkipped` condition that the human-facing wrapper turns into a notice and a successful no-op. That behavior is convenient for an operator issuing an opportunistic refresh, but it is unsafe for a coordinating extension. Such a caller must distinguish "the complete graph was refreshed at this exact boundary" from "another operation was busy and nothing happened," and it needs a stable group identifier, actual graph digest, source-boundary manifest, and per-node result rather than reconstructing those facts from private tables. Delta V1 separately provides terminal output positions.
 
-The existing [`pause_scheduler()`](../src/api/scheduler_control.rs) function is also not a durable orchestration contract. It is an operational drain control whose state and purpose are separate from stream-table semantic ownership. A graph coordinated by another extension must remain outside scheduler dispatch after process restart, scheduler restart, failover, backup, restore, and extension upgrade. An accidental independent refresh is not merely a freshness difference: it can separate relational evidence from the higher-level membership, policy, or publication revision that is supposed to consume it.
+The existing [`pause_scheduler()`](../src/api/scheduler_control.rs) function is also not a durable orchestration contract. It is an operational drain control whose state and purpose are separate from stream-table scheduling ownership. A graph coordinated by another extension must remain outside scheduler dispatch after process restart, scheduler restart, failover, backup, restore, and extension upgrade. An accidental independent refresh is not merely a freshness difference: it can separate relational evidence from the higher-level membership, policy, or publication revision that is supposed to consume it.
 
-The existing [`stream_table_spec()`](../src/api/spec.rs) function provides useful tooling metadata, but its present projection is not a complete semantic compatibility artifact. A coordinator must pin every result-affecting property, including defining-query semantics, output schema, owner execution identity, defining search path, dependency shape, source bindings, function dependencies, collations, row-identity and probe versions, and versioned semantic plans. It needs a canonical digest that changes when meaning changes but remains stable when only indexes, statistics, worker counts, or other physical choices change.
+The existing [`stream_table_spec()`](../src/api/spec.rs) function provides useful tooling metadata, but its present projection is not a complete execution-compatibility artifact. A coordinator must pin every tracked result-affecting property, including defining SQL, output schema, owner execution identity, defining search path, dependency shape, source bindings, function dependencies, collations, row-identity and probe versions, and versioned rewrite and DVM strategies. It needs a canonical digest that changes when a tracked input changes but remains stable for changes classified as contract-neutral.
 
 Finally, `pg_trickle` already computes logical output changes internally for stream-table-to-stream-table dependencies. The current architecture captures differential output and can compute a before-and-after logical difference for supported full paths so downstream stream tables remain incremental. Those internal buffers are deliberately private. A coordinating extension needs the same logical information through a supported contract: complete old and new rows grouped into immutable batches, a durable consumer cursor, transactional acknowledgement, and an explicit `FULL_INVALIDATION` marker when an exact delta is not available.
 
-The missing feature is therefore not another dataflow engine. It is a narrow, stable composition boundary around machinery that already exists inside `pg_trickle`.
+The first missing feature is a narrow, stable graph-coordination boundary around machinery that already exists inside `pg_trickle`. Durable public output consumption is a second feature with its own storage and operational contract.
 
 ---
 
@@ -100,25 +100,25 @@ The missing feature is therefore not another dataflow engine. It is a narrow, st
 
 ### 4.1 Goals
 
-The contract should let a trusted coordinating extension treat a `pg_trickle` graph as a versioned incremental component. A successful operation must answer four questions precisely: which graph was executed, which source state it represents, what each graph node did, and which terminal output changes remain for the coordinator to consume. The coordinator must then be able to write its own state and acknowledge those changes in the same PostgreSQL transaction.
+Graph V1 should let a trusted coordinating extension treat a `pg_trickle` graph as a versioned incremental component. A successful operation must answer three questions precisely: which graph was executed, which source state it represents, and what each graph node did. The coordinator must then be able to read terminal state and write its own state in the same PostgreSQL transaction. Delta V1 additionally answers which terminal output changes remain and lets the coordinator acknowledge them in that transaction.
 
-The contract must preserve encapsulation. Public consumers should not know whether source changes came from statement triggers, row triggers, WAL decoding, snapshot comparison, or a later capture adapter. They should not know whether output deltas are stored in a dedicated heap, a partitioned relation, or a future log representation. They should observe versioned contracts, a strict graph result, an opaque but complete boundary manifest, a typed logical delta relation, and durable acknowledgements.
+Both contracts preserve encapsulation. Graph V1 exposes execution contracts, a strict graph result, and an opaque but complete boundary manifest without exposing capture internals. Delta V1 exposes a typed logical delta relation and durable acknowledgements without stabilizing private buffer or payload storage.
 
-The contract must fail closed. A busy graph, stale contract digest, incomplete source boundary, missing output history, incompatible output schema, unknown row-identity version, authorization failure, or invalid acknowledgement must raise a stable error before the coordinator can mistake incomplete work for a valid refresh. Operational limits may block or reject work, but they may not silently skip evidence or advance a consumer cursor.
+Both contracts fail closed. Graph V1 rejects a busy graph, stale digest, incomplete boundary, unsupported contract version, or authorization failure before the coordinator can mistake incomplete work for a valid refresh. Delta V1 rejects missing output history, an incompatible output contract, an unknown row-identity version, or invalid acknowledgement. Operational limits may block work, but they may not silently skip evidence or advance a cursor.
 
-The contract should remain useful beyond `pg_mdm`. Its nouns are stream table, graph, contract, boundary, output delta, batch, and consumer. It does not mention entities, matches, golden records, clusters, or any other domain-specific concept.
+Both contracts should remain useful beyond `pg_mdm`. Their nouns are stream table, graph, contract, boundary, output delta, batch, and consumer. They do not include domain-specific entity-resolution concepts.
 
 ### 4.2 Non-goals
 
-V1 does not allow a caller to construct, edit, advance, or repair a source frontier. `pg_trickle` remains the sole authority for source visibility and completeness. The caller receives a source-boundary manifest as evidence of what was consumed, but cannot feed arbitrary positions back as refresh instructions.
+Graph V1 does not allow a caller to construct, edit, advance, or repair a source frontier. `pg_trickle` remains the sole authority for source visibility and completeness. The caller receives a source-boundary manifest as evidence of what was consumed, but cannot feed arbitrary positions back as refresh instructions.
 
-V1 does not expose private change-buffer relations. The implementation may reuse them, replace them, partition them, compact them, or introduce a different representation. Only the logical batch, typed row relation, acknowledgement, and gap behavior are public.
+Neither V1 contract exposes private change-buffer relations. Graph V1 exposes no buffer API. Delta V1 stabilizes only logical batches, the typed row relation, acknowledgement, and gap behavior.
 
-V1 does not execute arbitrary extension callbacks from the refresh engine. The coordinator invokes `pg_trickle` through SQL and remains responsible for its subsequent domain work. This avoids an open-ended callback ABI, recursion policy, security boundary, and failure-isolation problem.
+Graph V1 does not execute arbitrary extension callbacks from the refresh engine. The coordinator invokes `pg_trickle` through SQL and remains responsible for its subsequent domain work. This avoids an open-ended callback ABI, recursion policy, security boundary, and failure-isolation problem.
 
-V1 does not publish domain events, deliver messages to external systems, replace PostgreSQL logical replication, or provide a Kafka, NATS, HTTP, or outbox transport. A coordinating extension may publish its completed domain result through another mechanism after its local transaction commits.
+Neither V1 contract publishes domain events, delivers messages to external systems, replaces PostgreSQL logical replication, or provides a Kafka, NATS, HTTP, or outbox transport. A coordinating extension may publish its completed domain result through another mechanism after its local transaction commits.
 
-V1 does not support circular integration graphs, cross-database graphs, distributed transaction coordination, or multi-transaction graph execution. Those capabilities require separate semantics and proofs rather than hidden expansion of this contract.
+Graph V1 does not support circular integration graphs, cross-database graphs, distributed transaction coordination, or multi-transaction graph execution. Those capabilities require separate semantics and proofs rather than hidden expansion of this contract.
 
 ---
 
@@ -130,7 +130,7 @@ The motivating architecture has a simple responsibility boundary:
 
 A `pg_mdm` definition compiles into private stream tables that project source records, normalize fields, create bounded candidate blocks, produce canonical candidate pairs, compare those pairs, maintain structured pair evidence, and maintain golden-value candidates. `pg_mdm` then consumes changes from the terminal evidence relations, computes the complete affected identity closure, applies manual decisions and component rules, reconciles durable `mdm_id` values, selects golden values, creates review items, and publishes its own output tables.
 
-The V1 dependency maps directly to this proposal:
+The dependency maps directly to the two capability contracts:
 
 | `pg_mdm` requirement | `pg_trickle` contract |
 |---|---|
@@ -139,11 +139,12 @@ The V1 dependency maps directly to this proposal:
 | Prevent evidence from advancing independently of MDM publication | `EXTERNAL` orchestration |
 | Refresh the complete evidence graph inside `mdm.refresh()` | Strict transactional graph refresh |
 | Explain which source state the publication represents | Source-boundary manifest |
-| Recompute only affected identity components when safe | Durable typed output deltas |
-| Broaden safely when exact incremental impact is unavailable | `FULL_INVALIDATION` |
-| Roll everything back if MDM validation or publication fails | Shared outer transaction and transactional acknowledgement |
+| Publish correctly before Delta V1 is available | Complete terminal-table scan inside the strict graph transaction |
+| Recompute only affected identity components when measured scale requires it | Delta V1 typed output deltas |
+| Broaden safely when exact incremental impact is unavailable | Delta V1 `FULL_INVALIDATION` |
+| Roll everything back if MDM validation or publication fails | Shared outer transaction; Delta V1 acknowledgement joins it when enabled |
 
-Nothing in the SQL surface assumes that `pg_mdm` is installed. `pg_mdm` is a conformance consumer and a useful end-to-end test, not a dependency of `pg_trickle`.
+Nothing in the SQL API assumes that `pg_mdm` is installed. `pg_mdm` is a conformance consumer and a useful end-to-end test, not a dependency of `pg_trickle`.
 
 ---
 
@@ -151,11 +152,11 @@ Nothing in the SQL surface assumes that `pg_mdm` is installed. `pg_mdm` is a con
 
 This proposal is feasible because most of the difficult engine behavior already exists. `pg_trickle` maintains stream tables from declarative SQL, captures source changes through trigger and WAL paths, computes differential or full results, orders dependent stream tables through a graph, retains version frontiers, and finalizes output, frontiers, downstream change capture, cleanup, and refresh history transactionally. The current architecture also executes defining SQL under the stored stream-table owner and search-path contract, which is essential when a privileged coordinator invokes the engine.
 
-Stream-table-to-stream-table propagation already creates logical delete and insert rows for downstream consumers. A differential upstream refresh can expose its computed delta, while a supported full upstream refresh can compare old and new contents before propagating a minimal downstream difference. The V1 output-delta contract should reuse that logical algebra, but it must not make the current private buffer schema or naming convention public.
+Stream-table-to-stream-table propagation already creates logical delete and insert rows for downstream consumers. A differential upstream refresh can expose its computed delta, while a supported full upstream refresh can compare old and new contents before propagating a minimal downstream difference. Delta V1 should reuse that logical algebra, but it must not make the current private buffer schema or naming convention public.
 
 The versioned row-identity work also provides a strong foundation. A public output delta needs an opaque identity that is exact, deterministic, and consistent across full and differential paths. The integration contract should expose the active row-identity version and complete identity bytes for comparison and ordering while leaving parsing optional and separately versioned.
 
-The main implementation work is therefore orchestration and stabilization: expose canonical contracts, add durable external ownership, refactor graph refresh into a strict structured path, and create a supported durable cursor over logical output changes.
+Graph V1 needs canonical contracts, durable external ownership, and a strict structured graph-refresh path. Delta V1 separately needs durable typed logs and cursors over logical output changes.
 
 ---
 
@@ -163,11 +164,11 @@ The main implementation work is therefore orchestration and stabilization: expos
 
 A **coordinating extension** is a trusted PostgreSQL extension or database component that owns or has owner-equivalent authority over a set of stream tables and invokes this contract through SQL. PostgreSQL roles, object ownership, grants, and extension membership remain the security boundary; the contract does not attempt to authenticate a shared-library filename.
 
-A **stream-table contract** is the canonical, versioned description of one stream table's result-affecting semantics and execution identity. It is distinct from operational status, recent timings, planner statistics, scheduler tier, physical indexes, and other tuning state.
+A **stream-table execution contract** is the canonical, versioned description of one stream table's tracked definition, object binding, output schema, dependency versions, and execution identity. It is a syntactic and catalog contract, not a claim that `pg_trickle` can prove semantic equivalence between arbitrary SQL expressions. It is distinct from operational status, recent timings, planner statistics, scheduler tier, physical indexes, and other tuning state.
 
-A **refresh graph** is the transitive closure of stream-table dependencies reachable upstream from one or more named root stream tables. Base tables, materialized views, foreign or polled relations, and other non-stream sources appear in the graph contract as sources, but they are not refreshable graph members.
+A **refresh graph** is the transitive closure of stream-table dependencies reachable upstream from one or more named root stream tables. Non-stream relations appear in the graph contract as sources, not refreshable graph members. Graph V1 admits only the local source classes listed in Section 10.
 
-A **graph contract** is the canonical description and digest of the roots, member stream tables, dependency edges, deterministic topological order, output schemas, semantic versions, execution identities, and external source bindings that form one refresh graph.
+A **graph execution contract** is the canonical description and digest of the roots, member stream tables, dependency edges, deterministic topological order, output schemas, contract generations, execution identities, and external source bindings that form one refresh graph.
 
 A **source-boundary manifest** is an immutable, machine-readable statement of the lower and upper positions, snapshot tokens, upstream stream-table revisions, completeness classes, and source-contract digests consumed by one graph refresh. Position payloads are versioned and may remain opaque to callers.
 
@@ -181,9 +182,9 @@ An **output-delta consumer** is a durable, role-owned cursor over the output-del
 
 ## 8. Required invariants
 
-The V1 contract is governed by the following invariants. These are stronger than any suggested catalog layout, function spelling, or Rust module structure.
+The two V1 contracts are governed by the following invariants. Invariants 1 through 5 and 9 through 11 govern Graph V1. Invariants 6 through 8, 12, and 13 additionally govern Delta V1. These are stronger than any suggested catalog layout, function spelling, or Rust module structure.
 
-1. **One outer transaction.** `refresh_graph_strict()` performs no internal commit. Graph contents, node frontiers, refresh history, output-delta batches, the coordinator's own writes, and consumer acknowledgements commit or roll back with the caller's PostgreSQL transaction.
+1. **One outer transaction.** `refresh_graph_strict()` performs no internal commit. Graph contents, node frontiers, refresh history, and the coordinator's own writes commit or roll back with the caller's PostgreSQL transaction. When Delta V1 applies, output batches and consumer acknowledgements join that transaction.
 
 2. **Graph-wide validation before mutation.** The complete stream-table closure is resolved, authorized, locked, reloaded, and compared with the expected graph digest before any member is refreshed.
 
@@ -191,7 +192,7 @@ The V1 contract is governed by the following invariants. These are stronger than
 
 4. **Strict concurrency.** A competing refresh, query alteration, storage recreation, repair, or drop operation on any graph member produces an error or waits according to ordinary PostgreSQL lock policy. It is never converted into a successful skipped refresh.
 
-5. **Semantic contract pinning.** A refresh result names the graph digest and each member contract digest actually used. Unknown contract, semantic-plan, output-schema, row-identity, row-probe, or source-boundary versions fail closed.
+5. **Execution contract pinning.** A refresh result names the graph digest, each member contract generation, and each member contract digest actually used. Unknown contract, rewrite, DVM, output-schema, row-identity, row-probe, or source-boundary versions fail closed.
 
 6. **Exact delta or explicit invalidation.** A consumer receives either the complete logical output difference for a batch or an explicit `FULL_INVALIDATION` marker. Missing rows, truncated rows, expired rows, and fallback paths never masquerade as an empty exact batch.
 
@@ -203,7 +204,7 @@ The V1 contract is governed by the following invariants. These are stronger than
 
 10. **Owner-equivalent execution.** Defining SQL continues to execute under the stored stream-table owner and defining search-path contract. The integration API grants no authority over source data, current output, or retained deleted rows beyond the authority explicitly checked for the caller.
 
-11. **Public contract, private implementation.** A caller may use only the documented capability, contract, refresh, boundary, consumer, batch, and acknowledgement APIs, together with the generated read-only delta relation returned by registration. It may not derive or depend on private relation names, internal catalog identifiers, LSN placeholders, frontier JSON, or change-buffer schemas.
+11. **Public contract, private implementation.** A Graph V1 caller uses only the documented capability, execution-contract, refresh, and boundary APIs. A Delta V1 caller additionally uses the consumer, batch, acknowledgement, resnapshot, and returned typed-relation APIs. Neither may derive or depend on private relation names, internal catalog identifiers, LSN placeholders, frontier JSON, or change-buffer schemas.
 
 12. **No silent recovery.** If crash recovery, backup restore, PITR, manual DDL, storage loss, or an unsupported upgrade makes exact output history unverifiable, the consumer becomes `RESNAPSHOT_REQUIRED`. Repair may reconstruct infrastructure, but it may not invent a continuous exact history that no longer exists.
 
@@ -215,19 +216,19 @@ The V1 contract is governed by the following invariants. These are stronger than
 
 The exact SQL spelling may change during implementation review, but the following behavior is the proposal. Once capability major version 1 is declared stable, changing these semantics requires a new capability version rather than an undocumented function change.
 
-| Extension point | Purpose |
-|---|---|
-| `pgtrickle.integration_capabilities()` | Discover independently versioned integration contracts |
-| `pgtrickle.stream_table_contract()` | Return the canonical contract and digest for one stream table |
-| `pgtrickle.graph_contract()` | Return the canonical closure and digest for one refresh graph |
-| `pgtrickle.set_orchestration_mode()` | Persist `MANAGED` or `EXTERNAL` ownership of refresh scheduling |
-| `pgtrickle.refresh_graph_strict()` | Refresh a complete external graph synchronously and transactionally |
-| `pgtrickle.register_output_delta_consumer()` | Register a durable cursor over one stream table's logical output changes |
-| `pgtrickle.output_delta_batches()` | Inspect the continuous batch sequence after the acknowledged cursor |
-| Returned typed delta relation | Read complete old and new rows for exact batches |
-| `pgtrickle.ack_output_delta()` | Acknowledge an exact or resynchronized range transactionally |
-| `pgtrickle.output_delta_consumer_status()` | Inspect lag, retention, contract, and recovery state |
-| Resnapshot helpers | Establish a new full baseline under a transaction-scoped output lock |
+| Capability | Extension point | Purpose |
+|---|---|---|
+| Both | `pgtrickle.integration_capabilities()` | Discover independently versioned integration contracts |
+| Graph V1 | `pgtrickle.stream_table_contract()` | Return the execution contract, generation, and digest for one stream table |
+| Graph V1 | `pgtrickle.graph_contract()` | Return the canonical closure and digest for one refresh graph |
+| Graph V1 | `pgtrickle.set_orchestration_mode()` | Persist `MANAGED` or `EXTERNAL` ownership of refresh scheduling |
+| Graph V1 | `pgtrickle.refresh_graph_strict()` | Refresh a complete external graph synchronously and transactionally |
+| Delta V1 | `pgtrickle.register_output_delta_consumer()` | Register a durable cursor over one external stream table's logical output changes |
+| Delta V1 | `pgtrickle.output_delta_batches()` | Inspect the continuous batch sequence after the acknowledged cursor |
+| Delta V1 | Returned typed delta relation | Read complete old and new rows for exact batches |
+| Delta V1 | `pgtrickle.ack_output_delta()` | Acknowledge an exact or resynchronized range transactionally |
+| Delta V1 | `pgtrickle.output_delta_consumer_status()` | Inspect lag, retention, contract, and recovery state |
+| Delta V1 | Resnapshot helpers | Establish a new full baseline under a transaction-scoped output lock |
 
 ---
 
@@ -245,14 +246,10 @@ FROM pgtrickle.integration_capabilities();
 An illustrative result is:
 
 ```text
-capability                       major_version  minor_version  enabled  details
--------------------------------  -------------  -------------  -------  --------------------
-stream_table_contract            1              0              true     {...}
-graph_contract                   1              0              true     {...}
-external_orchestration           1              0              true     {...}
-transactional_graph_refresh      1              0              true     {...}
-source_boundary_manifest         1              0              true     {...}
-output_delta_consumer            1              0              true     {...}
+capability             major_version  minor_version  enabled  details
+---------------------  -------------  -------------  -------  --------------------
+external_graph_refresh  1              0              true     {...}
+output_delta_consumer   1              0              false    {"status":"experimental"}
 ```
 
 The function returns one row per capability:
@@ -270,7 +267,7 @@ RETURNS TABLE (
 
 A major version changes normative behavior or representation and requires explicit consumer support. A minor version is additive: it may add optional fields, supported source kinds, diagnostics, or admission limits without changing existing required fields or guarantees. A caller requires an exact supported major and may require a minimum minor. An absent or disabled capability is unsupported even when the package version appears recent enough.
 
-The `details` object may report supported PostgreSQL majors, row-identity versions, maximum graph members, accepted source kinds, typed-delta encoding versions, and whether exact full-refresh deltas are available on particular execution paths. Normative behavior belongs in the capability version and documentation, not in free-form details. The function should be inexpensive, side-effect free, and executable by `PUBLIC` because it reveals product capabilities rather than protected relation definitions or data.
+The `details` object may report supported PostgreSQL majors, row-identity versions, maximum graph members, admitted source-boundary classes, typed-delta encoding versions, and whether exact full-refresh deltas are available on particular execution paths. Graph V1 admits local regular and partitioned tables captured by trigger or WAL CDC, plus upstream stream tables that belong to the same graph. It rejects foreign tables, materialized-view polling sources, remote or distributed sources, and cross-database sources. A later minor version may add a source class only when it can produce one complete boundary under the same Graph V1 rules. Normative behavior belongs in the capability version and documentation, not in free-form details. The function should be inexpensive, side-effect free, and executable by `PUBLIC` because it reveals product capabilities rather than protected relation definitions or data.
 
 ---
 
@@ -302,7 +299,7 @@ Creation and bulk creation should also accept the mode through their structured 
 
 Changing from `MANAGED` to `EXTERNAL` acquires the normal lifecycle and refresh locks. It waits for or conflicts with in-flight work according to the caller's `lock_timeout`, and the scheduler rechecks orchestration mode under the same row-lock discipline used to claim a refresh. Once the mode change commits, no scheduler job accepted under stale managed state may remain able to publish afterward.
 
-Changing from `EXTERNAL` to `MANAGED` is rejected while a strict graph refresh holds the node, while an output resnapshot lock is active, or while schedule configuration is invalid for managed execution. The operation does not acknowledge external consumers, drop retained history, or imply that an external coordinator has accepted the latest output.
+Changing from `EXTERNAL` to `MANAGED` is rejected while a strict graph refresh holds the node, while an output resnapshot lock is active, while output consumers remain registered, or while schedule configuration is invalid for managed execution. The administrator must drop consumers explicitly before transferring scheduling ownership. The mode change does not acknowledge them or imply that an external coordinator accepted the latest output.
 
 ### 11.3 Relationship to scheduler pause
 
@@ -330,23 +327,31 @@ FROM pgtrickle.stream_table_contract(
 ```sql
 pgtrickle.stream_table_contract(stream_table regclass)
 RETURNS TABLE (
-    contract_version smallint,
-    contract_digest  bytea,
-    contract         jsonb
+  contract_version    smallint,
+  contract_generation bigint,
+  contract_digest     bytea,
+  contract            jsonb
 )
 ```
 
-The contract contains everything that can change the logical contents of the stream table, the interpretation of its row identity, or the database identity under which defining SQL runs. At minimum it includes the schema-qualified stream-table identity and current relation binding; normalized defining-query and original-query digests; owner role, defining search path, and result-affecting row-security execution policy; ordered output schema with PostgreSQL type, typmod, collation, and nullability; row-identity and row-probe versions; versioned rewrite and DVM strategies that can affect logical output; tracked function and extension dependencies; source and stream-table dependencies; source schema or contract fingerprints; and the durable orchestration mode.
+The contract records every tracked input that can change the stream table's logical contents, row-identity interpretation, or execution identity. At minimum it includes an opaque stream-table object identity, schema-qualified name, and current relation binding; original and normalized defining-query digests; owner role, defining search path, and result-affecting row-security execution policy; ordered output schema with PostgreSQL type, typmod, collation, and nullability; row-identity and row-probe versions; versioned rewrite and DVM strategies; tracked function and extension dependencies; source and stream-table dependencies; source schema or execution-contract fingerprints; the explicit database-instance identity defined by v0.92 clone isolation; and the durable orchestration mode.
 
-The contract excludes physical indexes, planner statistics, recent costs, worker counts, scheduler tier, batch sizes, cached plans, and other choices that may affect performance but are not allowed to affect meaning. A storage or plan optimization may therefore preserve the digest when it provably enumerates the same logical result.
+`contract_generation` is a per-object, monotonically increasing catalog value. The same transaction that changes any normative contract input increments it. Rollback restores the prior generation. Recreating a dropped stream table assigns a new opaque object identity; rebinding an existing object increments its generation. The generation provides a cheap invalidation check; the digest proves the complete tracked contract.
+
+The contract excludes physical indexes, planner statistics, recent costs, worker counts, scheduler tier, batch sizes, cached plans, and other choices that may affect performance but are not tracked execution inputs. A storage or plan optimization may preserve the generation and digest only when the implementation classifies it as contract-neutral. Matching digests prove equality of the tracked representation, not semantic equivalence between different SQL expressions.
 
 An illustrative object is:
 
 ```json
 {
   "contract_version": 1,
+  "contract_generation": 7,
   "stream_table": "mdm_internal.customer_pair_evidence_v3",
-  "relation_identity": {"oid": 48122, "database_lineage": "sha256:..."},
+  "relation_identity": {
+    "object_identity": "opaque-stream-table-id",
+    "oid": 48122,
+    "database_instance_id": "opaque-instance-id"
+  },
   "execution_identity": {
     "owner": "mdm_owner",
     "defining_search_path_digest": "sha256:...",
@@ -355,7 +360,8 @@ An illustrative object is:
   "query": {
     "original_digest": "sha256:...",
     "normalized_digest": "sha256:...",
-    "semantic_plan_digest": "sha256:..."
+    "rewrite_contract_version": 1,
+    "dvm_contract_version": 1
   },
   "output_schema": {
     "digest": "sha256:...",
@@ -374,7 +380,7 @@ An illustrative object is:
 }
 ```
 
-Every canonicalization rule and digest algorithm is part of the contract version. Human-readable optional fields may be added, but the document must identify which fields are normative digest inputs.
+Contract version 1 computes SHA-256 over an ordered typed byte encoding, not over JSON text. Each value is encoded as a fixed field tag, a type tag, a big-endian payload length, and payload bytes. Integers use fixed-width big-endian encoding, strings use UTF-8 bytes without Unicode rewriting, byte strings remain raw, null has its own type tag, and arrays start with a count followed by encoded elements in their specified canonical order. Normative fields have fixed tags and order. Sets are sorted by their encoded bytes before hashing. The JSON object is a diagnostic projection of those same values and is not itself a digest input. A contract-version change is required to alter this encoding or the normative field set.
 
 ### 12.2 Graph contract API
 
@@ -393,15 +399,15 @@ FROM pgtrickle.graph_contract(
 ```sql
 pgtrickle.graph_contract(roots regclass[])
 RETURNS TABLE (
-    contract_version smallint,
-    graph_digest      bytea,
-    contract          jsonb
+  contract_version smallint,
+  graph_digest      bytea,
+  contract          jsonb
 )
 ```
 
-The graph object contains the canonical root set, complete upstream stream-table closure, each member contract digest, dependency edges, deterministic topological order, external source descriptors, and one digest of the complete graph contract. Duplicate roots are rejected. Capability version 1 rejects cycles even when ordinary `pg_trickle` supports a separately governed monotone-cycle mode, because a strict external contract needs explicit fixed-point and delta semantics before cycles can be admitted.
+The graph object contains the canonical root set, complete upstream stream-table closure, each member's contract generation and digest, dependency edges, deterministic topological order, admitted external source descriptors, and one digest of the complete graph execution contract. Duplicate roots are rejected. Capability version 1 rejects cycles even when ordinary `pg_trickle` supports a separately governed monotone-cycle mode, because a strict external contract needs explicit fixed-point semantics before cycles can be admitted.
 
-The graph digest changes when a root or member is added, removed, replaced, rebound, or semantically altered. It does not change merely because an index is rebuilt, statistics change, or a different worker count would be used by ordinary managed scheduling. A graph contract is descriptive rather than a lock. `refresh_graph_strict()` re-resolves and revalidates the graph under the locks it acquires; a digest read earlier is an optimistic expectation, not permission to skip current validation.
+The graph digest uses the same versioned typed encoding. Roots and members are sorted by database-local relation identity, edges by encoded endpoint pair, and the topological order uses that same relation identity as its tie-breaker. The digest changes when a root or member is added, removed, replaced, rebound, or has a new execution-contract digest. It does not change merely because an index is rebuilt, statistics change, or a different worker count would be used by ordinary managed scheduling. A graph contract is descriptive rather than a lock. `refresh_graph_strict()` re-resolves and revalidates the graph under the locks it acquires; a digest read earlier is an optimistic expectation, not permission to skip current validation.
 
 ---
 
@@ -414,13 +420,12 @@ The core refresh API is:
 ```sql
 SELECT *
 FROM pgtrickle.refresh_graph_strict(
-    roots                       => ARRAY[
+  roots                 => ARRAY[
         'mdm_internal.customer_pair_evidence_v3'::regclass,
         'mdm_internal.customer_golden_candidates_v3'::regclass
     ],
-    expected_graph_digest       => decode(:graph_digest_hex, 'hex'),
-    require_complete_boundaries => true,
-    full_policy                 => 'ALLOW'
+  expected_graph_digest => decode(:graph_digest_hex, 'hex'),
+  full_policy           => 'ALLOW'
 );
 ```
 
@@ -428,10 +433,9 @@ An illustrative signature is:
 
 ```sql
 pgtrickle.refresh_graph_strict(
-    roots                       regclass[],
-    expected_graph_digest       bytea,
-    require_complete_boundaries boolean DEFAULT true,
-    full_policy                 text DEFAULT 'ALLOW'
+  roots                 regclass[],
+  expected_graph_digest bytea,
+  full_policy           text DEFAULT 'ALLOW'
 )
 RETURNS pgtrickle.graph_refresh_result
 ```
@@ -445,8 +449,9 @@ graph_digest            bytea
 source_boundary         jsonb
 source_boundary_digest  bytea
 node_results            jsonb
-terminal_delta_tokens   jsonb
 ```
+
+Graph V1 does not return or require output-delta tokens. When Delta V1 is enabled and a node has registered consumers, its `node_results` entry may include an `output_delta` object as an additive diagnostic. Consumers discover authoritative pending batches through the Delta V1 APIs.
 
 `full_policy` has two initial values. `ALLOW` permits any correct full or reinitialization fallback selected by the existing engine. `ERROR` rejects a member that cannot remain on an incremental or scoped-recomputation path and is intended for diagnostics or tightly controlled workloads. The policy never forces an unsafe incremental plan.
 
@@ -455,31 +460,31 @@ terminal_delta_tokens   jsonb
 The implementation performs the following logical sequence:
 
 1. Resolve the roots and compute the complete upstream stream-table closure.
-2. Reject duplicate roots, unsupported cycles, temporary relations, cross-database references, `IMMEDIATE` members, and members not in `EXTERNAL` orchestration mode.
+2. Reject duplicate roots, unsupported cycles, temporary relations, cross-database references, `IMMEDIATE` members, members not in `EXTERNAL` orchestration mode, and source classes not admitted by Graph V1.
 3. Verify that the caller is authorized to refresh every member.
-4. Sort members by a canonical database-local lock key and acquire every advisory, lifecycle, and catalog-row lock before refreshing any member.
+4. Sort members by a canonical database-local relation key and acquire each member's existing refresh, lifecycle, and catalog-row locks in that order. Do not use one hash of the member set as the graph lock.
 5. Reload every member under lock, recompute the graph contract, and compare it with `expected_graph_digest`.
-6. Allocate one graph-refresh identifier and one immutable graph-refresh context.
-7. Compute one source-boundary decision for every external source used by the graph.
+6. Lock admitted external source relations in canonical OID order, then compute one complete source-boundary decision for every external source used by the graph.
+7. Allocate one graph-refresh identifier and one immutable graph-refresh context.
 8. Refresh members synchronously in deterministic topological order, passing the immutable context to each member.
-9. Finalize node state and output-delta batches through the same transactional finalizer used by ordinary refresh paths.
+9. Finalize each member through the same transactional finalizer used by ordinary refresh paths. When Delta V1 applies, that finalizer also writes the member's output batch.
 10. Return the structured result while transaction-scoped locks remain held.
 
-Any failure raises an error. The API never returns a partial list of successful members. The first implementation executes in the calling backend and does not dispatch work to independent background workers. It may reuse bounded internal batching and temporary relations as long as all effects remain within the caller's outer transaction.
+All admission, authorization, contract, and boundary checks complete before the first member refresh begins. Any failure raises an error. The API never returns a partial list of successful members and never uses `SKIP LOCKED` or converts a busy member into a successful skip. The first implementation executes in the calling backend and does not dispatch work to independent background workers. It may reuse bounded internal batching and temporary relations as long as all effects remain within the caller's outer transaction.
 
 ### 13.3 Transaction semantics
 
-The function performs no commit. Calling it in autocommit mode is valid, but a coordinating extension obtains composition semantics by invoking it inside its own function or explicit transaction and performing domain work before commit. Stream-table data changes, frontiers, history, output-delta batches, cleanup, group metadata, the coordinator's writes, and acknowledgements therefore commit or roll back together.
+The function performs no commit. Calling it in autocommit mode is valid, but a coordinating extension obtains composition semantics by invoking it inside its own function or explicit transaction and performing domain work before commit. Stream-table data changes, frontiers, history, cleanup, group metadata, and the coordinator's writes therefore commit or roll back together. When Delta V1 applies, output batches and acknowledgements join that same transaction.
 
-The function returns only after every member has completed and finalized or one member has caused the call to fail. Internal savepoints may be used for bounded cleanup, but they do not create progressive visibility or an independently committed successful subset. A no-data path remains a strict execution: it validates contracts, locks, source boundaries, and output-log health before returning `NO_DATA`.
+The function returns only after every member has completed and finalized or one member has caused the call to fail. Per-member finalization remains inside the caller's outer transaction; there is no deferred graph-wide finalizer and no internal commit. Internal savepoints may be used for bounded cleanup, but they do not create progressive visibility or an independently committed successful subset. A no-data path remains a strict execution: it validates contracts, locks, and source boundaries before returning `NO_DATA`. When Delta V1 applies, it also validates output-log health and records an exact zero-row batch.
 
 ### 13.4 Coherent source boundary
 
 The graph-refresh context contains one immutable upper-bound decision for local CDC sources and one validated position or snapshot token for every other supported source. A source shared by several graph members appears once in the manifest, and every member consumes the same upper boundary. No member may call a current-position helper again and substitute a newer value.
 
-For local trigger or WAL sources, the position is the safe durable boundary already governed by `pg_trickle` frontier invariants. For an upstream stream table inside the graph, the downstream member consumes the output state and delta produced earlier in the same topological refresh. For a materialized view or polling source, the manifest identifies the snapshot-comparison boundary and its completeness. A remote or distributed source is accepted only when its provider can prove that data and position belong to one complete boundary.
+For local trigger or WAL sources, the position is the safe durable boundary already governed by `pg_trickle` frontier invariants. For an upstream stream table inside the graph, the downstream member consumes the output state produced earlier in the same topological refresh. Graph V1 rejects materialized-view polling, foreign, remote, distributed, and cross-database sources. Admitting any of those sources requires a later minor version with a concrete lock and boundary-proof mechanism.
 
-When `require_complete_boundaries` is true, an unknown, partial, unverifiable, or missing boundary aborts the graph refresh. A later minor contract may permit explicitly non-proven boundaries for generic consumers, but a consumer that requests complete boundaries must never receive a successful result with hidden uncertainty.
+An unknown, partial, unverifiable, or missing boundary always aborts Graph V1 refresh. Completeness is not optional and cannot be weakened in a minor version.
 
 ### 13.5 Result schema
 
@@ -497,19 +502,16 @@ An illustrative `node_results` entry is:
     "data_timestamp": "2026-09-01T18:02:11.531Z",
     "frontier": {"version": 1, "opaque": "..."},
     "row_identity_version": 2,
-    "row_probe_version": 1,
-    "output_delta": {
-      "batch_token": 5502,
-      "mode": "EXACT",
-      "row_count": 48
-    }
+    "row_probe_version": 1
   }
 }
 ```
 
+When Delta V1 applies, the member object may also contain `"output_delta": {"batch_token": "...", "mode": "EXACT", "row_count": 48}`.
+
 `result_class` is a small stable normalization such as `NO_DATA`, `INCREMENTAL`, or `FULL`. `action` may expose a more specific versioned engine path such as differential, full, reinitialize, TopK, or partition recomputation. Consumers should use the stable class for control flow and retain the detailed action for diagnosis.
 
-Reported row counts are exact or `NULL` with a machine-readable quality field. An estimate must never be presented as an exact inserted or deleted count. A no-data member may still advance a validated observation frontier, but its exact output-delta batch contains zero rows.
+Reported row counts are exact or `NULL` with a machine-readable quality field. An estimate must never be presented as an exact inserted or deleted count. A no-data member may still advance a validated observation frontier. When Delta V1 applies, it produces an exact zero-row batch.
 
 ### 13.6 Busy behavior
 
@@ -527,8 +529,7 @@ The source-boundary manifest is a first-class versioned result rather than an in
   "graph_refresh_id": 1208,
   "captured_at": "2026-09-01T18:02:10.992Z",
   "database_identity": {
-    "system_identifier_digest": "sha256:...",
-    "database_oid": 16384
+    "database_instance_id": "opaque-instance-id"
   },
   "completeness": "PROVEN",
   "sources": [
@@ -539,21 +540,8 @@ The source-boundary manifest is a first-class versioned result rather than an in
       "capture_mode": "TRIGGER",
       "position": {
         "version": 1,
-        "kind": "WAL_LSN_RANGE",
-        "lower": "0/16B6A90",
-        "upper": "0/16D0200"
-      },
-      "completeness": "PROVEN"
-    },
-    {
-      "relation": "registry.company_snapshot",
-      "kind": "MATERIALIZED_VIEW",
-      "source_contract_digest": "sha256:...",
-      "capture_mode": "SNAPSHOT_COMPARE",
-      "position": {
-        "version": 1,
-        "kind": "SNAPSHOT_TOKEN",
-        "token": "opaque-provider-value"
+        "kind": "OPAQUE_CDC_BOUND",
+        "token": "opaque-local-bound"
       },
       "completeness": "PROVEN"
     }
@@ -563,7 +551,7 @@ The source-boundary manifest is a first-class versioned result rather than an in
 
 The manifest has an authoritative digest returned separately. Callers store the object for explanation but treat individual source positions as opaque unless another capability explicitly documents them. A caller may not construct a replacement manifest, edit an upper position, or feed historical boundary JSON back into ordinary refresh as an instruction.
 
-The database identity binds graph results and delta tokens to one database lineage so a token copied from a restored clone or another database cannot be mistaken for live state in the current database. The exact lineage identifier may be protected or hashed, but token validation must include it.
+`database_instance_id` is the explicit capture-ownership identity required by [roadmap/v0.92.0.md](../roadmap/v0.92.0.md). PostgreSQL's system identifier and database OID are insufficient because a physical clone can preserve both. Graph V1 cannot be enabled until clone isolation creates and validates this identity before capture resumes. Graph results, refresh identifiers, Delta V1 batch tokens, and acknowledgements bind to it. A clone with a new identity cannot reuse state issued by the source database.
 
 A boundary manifest states completeness, not merely recency. A timestamp saying when a refresh ran is not proof that every relevant source change was included. When a source cannot provide a complete boundary under the requested contract, the graph refresh fails before publication.
 
@@ -573,9 +561,13 @@ A boundary manifest states completeness, not merely recency. A timestamp saying 
 
 ### 15.1 Overview
 
-A terminal stream table is useful to another extension only when the extension can identify its logical changes without querying private `changes_pgt_*` relations. The V1 consumer contract records one shared logical output log per opted-in stream table and one durable acknowledgement position per consumer. The log is created only when at least one external consumer exists, so ordinary stream tables pay no output-log storage or write cost.
+Delta V1 is optional. A Graph V1 coordinator can always read the complete terminal stream table after strict refresh. Delta V1 avoids that scan without exposing private `changes_pgt_*` relations.
+
+The consumer contract creates exactly one shared logical output log and one shared typed read-only relation per opted-in stream table, plus one durable acknowledgement position per consumer. It never duplicates payload by consumer. The log exists only while the stream table has external consumers, so ordinary stream tables pay no output-log storage or write cost. Delta consumers may register only on stream tables in `EXTERNAL` orchestration mode.
 
 The output delta describes changes to the stream table itself, not raw source events. It is independent of whether the producing refresh was differential, scoped recomputation, reinitialization, or full. An exact batch transforms the previous visible stream-table multiset into the new visible multiset. If row identity remains the same while non-identity values change, the batch contains a `DELETE` carrying the complete old row followed by an `INSERT` carrying the complete new row.
+
+The output-contract digest combines the stream-table contract generation and digest, ordered public output schema, row-identity version, and Delta V1 encoding version. It changes whenever an existing consumer could no longer interpret its baseline and later batches under the same rules.
 
 ### 15.2 Registration
 
@@ -587,7 +579,7 @@ FROM pgtrickle.register_output_delta_consumer(
     stream_table             => 'mdm_internal.customer_pair_evidence_v3'::regclass,
     consumer_name            => 'pg_mdm/customer/v3/pair-evidence',
     expected_contract_digest => decode(:stream_contract_digest_hex, 'hex'),
-    start_position           => 'CURRENT'
+  start_position           => 'RESNAPSHOT_REQUIRED'
 );
 ```
 
@@ -596,7 +588,7 @@ pgtrickle.register_output_delta_consumer(
     stream_table             regclass,
     consumer_name            text,
     expected_contract_digest bytea,
-    start_position           text DEFAULT 'CURRENT'
+    start_position           text DEFAULT 'RESNAPSHOT_REQUIRED'
 )
 RETURNS pgtrickle.output_delta_consumer_registration
 ```
@@ -612,11 +604,14 @@ acknowledged_batch_token   bigint
 output_contract_digest     bytea
 row_identity_version       smallint
 state                      text
+state_reason               text
 ```
 
-`CURRENT` creates the cursor at the latest completed batch and claims no earlier history. It is appropriate when the coordinator already has a matching baseline or when the stream table is newly created and unpopulated. A coordinator that does not already possess a matching baseline registers in `RESNAPSHOT_REQUIRED` mode and establishes one through the resnapshot protocol before claiming current state.
+Registration requires the stream table to be in `EXTERNAL` orchestration mode and compares `expected_contract_digest` with its locked stream-table contract. A managed table, stale digest, unsupported row-identity version, or unauthorized caller fails before creating consumer state.
 
-Registration is transactional and idempotent for `(stream_table, owner_role, consumer_name)` only when the expected digest and options are identical. A conflicting registration raises an error rather than silently altering an existing cursor. The function creates or references one shared typed output log for the stream table and returns a read-only relation through which the consumer can read exact rows. Callers use the returned `regclass`; they do not derive its physical name.
+The default creates the consumer in `RESNAPSHOT_REQUIRED` with reason `INITIAL_BASELINE_REQUIRED`. The coordinator must establish a baseline through the resnapshot protocol. `CURRENT` is accepted only when `pg_trickle` can prove that the stream table is newly created, has never completed a refresh, and is empty. That case creates an `ACTIVE` consumer at token zero. Delta V1 does not accept an unverifiable caller assertion that an existing external baseline matches current state.
+
+Registration is transactional and idempotent for `(stream_table, owner_role, consumer_name)` only when the expected digest and options are identical. A conflicting registration raises an error rather than silently altering an existing cursor. The function creates or references the stream table's shared typed output log and read-only relation. Every consumer of that stream table receives the same `delta_relation` identity. Callers use the returned `regclass`; they do not derive its physical name.
 
 ### 15.3 Typed delta relation
 
@@ -632,9 +627,9 @@ row_identity      bytea    NOT NULL
 
 The relation preserves the stream table's user-visible PostgreSQL types and contains complete old values for `DELETE` and complete new values for `INSERT`. Private generated columns are not exposed, except for the opaque canonical `row_identity` needed to pair and order changes. The relation is read only. Its physical name and implementation are not stable; the returned relation identity and logical schema remain valid for the lifetime of the consumer contract.
 
-Rows are ordered by `(batch_token, ordinal)`. Ordinals are deterministic within a batch, and deletion precedes insertion for a same-identity update. Consumers may page within the relation, but acknowledgement remains batch-granular so a partially read batch cannot be discarded accidentally.
+`ordinal` is unique within a batch, starts at zero, and is immutable once stored. A `DELETE` precedes the matching `INSERT` for a same-identity update. Order between distinct row identities has no public meaning. Consumers apply every row as a multiset operation and must not infer source transaction order from the ordinal. Consumers may page within the relation, but acknowledgement remains batch-granular so a partially read batch cannot be discarded accidentally.
 
-The recommended initial implementation uses one protected typed output-log table per stream table and one security-controlled read-only view per consumer. The output log is distinct from the private stream-table-to-stream-table buffer so this public contract does not freeze an existing internal schema. A later physical implementation may share storage when it preserves the same public behavior, types, retention, and upgrade boundary.
+The initial implementation uses one protected typed output-log table and one security-controlled read-only view per stream table. The output log is distinct from the private stream-table-to-stream-table buffer so this public contract does not freeze an existing internal schema. Physical names are not stable. A later implementation may change physical storage when it preserves the same single-copy payload, public relation behavior, types, retention, and upgrade boundary.
 
 ### 15.4 Batch metadata
 
@@ -644,7 +639,7 @@ Consumers inspect batches through:
 SELECT *
 FROM pgtrickle.output_delta_batches(
     consumer_id   => :consumer_id,
-    through_token => :terminal_batch_token
+  through_token => :through_token
 );
 ```
 
@@ -668,7 +663,9 @@ RETURNS TABLE (
 )
 ```
 
-The result begins after the consumer's acknowledged token and ends at `through_token`, or at the newest retained token when no upper token is supplied. It returns a continuous ordered sequence or raises a delta-gap error. It never silently omits an unavailable batch.
+Batch tokens are positive, monotonically increasing integers scoped to one stream table's output log and database-instance identity. The log head is a catalog counter locked and incremented in the same transaction that inserts batch metadata and payload. PostgreSQL sequences must not allocate these tokens because sequence increments do not roll back. Every committed refresh of an opted-in stream table records exactly one metadata row, including exact zero-row and invalidation batches. Token zero denotes the pristine empty origin and never has payload.
+
+The result begins after the consumer's acknowledged token and ends at `through_token`, or at the current log head when no upper token is supplied. It must return every metadata token in that closed range in order. A missing token, payload relation, required payload row, or continuity sentinel changes the consumer to `RESNAPSHOT_REQUIRED` with reason `LOG_INCOMPLETE` and raises a delta-gap error. It never treats missing history as no changes.
 
 The initial modes are:
 
@@ -677,25 +674,25 @@ The initial modes are:
 | `EXACT` | The typed delta relation contains the complete logical delete and insert rows for the batch; an exact batch may contain zero rows |
 | `FULL_INVALIDATION` | An exact logical row delta is unavailable; the consumer must read the complete current stream table at the transactionally stable graph result before acknowledging |
 
-A differential refresh produces an exact batch when the output log is healthy. A full refresh produces an exact batch when the refresh path already has a complete before-and-after logical difference. Otherwise it produces `FULL_INVALIDATION`. V1 does not require `pg_trickle` to perform an additional unbounded full-table diff solely to satisfy an external consumer. Initial population may be represented as exact insertions when already materialized, but invalidation is always a permitted truthful result.
+A differential refresh produces an exact batch when the output log is healthy. A full refresh produces an exact batch when the refresh path already has a complete before-and-after logical difference. Otherwise it produces `FULL_INVALIDATION`. Delta V1 does not require `pg_trickle` to perform an additional unbounded full-table diff solely to satisfy an external consumer. Initial population may be represented as exact insertions when already materialized, but invalidation is always a permitted truthful result.
 
 ### 15.5 Reading and acknowledgement
 
-A V1 coordinator reads the graph result, selects batch metadata through the terminal token returned for the relevant root, and follows one of two paths. If every batch in the range is exact, it reads the typed relation through that token and applies the logical changes. If the range contains a full invalidation, it reads the complete current terminal stream table while the strict graph transaction still holds a stable graph state and runs its full reference computation.
+An `ACTIVE` Delta V1 coordinator refreshes the graph, then calls `output_delta_batches()` for each terminal consumer while the strict graph locks remain held by the caller's transaction. The newest returned batch token is the acknowledgement target. If every batch in the range is exact, the coordinator reads the typed relation through that token and applies the logical changes. If the range contains a full invalidation, it reads the complete current terminal stream table and runs its full reference computation.
 
 Acknowledgement is explicit:
 
 ```sql
 SELECT pgtrickle.ack_output_delta(
     consumer_id   => :consumer_id,
-    through_token => :terminal_batch_token,
+  through_token => :through_token,
     disposition   => 'APPLIED'
 );
 ```
 
-`disposition` is `APPLIED` when all acknowledged batches were exact and the consumer applied their rows. It is `RESYNCHRONIZED` when the range contained an invalidation and the consumer rebuilt from the complete terminal table. `APPLIED` is rejected for a range containing `FULL_INVALIDATION`. The acknowledgement is monotonic, validates the output contract and row-identity version, and updates the durable cursor in the caller's transaction.
+`disposition` is `APPLIED` when all acknowledged batches were exact and the consumer applied their rows. It is `RESYNCHRONIZED` when the range contained an invalidation and the consumer rebuilt from the complete terminal table. `APPLIED` is rejected for a range containing `FULL_INVALIDATION`. `RESYNCHRONIZED` requires the output lock held by the strict graph refresh or resnapshot protocol. The acknowledgement is monotonic, validates the output contract and row-identity version, and updates the durable cursor in the caller's transaction.
 
-Reading never acknowledges. Acknowledging an already acknowledged token is an idempotent no-op only when it belongs to the same consumer, output contract, and database lineage. Acknowledging beyond the newest visible token, across a gap, across an invalid contract, or out of order raises a stable error.
+Reading never acknowledges. `ack_output_delta()` is valid only in `ACTIVE`; a consumer in `RESNAPSHOT_REQUIRED` must use the resnapshot protocol. Acknowledging an already acknowledged token is an idempotent no-op only when it belongs to the same consumer, output contract, and database-instance identity. Acknowledging beyond the current log head, across a gap, across an invalid contract, or out of order raises a stable error.
 
 ### 15.6 Resnapshot protocol
 
@@ -709,12 +706,12 @@ FROM pgtrickle.begin_output_delta_resnapshot(:consumer_id);
 -- consumer-owned state while the transaction-scoped output lock is held.
 
 SELECT pgtrickle.ack_output_delta_resnapshot(
-    consumer_id    => :consumer_id,
+    consumer_id      => :consumer_id,
     resnapshot_token => :resnapshot_token
 );
 ```
 
-The begin call returns the stream table, stable output batch token, contract digest, row-identity version, and one-use token. It locks the output against refresh or semantic change until transaction end. The acknowledgement advances the cursor to that stable token and moves the consumer to `ACTIVE`. A rollback leaves the cursor and consumer state unchanged.
+The begin call is valid only in `RESNAPSHOT_REQUIRED`. It returns the stream table, current output-log head, output-contract digest, row-identity version, and a one-use token bound to the consumer and database-instance identity. It locks the stream table against refresh or contract change until transaction end. The acknowledgement advances the cursor to that head, clears the reason, and moves the consumer to `ACTIVE`. Both calls and the complete terminal-table read must occur in one transaction. A rollback leaves the cursor and consumer state unchanged.
 
 ### 15.7 Consumer lifecycle
 
@@ -728,23 +725,39 @@ INVALIDATED
 DROPPED
 ```
 
-`ACTIVE` means a continuous exact-or-invalidation sequence exists after the cursor. `PAUSED` retains history but rejects acknowledgement and is an operator control. `RESNAPSHOT_REQUIRED` means exact retained history was lost, deliberately expired, or made unverifiable by recovery. `INVALIDATED` means the stream-table semantic or output contract changed and the consumer must be recreated or explicitly rebound after a new baseline. `DROPPED` may remain only in audit history.
+`ACTIVE` means a continuous exact-or-invalidation sequence exists after the cursor. `PAUSED` retains history but rejects acknowledgement and is an operator control. `RESNAPSHOT_REQUIRED` means the consumer has no proven baseline or retained history became unavailable. `INVALIDATED` means the stream-table or output contract changed and the consumer must be recreated or explicitly rebound after a new baseline. `DROPPED` may remain only in audit history.
 
-A semantic or output-changing `ALTER QUERY` is rejected while active consumers exist under capability version 1. `pg_mdm` avoids in-place mutation by creating a new private graph for each entity-definition version. Dropping a stream table requires dropping or explicitly cascading its consumers. Dropping a consumer is authorization-checked and may allow retained rows to be cleaned immediately.
+State transitions record one stable reason code:
+
+| Reason | State | Meaning |
+|---|---|---|
+| `INITIAL_BASELINE_REQUIRED` | `RESNAPSHOT_REQUIRED` | A new consumer has no proven baseline |
+| `HISTORY_EXPIRED` | `RESNAPSHOT_REQUIRED` | An administrator explicitly discarded history behind the cursor |
+| `LOG_INCOMPLETE` | `RESNAPSHOT_REQUIRED` | Metadata, payload, relation, or continuity validation failed |
+| `RECOVERY_INCOMPLETE` | `RESNAPSHOT_REQUIRED` | Restored consumer state is ahead of recoverable output history |
+| `DATABASE_INSTANCE_CHANGED` | `RESNAPSHOT_REQUIRED` | Clone activation assigned a new database-instance identity |
+| `CONTRACT_CHANGED` | `INVALIDATED` | The stream-table or output contract no longer matches registration |
+| `ADMIN_RESET` | `RESNAPSHOT_REQUIRED` | An administrator explicitly requested a new baseline |
+
+An execution-contract or output-contract-changing `ALTER QUERY` is rejected while active consumers exist under Delta V1. `pg_mdm` avoids in-place mutation by creating a new private graph for each entity-definition version. Dropping a stream table requires dropping or explicitly cascading its consumers. Dropping a consumer is authorization-checked and may allow retained rows to be cleaned immediately.
 
 ### 15.8 Retention and backpressure
 
 The output log is retained through the minimum acknowledged batch among active consumers. Internal downstream stream-table consumers continue to use their private frontier contract; an implementation may combine retention minima physically, but neither public cursor is represented as the other.
 
-The default V1 retention behavior is fail closed. A slow consumer may retain substantial data, and `pg_trickle` must expose row, byte, batch, and age lag. If writing another exact batch would exceed a configured hard resource limit, the refresh fails before unacknowledged history is lost. An administrator may explicitly move a consumer to `RESNAPSHOT_REQUIRED`, record the gap boundary and reason, and then permit cleanup. Silent expiration is never allowed.
+The default V1 retention behavior is fail closed. A slow consumer may retain substantial data, and `pg_trickle` must expose row, byte, batch, and age lag. Soft limits warn but do not delete history. If finalizing a new exact batch would cross an enabled hard limit, the refresh raises `PGT_EXT_CONSUMER_BLOCKED` before inserting batch metadata, payload, or advancing the transactional log head. The outer refresh transaction then rolls back.
+
+An administrator may explicitly move one or more blocking consumers to `RESNAPSHOT_REQUIRED` with reason `HISTORY_EXPIRED` or `ADMIN_RESET`. That transaction records the discarded-through token before cleanup becomes eligible. The administrator then retries the refresh. Delta V1 never expires history, truncates the current batch, or changes consumer state automatically merely because a size or age threshold elapsed.
 
 Output logs required by active consumers are logged and crash-safe. Loss of a log sentinel, batch metadata, typed relation, or continuity proof changes affected consumers to `RESNAPSHOT_REQUIRED`; it is never interpreted as no changes.
 
 ---
 
-## 16. V1 end-to-end protocol
+## 16. V1 end-to-end protocols
 
-The complete composition pattern is:
+### 16.1 Graph V1 with complete terminal reads
+
+Graph V1 is complete without Delta V1:
 
 ```sql
 BEGIN;
@@ -754,25 +767,17 @@ BEGIN;
 SELECT *
 INTO TEMP TABLE _graph_result
 FROM pgtrickle.refresh_graph_strict(
-    roots                       => ARRAY[
+  roots                 => ARRAY[
         'mdm_internal.customer_pair_evidence_v3'::regclass,
         'mdm_internal.customer_golden_candidates_v3'::regclass
     ],
-    expected_graph_digest       => decode(:expected_graph_digest, 'hex'),
-    require_complete_boundaries => true,
-    full_policy                 => 'ALLOW'
+  expected_graph_digest => decode(:expected_graph_digest, 'hex'),
+  full_policy           => 'ALLOW'
 );
 
--- Inspect the exact batch sequence through the terminal token returned above.
-SELECT *
-FROM pgtrickle.output_delta_batches(
-    consumer_id   => :pair_consumer_id,
-    through_token => :pair_terminal_token
-)
-ORDER BY batch_token;
-
--- Read exact typed rows from the consumer's returned delta relation, or scan
--- the complete terminal stream table when FULL_INVALIDATION is present.
+-- Read the complete terminal stream tables while graph locks remain held.
+SELECT * FROM mdm_internal.customer_pair_evidence_v3;
+SELECT * FROM mdm_internal.customer_golden_candidates_v3;
 
 -- Perform domain-specific work. pg_trickle does not know this schema.
 SELECT mdm_internal.resolve_and_publish_customer(
@@ -781,23 +786,33 @@ SELECT mdm_internal.resolve_and_publish_customer(
     source_boundary_digest => :source_boundary_digest
 );
 
--- Acknowledge only after the domain result has been validated and written.
-SELECT pgtrickle.ack_output_delta(
-    consumer_id   => :pair_consumer_id,
-    through_token => :pair_terminal_token,
-    disposition   => :pair_disposition
-);
+  COMMIT;
+  ```
 
-SELECT pgtrickle.ack_output_delta(
-    consumer_id   => :golden_consumer_id,
-    through_token => :golden_terminal_token,
-    disposition   => :golden_disposition
-);
+  ### 16.2 Delta V1 optimization
 
-COMMIT;
+  When Delta V1 is enabled, an `ACTIVE` consumer replaces each complete terminal read with this sequence inside the same transaction:
+
+  ```sql
+  -- Read every pending batch through the head visible after strict refresh.
+  SELECT *
+  FROM pgtrickle.output_delta_batches(
+    consumer_id => :consumer_id
+  )
+  ORDER BY batch_token;
+
+  -- Apply all exact rows from delta_relation. If any batch is
+  -- FULL_INVALIDATION, rebuild from the complete terminal stream table instead.
+
+  -- Acknowledge only after the coordinator has validated and written its state.
+  SELECT pgtrickle.ack_output_delta(
+    consumer_id   => :consumer_id,
+    through_token => :newest_batch_token,
+    disposition   => :disposition
+  );
 ```
 
-If domain resolution, clustering, validation, public-table DML, or acknowledgement raises an error, the transaction rolls back. Private stream tables return to their previous contents, node frontiers do not advance, graph and node refresh records do not commit, newly written output-delta batches disappear, and consumer cursors remain unchanged. The next invocation can repeat the complete operation without reconciling a half-published boundary.
+  If domain work raises an error, the transaction rolls back. Private stream tables return to their previous contents, node frontiers do not advance, and graph and node refresh records do not commit. Under Delta V1, newly written output batches also disappear and consumer cursors remain unchanged. The next invocation can repeat the complete operation without reconciling a half-published boundary.
 
 The coordinator does not need to block new source writes for the duration of the transaction. `pg_trickle` captures a safe upper boundary and leaves later committed changes pending for the next refresh. The important property is not that the database stops changing; it is that every graph member and every domain output in this transaction refers to the same named boundary.
 
@@ -847,7 +862,7 @@ A backend crash or server restart during an uncommitted strict refresh relies on
 
 Output-log integrity is durable control state. On startup, restore, or repair, `pg_trickle` validates consumer catalog rows, output-log relation identity, required columns and types, contract versions, sentinels, batch continuity, and acknowledged positions. Missing or unverifiable history moves the consumer to `RESNAPSHOT_REQUIRED`. The system does not synthesize an empty batch or silently jump the cursor.
 
-A semantic contract change invalidates active consumers rather than reinterpreting retained rows. A physical-only change may preserve the contract and consumer continuity when validation proves the typed output relation and logical ordering remain unchanged. A dropped and recreated database clone has a different lineage identity, so copied tokens are rejected even when relation OIDs happen to match.
+An execution-contract change invalidates active consumers rather than reinterpreting retained rows. A contract-neutral physical change may preserve the contract and consumer continuity. Clone activation assigns and validates a different database-instance identity, so copied tokens are rejected even when relation OIDs happen to match.
 
 `repair_stream_table()` may rebuild triggers, buffers, or derived storage, but it cannot repair an exact external history that has been lost. Its result must state whether consumers remain active, require resnapshot, or were invalidated by the repair.
 
@@ -891,7 +906,7 @@ ADD COLUMN orchestration_mode text NOT NULL DEFAULT 'MANAGED'
     CHECK (orchestration_mode IN ('MANAGED', 'EXTERNAL'));
 ```
 
-The catalog should also retain the contract version or enough semantic metadata to build and validate the contract deterministically. A cached digest may be stored as an optimization, but it must be invalidated by every result-affecting DDL, function, owner, search-path, source-binding, and semantic-plan change.
+The catalog also retains `contract_generation`, the contract version, and enough tracked metadata to build and validate the contract deterministically. A cached digest may be stored as an optimization, but the same transaction that changes a normative input increments the generation and invalidates the digest.
 
 ### 21.2 Graph refresh records
 
@@ -921,13 +936,14 @@ A small logged catalog records consumer state:
 pgt_output_delta_consumers
   consumer_id
   stream_table_id
+  database_instance_id
   owner_role
   consumer_name
   output_contract_digest
   row_identity_version
   acknowledged_batch_token
   state
-  resnapshot_reason
+  state_reason
   created_at
   acknowledged_at
 ```
@@ -937,6 +953,7 @@ Batch metadata is also logged:
 ```text
 pgt_output_delta_batches
   stream_table_id
+  database_instance_id
   batch_token
   producing_refresh_id
   graph_refresh_id
@@ -950,11 +967,11 @@ pgt_output_delta_batches
   created_at
 ```
 
-The payload is stored once per opted-in stream table in a protected typed relation. Consumer-specific views or access predicates may expose the shared rows without duplicating payload. Batch tokens are monotonically increasing within one stream-table output log and remain opaque outside the documented ordering and acknowledgement contract.
+Each opted-in stream table also has one locked `output_log_head` counter, one protected typed payload relation, and one shared read-only view. The finalizer increments the counter and writes batch metadata and payload in one transaction. Rollback restores the previous head. Consumer authorization is enforced before returning or reading the shared view; consumer-specific payload copies and views are not created. Batch tokens have meaning only with their stream-table identity, output contract, and database-instance identity.
 
 ### 21.4 Resnapshot state
 
-A resnapshot token may be represented as a signed or catalog-backed one-use record bound to consumer, database lineage, stream-table identity, output contract, stable batch token, owner, and transaction. Its implementation must prevent replay against another consumer or later incompatible contract. No long-lived application secret is required; PostgreSQL authorization remains primary.
+A resnapshot token may be represented as a signed or catalog-backed one-use record bound to consumer, database-instance identity, stream-table identity, output contract, stable batch token, owner, and transaction. Its implementation must prevent replay against another consumer or later incompatible contract. No long-lived application secret is required; PostgreSQL authorization remains primary.
 
 ---
 
@@ -966,9 +983,9 @@ The scheduler already computes dependency-aware execution units and database-loc
 
 The contract builder can reuse stream-table metadata, dependency catalogs, defining-query hashes, owner execution state, row-identity and row-probe versions, function fingerprints, collation validation, source schema fingerprints, and versioned strategy fields already present in the system. A dedicated canonicalization module should define digest inputs, with independent fixtures so an incidental JSON serialization refactor cannot change a contract silently.
 
-Output-delta batch creation belongs in the common finalizer. A member frontier must not commit without the corresponding promised batch metadata and exact payload or `FULL_INVALIDATION` marker. Differential output can reuse the logical D+I relation already produced by the engine. Supported full paths can reuse their existing before-and-after diff. Other full paths write invalidation metadata rather than an incomplete payload.
+When Delta V1 is enabled for a member, output-batch creation belongs in the common finalizer. That member's frontier cannot commit without the corresponding batch metadata and exact payload or `FULL_INVALIDATION` marker. Differential output can reuse the logical D+I relation already produced by the engine. Supported full paths can reuse their existing before-and-after diff. Other full paths write invalidation metadata rather than an incomplete payload. A Graph V1-only member finalizes without an external output batch.
 
-The external output log should remain distinct from private downstream buffers in capability version 1. This slightly increases write amplification for opted-in stream tables but preserves a clean public boundary and permits private buffer evolution. Shared physical storage may be considered later only after the public cursor, type, retention, and upgrade semantics are fixed.
+Under Delta V1, the external output log remains distinct from private downstream buffers. This increases write amplification for opted-in stream tables but permits private buffer evolution. Shared physical storage may be considered in a later Delta capability major only if it preserves the public cursor, type, retention, and upgrade semantics.
 
 ---
 
@@ -976,141 +993,136 @@ The external output log should remain distinct from private downstream buffers i
 
 ### 23.1 Create and bulk create
 
-A coordinating extension normally creates an immutable private graph with `orchestration_mode = 'EXTERNAL'` and `initialize = false`, computes and stores its graph digest, registers consumers on terminal nodes, and performs first population through `refresh_graph_strict()`. Bulk creation should validate all names, ownership, modes, and graph constraints before making any member visible.
+A coordinating extension normally creates an immutable private graph with `orchestration_mode = 'EXTERNAL'` and `initialize = false`, computes and stores its graph digest, and performs first population through `refresh_graph_strict()`. A Delta V1 coordinator may register terminal consumers at the pristine `CURRENT` origin before first refresh or use the default resnapshot protocol after population. Bulk creation should validate all names, ownership, modes, and graph constraints before making any member visible.
 
 ### 23.2 Alter query and storage recreation
 
-A stream table with active output consumers cannot undergo a semantic or output-contract change in place under capability version 1. The caller creates a new stream table or graph version, registers new consumers, establishes a new baseline, activates the corresponding higher-level definition, and later removes the old graph after its audit or explanation horizon is satisfied.
+A stream table with active output consumers cannot undergo an execution-contract or output-contract change in place under Delta V1. The caller creates a new stream table or graph version, registers new consumers, establishes a new baseline, activates the corresponding higher-level definition, and later removes the old graph after its audit or explanation horizon is satisfied.
 
-Operational alterations that do not change the stream-table contract, such as supported index maintenance or statistics updates, may proceed when they do not conflict with an active refresh. The contract digest remains unchanged only when semantic equivalence is proven.
+Operational alterations classified as contract-neutral, such as supported index maintenance or statistics updates, may proceed when they do not conflict with an active refresh. Other alterations increment the stream-table contract generation and change the graph digest.
 
 ### 23.3 Suspend, resume, and repair
 
-Suspending an external stream table blocks strict graph refresh but does not transfer it to the scheduler. Resuming makes it explicitly refreshable again. Repair validates contracts and output-log continuity and reports whether consumers remain active or require resnapshot. It never acknowledges on behalf of a coordinator.
+Suspending an external stream table blocks strict graph refresh but does not transfer it to the scheduler. Resuming makes it explicitly refreshable again. Repair always validates execution contracts. When Delta V1 applies, it also validates output-log continuity and reports whether consumers remain active or require resnapshot. It never acknowledges on behalf of a coordinator.
 
 ### 23.4 Drop
 
-Dropping a stream table fails while output consumers exist unless the caller uses a documented cascade operation. A privileged cascade explicitly invalidates or drops consumers, records the consequence, removes generated views and payload storage, and then follows ordinary dependency cleanup. It may not leave another extension believing that its acknowledged cursor has a continuous future stream.
+Under Delta V1, dropping a stream table fails while output consumers exist unless the caller uses a documented cascade operation. A privileged cascade explicitly invalidates or drops consumers, records the consequence, removes the shared view and payload storage, and then follows ordinary dependency cleanup. It may not leave another extension believing that its acknowledged cursor has a continuous future stream.
 
 ### 23.5 Orchestration-mode changes
 
-Returning a table to `MANAGED` mode does not consume or delete pending external output history. Administrators must explicitly decide whether consumers are retained, resnapshotted, or dropped. A mode change is a lifecycle operation, not an acknowledgement shortcut.
+Returning a table to `MANAGED` mode is rejected while Delta V1 consumers exist. Administrators must drop them explicitly first; the drop records the final cursor state and makes retained history eligible for cleanup. A mode change is a lifecycle operation, not an acknowledgement shortcut.
 
 ---
 
 ## 24. Observability and administration
 
-The new contract should add concise supported status functions rather than require operators to join private catalogs:
+The capability contracts should add concise supported status functions rather than require operators to join private catalogs:
 
 ```sql
 SELECT * FROM pgtrickle.external_graph_status(roots => ARRAY[...]::regclass[]);
 SELECT * FROM pgtrickle.output_delta_consumer_status();
 ```
 
-Graph status should report graph digest, member count, orchestration eligibility, current busy state, most recent graph refresh, source-boundary completeness, and terminal batch positions. Consumer status should report owner, stream table, state, acknowledged and newest batch token, retained rows and bytes, batch lag, age lag, contract digest, row-identity version, and resnapshot reason.
+Graph V1 status reports graph digest, member count, orchestration eligibility, current busy state, most recent graph refresh, and source-boundary completeness. Delta V1 consumer status reports owner, stream table, state, acknowledged and newest batch token, retained rows and bytes, batch lag, age lag, output-contract digest, row-identity version, and state reason.
 
-`health_check()` should warn when an external consumer needs resnapshot, is invalidated, retains more than configured advisory thresholds, references missing storage, or blocks refresh because a hard limit is near; when an external graph contains a managed or unsupported member; or when a graph contract can no longer be computed. Warnings are operational and do not change truth or advance state.
+Graph V1 health checks warn when an external graph contains a managed or unsupported member or when its execution contract can no longer be computed. Delta V1 adds warnings for consumers that need resnapshot, are invalidated, exceed advisory thresholds, reference missing storage, or approach a hard retention limit. Warnings are operational and do not change state.
 
-Refresh history should identify `initiated_by = 'EXTERNAL_GRAPH'`, the graph refresh identifier, and the graph digest. Existing timeline and metrics surfaces may aggregate graph duration and output-log overhead while preserving per-member history. Useful counters include strict refresh totals and failures, busy conflicts, exact and invalidation batches, output rows and retained bytes, consumer gaps, resnapshots, and acknowledgement latency.
+External graph refresh history identifies `initiated_by = 'EXTERNAL_GRAPH'`, the graph refresh identifier, and the graph digest while preserving per-member history. Graph V1 counters include strict refresh totals and failures, busy conflicts, and boundary failures. Delta V1 adds exact and invalidation batches, output rows and retained bytes, consumer gaps, resnapshots, and acknowledgement latency.
 
 ---
 
 ## 25. Performance and resource behavior
 
-The integration contract should add no output-delta overhead to a stream table that remains `MANAGED` and has no registered external consumer. Capability discovery is constant-size metadata. Contract digests may be cached by a complete semantic cache key and invalidated by the same catalog and function-dependency mechanisms that invalidate query plans.
+Graph V1 adds no output-log overhead. Delta V1 adds none to a stream table without a registered consumer. Capability discovery is constant-size metadata. Contract digests may be cached by a complete execution-contract key and invalidated by the same catalog and function-dependency mechanisms that invalidate query plans.
 
 A strict graph refresh may be cheaper than repeated single-node public refreshes because it computes one closure, one lock plan, one source-boundary context, and one topological traversal. It should not repeatedly probe the same source, parse the same contract, or rebuild identical dependency state. The locked database catalog remains authoritative even when a cached DAG is reused.
 
-Output-delta capture adds one shared write per logical changed row, regardless of the number of external consumers. Per-consumer cost is a cursor row and access view rather than duplicate payload. Batch metadata adds one row per opted-in stream-table refresh, including no-data batches where a stable token is useful.
+Under Delta V1, output capture adds one shared write per logical changed row regardless of consumer count. Per-consumer cost is one cursor row; all consumers use the stream table's shared typed view. Batch metadata adds one row per opted-in stream-table refresh, including no-data batches.
 
-A slow consumer can retain substantial output history. Advisory limits must be observable. Hard limits may block a refresh before history is lost or may require an administrator to move the consumer explicitly to `RESNAPSHOT_REQUIRED`; they may not truncate the current exact batch. If a complete exact batch cannot be written, the finalizer either writes an allowed invalidation marker or aborts.
+A slow Delta V1 consumer can retain substantial output history. Advisory limits must be observable. A hard limit blocks refresh before the finalizer changes the output-log head or writes a batch. Only an explicit administrator transition to `RESNAPSHOT_REQUIRED` makes unacknowledged history eligible for cleanup. If a complete exact batch cannot be written, the finalizer writes a truthful allowed invalidation marker or aborts.
 
-The initial contract should publish conservative admission bounds for root count, graph members, dependency edges, consumers per stream table, generated views, contract size, and batch pagination. Exceeding an admission bound fails before refresh and does not process an arbitrary graph prefix. V1 does not promise resumability; callers must operate within documented transaction, WAL, lock, memory, and temporary-space limits.
+Graph V1 publishes conservative admission bounds for root count, graph members, dependency edges, and contract size. Delta V1 separately bounds consumers per stream table and batch pagination. Exceeding a bound fails before mutation and does not process an arbitrary prefix. Neither V1 contract promises resumability; callers must operate within documented transaction, WAL, lock, memory, and temporary-space limits.
 
 ---
 
 ## 26. Upgrade and compatibility policy
 
-The proposal is additive. Existing stream tables receive `orchestration_mode = 'MANAGED'`. Existing APIs, including the human-friendly notice-and-skip behavior of `refresh_stream_table()`, remain unchanged. No external output log exists until a consumer registers.
+The proposal is additive. Existing stream tables receive `orchestration_mode = 'MANAGED'`. Existing APIs, including the human-friendly notice-and-skip behavior of `refresh_stream_table()`, remain unchanged. No external output log exists until a Delta V1 consumer registers.
 
-Capability major versions are independent of the extension package version. A storage-only or physical-plan upgrade may preserve capability majors and contract digests. A change to canonical contract encoding, graph closure, source-boundary meaning, output-delta row semantics, acknowledgement rules, token validation, or resnapshot behavior requires a new capability major and either side-by-side support or an explicit integrator migration.
+Capability major versions are independent of each other and of the extension package version. A change to canonical execution-contract encoding, graph closure, strict-refresh semantics, or source-boundary meaning requires a new `external_graph_refresh` major. A change to output-row semantics, acknowledgement rules, token validation, retention, or resnapshot behavior requires a new `output_delta_consumer` major. Either change needs side-by-side support or an explicit integrator migration.
 
-A mandatory correctness repair that changes logical semantics must change the relevant semantic-plan version and therefore the contract digest. A coordinating extension then refuses to refresh the old graph until it creates or explicitly adopts a new definition. A repair must not claim compatibility merely because the output column list is unchanged.
+A mandatory correctness repair that changes tracked logical behavior increments the relevant rewrite or DVM contract version and the stream-table contract generation. A coordinating extension then refuses to refresh the old graph until it creates or explicitly adopts a new definition. A repair must not claim compatibility merely because the output column list is unchanged.
 
-Upgrade scripts preserve durable orchestration mode, consumer registrations and cursors, batch metadata, output-log payload, contract versions, and graph refresh identities. `pg_dump`, physical backup, PITR, and failover treat those objects as durable state. Generated consumer views may be recreated deterministically from the consumer catalog, but missing payload history moves the consumer to `RESNAPSHOT_REQUIRED`.
+Graph V1 upgrade scripts preserve durable orchestration mode, contract generations, contract versions, and graph refresh identities. Delta V1 scripts additionally preserve consumer registrations and cursors, the transactional log head, batch metadata, and output-log payload. `pg_dump`, physical backup, PITR, and failover treat enabled capability state as durable. The shared typed view may be recreated deterministically from catalog state, but missing payload history moves affected consumers to `RESNAPSHOT_REQUIRED`.
 
-The V1 contract is SQL-facing. Coordinating extensions must not link to private Rust modules or assume a stable Rust ABI. Runtime capability negotiation is authoritative even when package dependencies pin a supported release line.
+Both V1 contracts are SQL-facing. Coordinating extensions must not link to private Rust modules or assume a stable Rust ABI. Runtime capability negotiation is authoritative even when package dependencies pin a supported release line.
 
 ---
 
 ## 27. Delivery plan
 
-The work should be delivered in three phases while keeping capability versions experimental until transaction, crash, and upgrade proofs pass.
+The work should be delivered in three phases with separate stability gates.
 
 ### Phase 1: contracts and external ownership
 
-Add capability discovery, canonical stream-table contracts, graph contracts, graph digests, and durable orchestration mode. Extend create, bulk-create, status, scheduler admission, lifecycle locks, dump, restore, and upgrade handling. This phase has no external output log and can be tested independently.
+Add capability discovery, canonical stream-table execution contracts, graph contracts, graph digests, contract generations, and durable orchestration mode. Extend create, bulk-create, status, scheduler admission, lifecycle locks, dump, restore, and upgrade handling. This phase has no external output log and can be tested independently.
 
 ### Phase 2: strict graph refresh
 
-Extract or reuse one structured internal graph-refresh context, acquire all external-member locks before execution, compute one immutable source boundary, execute members synchronously in topological order, and return a typed graph result. Wire every member through the common transactional finalizer and add stable busy, contract, completeness, and mode errors. At the end of this phase, a consumer may safely coordinate a graph but may still scan terminal relations completely after every refresh.
+Extract or reuse one structured internal graph-refresh context, acquire all external-member locks before execution, compute one immutable source boundary, execute members synchronously in topological order, and return a typed graph result. Wire every member through the common transactional finalizer and add stable busy, contract, completeness, and mode errors. At the end of this phase, Graph V1 is complete. It may advertise stable version 1 after its transaction, concurrency, crash, clone-isolation, security, and upgrade tests pass.
 
 ### Phase 3: durable typed output deltas
 
-Add consumer registration, shared typed output logs, batch metadata, generated read-only consumer relations, exact differential capture, full invalidation, transactional acknowledgement, resnapshot, retention, status, and repair behavior. Integrate batch creation into the common finalizer so frontier advancement cannot commit without the corresponding promised batch. This phase completes the V1 dependency.
+Add consumer registration, shared typed output logs and read-only relations, transactional batch metadata, exact differential capture, full invalidation, acknowledgement, resnapshot, retention, status, and repair behavior. Integrate batch creation into the common finalizer for opted-in stream tables. Delta V1 remains absent, disabled, or experimental until its separate algebra, retention, recovery, clone-isolation, security, and upgrade tests pass.
 
-Operational documentation, metrics, capacity guidance, backup and restore verification, upgrade matrix tests, and an example coordinating test extension are required before capability major version 1 is advertised as stable. During implementation, discovery should report an experimental version or `enabled = false` until each phase's complete contract is available.
+Each capability needs its own operational documentation, metrics, capacity guidance, backup and restore verification, upgrade matrix, and conformance tests before discovery advertises stable major version 1. During implementation, discovery reports that capability as experimental or `enabled = false`; the status of one capability does not affect the other.
 
 ---
 
 ## 28. Test plan
 
-### 28.1 Unit and property tests
+### 28.1 Graph V1 unit and property tests
 
-Canonical contract tests must prove deterministic ordering, exclusion of operational fields, inclusion of every result-affecting field, digest changes for semantic mutations, and digest stability for physical tuning. Graph tests should generate DAGs with duplicate roots, shared upstream members, diamonds, unsupported cycles, renames, object recreation, owner changes, and dependency changes and verify one canonical closure and lock order.
+Canonical contract fixtures pin the typed byte encoding and prove deterministic ordering, exclusion of operational fields, inclusion of every normative field, generation changes for tracked mutations, and stability for contract-neutral tuning. Graph generators cover duplicate roots, shared upstream members, diamonds, unsupported cycles, renames, object recreation, owner changes, and dependency changes. They verify one canonical closure and member lock order.
 
-Output-delta algebra tests must compare the old and new stream-table multisets with every exact batch after inserts, deletes, same-identity updates, key-changing updates, duplicates, aggregates, joins, set operations, TopK paths, no-op changes, and full fallback. Consumer state-machine tests cover registration idempotency, monotonic acknowledgement, invalidation disposition, resnapshot, gap handling, pause and resume, multiple consumers, drop, and contract change.
+### 28.2 Graph V1 integration tests
 
-### 28.2 PostgreSQL integration tests
+At minimum, Graph V1 tests cover:
 
-At minimum, integration tests must cover:
+1. One-node, chain, and diamond graphs committing against one complete source boundary.
+2. A coordinator error after refresh, proving stream output, frontiers, graph history, and coordinator writes all roll back.
+3. Concurrent refresh, alter, repair, mode change, and drop operations, proving canonical lock behavior and no successful skip.
+4. A contract change between inspection and locked refresh, proving mismatch before the first member executes.
+5. Source writers on both sides of the safe boundary, proving no lost or double-consumed changes.
+6. Rejection of every unadmitted source class before member execution.
+7. Scheduler and PostgreSQL restart with durable `EXTERNAL` ownership.
+8. Crash, physical restore, logical restore, clone activation, and extension upgrade with contract and database-instance validation.
 
-1. A one-node external graph refreshed inside a transaction that later commits.
-2. The same refresh followed by a coordinator error, proving stream output, frontier, output batch, and acknowledgement all roll back.
-3. A chain of stream tables refreshed in dependency order against one boundary.
-4. A diamond graph in which both branches observe one shared upstream result and the terminal sees a coherent fan-in.
-5. A concurrent strict refresh producing `PGT_EXT_REFRESH_BUSY` or bounded lock wait, never successful skip.
-6. A concurrent `ALTER QUERY`, repair, mode change, and drop against a strict refresh, proving compatible lock behavior.
-7. A graph-contract change between initial inspection and locked refresh, producing contract mismatch before committed mutation.
-8. Concurrent source writers before and after the safe boundary, proving no lost or double-consumed changes.
-9. Exact differential output with inserts, deletes, and updates represented as delete plus insert.
-10. Full refresh with an exact before-and-after delta.
-11. Full refresh without exact delta support, producing one `FULL_INVALIDATION` and no partial payload.
-12. Multiple external consumers at different cursors, proving cleanup follows the slowest consumer.
-13. Acknowledgement followed by transaction rollback, proving the batch remains pending.
-14. A hard retention limit, proving refresh blocks before exact history is lost.
-15. Explicit resnapshot, proving full-table read and cursor reset commit together.
-16. Output-schema or semantic change with active consumers, proving rejection or explicit invalidation rather than silent reinterpretation.
-17. External orchestration across scheduler restart and PostgreSQL restart.
-18. Missing or corrupted output-log state after restore, proving `RESNAPSHOT_REQUIRED` rather than an empty delta.
-19. Ownership and RLS cases proving owner-equivalent defining-query execution and no deleted-row leak.
-20. Cross-database or restored-clone token reuse, proving database-lineage validation.
+### 28.3 Delta V1 unit and property tests
 
-### 28.3 Full and differential equivalence
+Output-delta algebra tests compare old and new stream-table multisets with every exact batch after inserts, deletes, same-identity updates, key-changing updates, duplicates, aggregates, joins, set operations, TopK paths, no-op changes, and full fallback. Applying all exposed deletes and inserts must produce the full query result at the same source boundary. State-machine tests cover default registration, pristine `CURRENT`, idempotency, transactional token allocation, acknowledgement, invalidation disposition, resnapshot, gaps, pause and resume, multiple consumers, drop, and contract change.
 
-For every supported query family used by the contract, a reference harness should begin from one committed stream-table state, apply a generated source-change sequence, run differential refresh with exact output logging, and compare the resulting multiset with full query evaluation at the same source boundary. It should also verify that applying the exposed delete and insert rows to the old multiset produces the new multiset exactly. This is the central semantic proof for the public delta contract.
+### 28.4 Delta V1 integration tests
 
-### 28.4 Security tests
+At minimum, Delta V1 tests cover:
 
-Security tests cover function grants, unauthorized graph members, mixed owners, hostile `search_path`, RLS-enabled sources, guessed consumer tokens, guessed resnapshot tokens, private relation disclosure, direct DML attempts against generated delta relations, and deleted-row access. SQL-reachable Rust paths must not panic on malformed input or unexpected catalog state.
+1. Exact differential output and exact full output, including delete-plus-insert updates and zero-row batches.
+2. Full refresh without an exact diff, producing one `FULL_INVALIDATION` and no partial payload.
+3. Several consumers sharing one typed relation while cleanup follows the slowest cursor.
+4. Refresh and acknowledgement rollback, proving the log head, payload, and cursor all return to their prior state without a token gap.
+5. Hard retention backpressure before metadata, payload, or log-head mutation.
+6. Explicit resnapshot, proving the complete read and cursor activation commit together.
+7. Contract change, missing storage, damaged continuity, recovery rollback, and clone activation, proving the documented state and reason code.
+8. Registration rejection for managed stream tables and non-pristine `CURRENT` requests.
 
-### 28.5 Recovery and upgrade tests
+### 28.5 Security and compatibility tests
 
-Physical restart, crash during refresh, PITR-style restore, logical dump and restore, extension upgrade, relation recreation, missing payload relations, and damaged sentinels must be tested. Machine-readable status must distinguish active, pending, invalidated, and resnapshot-required consumers. Compatibility fixtures should pin capability results, contract canonicalization, graph digest behavior, batch ordering, and token validation across every supported upgrade path.
+Graph V1 tests cover function grants, unauthorized graph members, mixed owners, hostile `search_path`, RLS-enabled sources, private relation disclosure, and malformed catalog state. Delta V1 adds guessed consumer and resnapshot tokens, direct DML against the shared typed relation, and retained deleted-row access. Compatibility fixtures pin each capability result independently. Graph fixtures also pin contract encoding and graph digests; Delta fixtures pin batch ordering, token validation, state reasons, and resnapshot behavior across supported upgrades.
 
 ### 28.6 Performance tests
 
-Benchmarks should measure strict graph overhead against repeated single-node refresh, contract-digest cache cost, exact output-log write amplification, typed consumer-view scan throughput, batch metadata cost, cleanup with several consumers, and zero-cost behavior when no external consumer exists. Performance gates must never weaken exactness or failure behavior.
+Graph V1 benchmarks measure strict graph overhead against repeated single-node refresh and contract-digest cache cost. Delta V1 separately measures output-log write amplification, shared typed-view scan throughput, batch metadata cost, cleanup with several consumers, and zero overhead when no consumer exists. Performance gates must never weaken exactness or failure behavior.
 
 ---
 
@@ -1142,7 +1154,7 @@ Logical replication is appropriate for an external downstream system. It is not 
 
 ### 29.7 Always scan the terminal stream table
 
-A full scan is correct and can be the first milestone after strict graph refresh. It discards the principal performance benefit of incremental evidence maintenance for large terminal relations. The completed V1 contract therefore includes durable deltas, while full scan remains the explicit invalidation and resnapshot fallback.
+A full scan is the complete Graph V1 consumption path and the Delta V1 invalidation and resnapshot fallback. It may be too expensive for large terminal relations, which is the measured reason to enable the separate Delta V1 contract.
 
 ### 29.8 Add an arbitrary post-refresh callback
 
@@ -1156,46 +1168,51 @@ PostgreSQL extensions do not have a stable Rust ABI, and a fork would duplicate 
 
 ## 30. Risks and open implementation choices
 
-The largest risk is that a public output-delta contract constrains internal cleanup and storage. The mitigation is to stabilize logical batch tokens, ordering, typed relations, acknowledgement, and gap behavior rather than the private buffer layout. The output log may be a separate relation initially and can evolve physically behind the contract.
+Graph V1's main risk is claiming source coherence that the engine cannot prove. Its closed source admission list, typed boundary manifest, and fail-closed refresh rule address that risk. Several incomparable source positions must not be reduced to a timestamp.
 
-A second risk is unbounded retention caused by a failed coordinator. The mitigation is explicit lag status, alerts, conservative hard bounds, blocking before data loss, and an administrator-controlled transition to `RESNAPSHOT_REQUIRED`. Availability must not be obtained by silently discarding exact history.
+Delta V1 has the larger implementation risk. A public log constrains cleanup and upgrades, a failed coordinator can retain unbounded history, and retained deleted rows can leak data. The contract therefore fixes transactional per-stream-table tokens, single-copy typed payload, owner-only access, explicit acknowledgement, observable lag, refresh backpressure, and administrator-controlled resnapshot. It does not stabilize private downstream buffers or physical output-log names.
 
-A third risk is API growth in an already broad extension. The mitigation is a focused integration namespace with independently versioned capabilities and a small number of functions. Ordinary users never need these functions to create and query a normal stream table.
-
-A fourth risk is overclaiming source coherence. The mitigation is a typed source-boundary manifest and failure when the graph cannot obtain one complete proof. Several incomparable source positions must not be reduced to a reassuring but meaningless timestamp.
-
-A fifth risk is security leakage from retained deleted rows. The initial owner-only consumer policy avoids delegated access until a complete filtering and masking design exists.
-
-Several implementation choices remain open without changing the proposal's semantics. Capability discovery may return rows or one versioned JSON document. Graph and refresh results may use named composite types or versioned JSON subdocuments. The typed delta surface may be a protected table, view, or set-returning function backed by one shared log. Lock behavior may rely on ordinary `lock_timeout` rather than a separate API option. Batch tokens may be per stream table or globally allocated, provided ordering, continuity, and validation remain exactly defined. These choices should be resolved in implementation review and recorded before capability major version 1 is frozen.
+Both contracts add API and long-term compatibility cost. Capability discovery may return rows or one versioned JSON document, graph and refresh results may use named composites or versioned JSON subdocuments, and busy behavior may rely on ordinary `lock_timeout` rather than a separate option. These representation choices must be settled before the relevant capability advertises stable major version 1. Decisions already fixed by this proposal, including source admission, typed digest encoding, per-stream-table output logs and tokens, shared typed views, and state transitions, are not implementation options.
 
 ---
 
 ## 31. Acceptance criteria
 
-The V1 proposal is complete when a small conformance extension can perform the following operations using only supported SQL APIs:
+### 31.1 Graph V1
 
-1. Discover and require the six V1 integration capabilities by major and minimum minor version.
-2. Create an acyclic private stream-table graph durably in `EXTERNAL` orchestration mode.
-3. Obtain canonical stream-table and graph contracts whose digests change for semantic or binding changes and remain stable for physical-only changes.
-4. Register durable typed output consumers on terminal stream tables without learning private buffer names.
-5. Refresh the complete graph synchronously against one coherent, complete source-boundary decision and receive one structured graph result.
-6. Observe a busy, altered, unsupported, incomplete, unauthorized, or failed graph as a stable error with no committed member subset.
-7. Read an immutable continuous exact batch, apply it to coordinator-owned state, acknowledge it, and commit all effects together.
-8. Roll back after graph refresh or acknowledgement and observe graph contents, frontiers, output batches, coordinator state, and cursor all unchanged.
-9. Receive `FULL_INVALIDATION` rather than a partial row set when exact output change cannot be supplied, then resynchronize from the complete stable terminal relation.
-10. Retain independent cursors for multiple consumers and clean payload only through the slowest acknowledged position or an explicit resnapshot transition.
-11. Survive PostgreSQL restart, backup and restore, failover, and supported extension upgrade without losing external orchestration or silently skipping a delta gap.
-12. Observe owner checks, safe search paths, row-identity and contract validation, bounded inputs, stable errors, lag status, and health diagnostics.
-13. Prove through differential/full tests that every exact batch transforms the prior output multiset into the complete query result at the named source boundary.
-14. Implement the complete `pg_mdm` V1 refresh and publication transaction without reading or writing a private `pg_trickle` catalog, buffer, frontier, scheduler table, or generated implementation column.
+Graph V1 is complete when a small conformance extension can use supported SQL APIs to:
 
-Nothing in Appendix A is part of these acceptance criteria.
+1. Discover and require `external_graph_refresh` by major and minimum minor version.
+2. Create an acyclic private graph durably in `EXTERNAL` mode and obtain canonical member generations, execution-contract digests, and one graph digest.
+3. Refresh the complete graph synchronously against one coherent, proven source boundary and receive one structured result.
+4. Read complete terminal tables and publish coordinator-owned state before committing the same transaction.
+5. Receive stable errors for busy, changed, unsupported, incomplete, unauthorized, or failed graphs with no committed member subset.
+6. Roll back after refresh and observe graph contents, frontiers, graph history, and coordinator state unchanged.
+7. Survive restart, backup and restore, failover, clone activation, and supported upgrade without losing external ownership or accepting stale identity.
+8. Enforce owner checks, safe search paths, bounded inputs, contract validation, status, and health diagnostics.
+9. Implement the `pg_mdm` V1 refresh and publication transaction without reading or writing private `pg_trickle` catalogs, buffers, frontiers, scheduler tables, or generated columns.
+
+### 31.2 Delta V1
+
+Delta V1 is complete when the conformance extension can independently:
+
+1. Discover `output_delta_consumer`, register only on an external stream table, and establish a proven baseline through pristine `CURRENT` or resnapshot.
+2. Read every immutable batch after its cursor from the stream table's shared typed relation and prove that each exact batch transforms the prior multiset into the full result at the named boundary.
+3. Acknowledge exact batches or resynchronize after `FULL_INVALIDATION`, committing output batches, coordinator state, and cursors together.
+4. Roll back refresh or acknowledgement without advancing the transactional log head or leaving a token gap.
+5. Retain independent cursors without duplicating payload and clean only through the slowest cursor or an explicit resnapshot transition.
+6. Fail closed with the specified state and reason when history, storage, contract, or database-instance validation fails.
+7. Enforce owner-only deleted-row access, hard-limit backpressure, stable errors, lag status, and health diagnostics.
+
+Nothing in Appendix A is part of either acceptance gate.
 
 ---
 
 ## 32. Recommended disposition
 
-Adopt the V1 composition contract as a focused pre-1.0 extension boundary. Deliver durable external orchestration and canonical contracts first, strict transactional graph refresh second, and durable typed output deltas third. Keep the surface experimental until transaction, concurrency, crash, security, and upgrade proofs pass, then advertise capability major version 1.
+Adopt Graph V1 as a focused pre-1.0 extension boundary. Deliver durable external orchestration and execution contracts first, then strict transactional graph refresh. Advertise `external_graph_refresh` major version 1 when its acceptance gate passes.
+
+Pursue Delta V1 as a separate optimization. Keep `output_delta_consumer` absent, disabled, or experimental until its own algebra, transaction, retention, crash, security, clone, and upgrade proofs pass. Delta V1 must not delay Graph V1 or weaken its complete terminal-read path.
 
 The proposed boundary preserves the responsibilities of both projects:
 
@@ -1207,7 +1224,7 @@ The proposed boundary preserves the responsibilities of both projects:
 
 **This appendix is non-normative. It summarizes the `pg_mdm` V2 need only. It is not part of the V1 decision, delivery plan, implementation estimate, or acceptance criteria, and every capability described here requires a separate proposal before implementation.**
 
-The V1 contract keeps graph refresh, domain computation, domain publication, and delta acknowledgement inside one PostgreSQL transaction. That is the simplest and strongest model for small and medium workloads, but a higher-level resolver may eventually need minutes or hours of component analysis, stable-identity reconciliation, validation, or preview work. Holding one database transaction and one set of graph locks for that entire period may become operationally unacceptable.
+Graph V1 keeps graph refresh, domain computation, and domain publication inside one PostgreSQL transaction. Delta V1 adds acknowledgement to that transaction. This model is simple and strong for small and medium workloads, but a higher-level resolver may eventually need minutes or hours of component analysis, stable-identity reconciliation, validation, or preview work. Holding one database transaction and one set of graph locks for that entire period may become operationally unacceptable.
 
 A later capability would therefore need an immutable prepared graph result at a named source boundary. `pg_trickle` would refresh the graph, commit the private relational state, and seal the exact member contracts, source-boundary manifest, terminal output state, and delta positions. The coordinating extension could then perform deterministic checkpointed work across several transactions while source changes beyond the sealed boundary continued to accumulate for a later refresh.
 
@@ -1215,6 +1232,6 @@ Final publication would still need one short atomic transaction. In that transac
 
 That capability introduces concerns that are deliberately absent from V1: immutable generation identity, graph-member leases, prepared-state recovery after restart, promotion and abandonment, source-buffer retention while a graph is frozen, output-delta continuity across several transactions, storage cleanup, and the choice between freezing one physical graph or maintaining multiple physical generations. It may also require progress reporting, resumable work allocation, and stronger resource governance.
 
-The V1 design is intended to leave room for that later work. Graph contracts already name a complete semantic closure. Graph refreshes already have stable identifiers and source-boundary manifests. Output consumers already use durable cursors rather than assuming that the current private frontier equals the last accepted domain publication. Capability discovery can add a separately versioned future feature without changing any V1 major contract.
+The V1 design is intended to leave room for that later work. Graph V1 contracts already name a complete execution closure, and graph refreshes already have stable identifiers and source-boundary manifests. Delta V1 consumers use durable cursors rather than assuming that the current private frontier equals the last accepted domain publication. Capability discovery can add a separately versioned future feature without changing either V1 major contract.
 
 The later design should not be inferred from this appendix. In particular, V1 does not promise a `prepare_graph()` function, generation-specific storage, concurrent preparations, asynchronous workers, checkpoint formats, or promotion semantics. Those decisions require a dedicated proposal and a full crash, upgrade, retention, and transaction proof matrix.

--- a/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
+++ b/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
@@ -2,13 +2,13 @@
 
 ## Immutable cross-transaction graph state and atomic acceptance for coordinating PostgreSQL extensions
 
-**Status:** Proposed  
-**Scope:** V2-only integration capability. This proposal does not alter or enlarge the V1 acceptance boundary.  
-**Target:** Additive capability after the V1 composable refresh and durable delta contract  
-**Decision:** Add a versioned prepared-generation lifecycle that lets an authorized extension refresh an externally orchestrated stream-table graph, commit and freeze that exact result, process it across several later transactions, and finally promote or abandon it without losing source or output-delta continuity  
-**Compatibility:** Existing stream tables and the V1 integration APIs retain their behavior. Prepared generations are opt-in and apply only to eligible `EXTERNAL` graphs.  
-**Motivating consumer:** `pg_mdm` V2, particularly large entity-resolution runs that cannot safely or economically remain inside one PostgreSQL transaction  
-**Prerequisite:** [V1 Composable Refresh and Durable Delta Contracts](PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)  
+**Status:** Proposed
+**Scope:** Two separately gated V2 integration capabilities. This proposal does not alter or enlarge either V1 acceptance boundary.
+**Target:** Additive post-1.0 capabilities after Graph V1 is stable
+**Decision:** Add a core prepared-generation lifecycle that freezes one externally orchestrated graph result for processing across later transactions. Add prepared output-delta binding as a separate optimization when Delta V1 is available.
+**Compatibility:** Existing stream tables and V1 integration APIs retain their behavior. Prepared generations are opt-in and apply only to eligible `EXTERNAL` graphs.
+**Motivating consumer:** `pg_mdm` V2, particularly large entity-resolution runs that cannot safely or economically remain inside one PostgreSQL transaction
+**Prerequisite:** [V1 Composable Refresh and Durable Delta Contracts](PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)
 **Baseline reviewed:** `pg_trickle` 0.90.0 at commit [`a6a53e0`](https://github.com/trickle-labs/pg-trickle/commit/a6a53e0f6697eed4407a664b1af5172ca137fd9c)  
 **Last updated:** 2026-09-01
 
@@ -34,7 +34,7 @@
 14. [Prepared-generation state machine](#14-prepared-generation-state-machine)
 15. [Durable member leases and graph isolation](#15-durable-member-leases-and-graph-isolation)
 16. [Cross-transaction read protocol](#16-cross-transaction-read-protocol)
-17. [Prepared output-delta ranges](#17-prepared-output-delta-ranges)
+17. [Prepared output-delta bindings](#17-prepared-output-delta-bindings)
 18. [`promote_prepared_graph()`](#18-promote_prepared_graph)
 19. [`abandon_prepared_graph()`](#19-abandon_prepared_graph)
 20. [Source changes while a generation is prepared](#20-source-changes-while-a-generation-is-prepared)
@@ -62,30 +62,26 @@
 
 ## 1. Executive decision
 
-`pg_trickle` should add one separately versioned integration capability called **prepared graph generations**. The capability is for trusted PostgreSQL extensions that already use the V1 composition contract but need to perform expensive domain work after relational evidence has been refreshed. Instead of keeping one PostgreSQL transaction open while that work runs, the caller can ask `pg_trickle` to refresh an eligible private graph to one complete source boundary, commit the resulting stream-table state, and seal it as an immutable prepared generation. The caller may then inspect that exact generation and maintain its own checkpoints over several later transactions. When its complete domain result is ready, it promotes the prepared generation and acknowledges the bound output deltas inside the same short transaction that publishes its own result.
+`pg_trickle` should add a separately versioned integration capability called `prepared_graph_generation`. It is for trusted PostgreSQL extensions that already use Graph V1 but need to perform expensive domain work after relational evidence has been refreshed. Instead of keeping one PostgreSQL transaction open while that work runs, the caller can ask `pg_trickle` to refresh an eligible private graph to one complete source boundary and seal the resulting stream-table state as an immutable prepared generation. The caller commits that preparation, inspects the same generation over several later transactions, and maintains its own checkpoints. When its complete domain result is ready, it promotes the generation in the same short transaction that publishes its own result.
+
+`prepared_output_delta_binding` is a second capability for coordinators that need incremental terminal consumption. It binds Delta V1 consumer ranges to the generation and acknowledges those ranges during promotion. It requires compatible enabled versions of `prepared_graph_generation` and `output_delta_consumer`. Core prepared generations require only `external_graph_refresh`; they remain complete through frozen terminal-table reads and promotion without output acknowledgements.
 
 The first implementation should deliberately use a simple physical model. Preparing a graph freezes the graph's existing stream-table storage in place. It does not clone a second writable copy, and it does not permit another refresh over any overlapping member while the generation remains prepared. Source tables may continue to accept writes, and `pg_trickle` continues to capture those later changes in its ordinary CDC state. The next graph refresh processes them only after the prepared generation has been promoted or abandoned. This model supports one active prepared generation per stream-table member, avoids creating a second data-storage architecture, and is sufficient for private graphs whose higher-level resolver needs time rather than simultaneous graph versions.
 
-The capability does not make `pg_trickle` responsible for another extension's business computation. `pg_trickle` owns the immutable evidence generation, its source boundary, member contracts, output-delta positions, and lifecycle lease. The coordinating extension owns its checkpoint format, worker allocation, domain validation, compare-and-swap conditions, public tables, and final business publication. Promotion is intentionally called by the coordinating extension rather than triggered through a callback. PostgreSQL remains the mechanism that commits the final domain publication, delta acknowledgement, and prepared-generation transition together.
+Neither capability makes `pg_trickle` responsible for another extension's business computation. `pg_trickle` owns the immutable evidence generation, its source boundary, member execution contracts, storage markers, and lifecycle leases. When prepared delta binding applies, it also owns the bound output ranges. The coordinating extension owns its checkpoint format, worker allocation, domain validation, compare-and-swap conditions, public tables, and final business publication. Promotion is called by the coordinating extension rather than triggered through a callback. PostgreSQL commits the final domain publication and prepared-generation transition together, plus bound acknowledgements when that capability applies.
 
 ---
 
 ## 2. V2 release boundary
 
-This proposal is only for the cross-transaction lifecycle that begins after the V1 composition contract exists. It assumes that `pg_trickle` can already discover integration capabilities, compute canonical stream-table and graph contracts, keep a graph in durable `EXTERNAL` orchestration mode, refresh a complete graph strictly inside the caller's transaction, return one coherent source-boundary manifest, expose durable typed output deltas, and acknowledge those deltas transactionally. Those capabilities remain governed by their V1 contract and are not redefined here.
+This proposal is only for the cross-transaction lifecycle that begins after Graph V1 exists. Core preparation assumes that `pg_trickle` advertises `external_graph_refresh`, computes canonical stream-table and graph execution contracts, keeps a graph in durable `EXTERNAL` orchestration mode, refreshes a complete graph strictly inside the caller's transaction, and returns one coherent source-boundary manifest. Prepared delta binding additionally assumes that `output_delta_consumer` is enabled. Those capabilities remain governed by their V1 contracts and are not redefined here.
 
-The V2 capability adds the following behavior:
+The V2 capabilities add the following behavior:
 
-| V2 capability | Purpose |
-|---|---|
-| Prepare an eligible graph | Refresh the graph once and commit a named immutable result |
-| Durable generation identity | Let later transactions prove that they are reading the same evidence |
-| Durable member leases | Prevent refresh or semantic mutation of every prepared member |
-| Transaction-scoped read opening | Prevent promotion or abandonment while one processing transaction is reading |
-| Prepared consumer ranges | Pin the exact output-delta interval or resnapshot requirement associated with the generation |
-| Atomic promotion | Acknowledge prepared deltas and release the graph in the caller's final publication transaction |
-| Explicit abandonment | Release a generation without claiming that its evidence was accepted |
-| Recovery and verification | Preserve or fail closed across restart, failover, restore, upgrade, or detected corruption |
+| Capability | Required behavior | Purpose |
+|---|---|---|
+| `prepared_graph_generation` | Preparation, durable identity, member leases, transaction-scoped opening, promotion, abandonment, recovery, and verification | Freeze a named graph result for cross-transaction processing and accept or reject it explicitly |
+| `prepared_output_delta_binding` | Prepared consumer ranges, retained payload, promotion acknowledgement, and prepared resynchronization | Consume terminal changes incrementally without making delta support a prerequisite for frozen full-table reads |
 
 This proposal does not implement several broader `pg_mdm` V2 ideas. It does not add valid-time source processing, custom MDM functions, entity-level stewardship, semantic business events, MDM worker coordination, or domain checkpoint tables to `pg_trickle`. It also does not make the graph refresh itself resumable across committed transactions. `prepare_graph()` still performs one ordinary strict graph refresh in one PostgreSQL transaction; the cross-transaction benefit begins after that refresh has committed. A graph whose relational refresh cannot fit within the existing transaction and resource envelope needs a later, separate design.
 
@@ -93,13 +89,13 @@ This proposal does not implement several broader `pg_mdm` V2 ideas. It does not 
 
 ## 3. Relationship to the V1 contract
 
-The V1 composition protocol is intentionally the default. A coordinating extension begins a transaction, calls strict graph refresh, consumes exact output deltas or performs a full resynchronization, updates its own durable state, acknowledges the deltas, and commits. That is the simplest and strongest execution model because every layer shares one snapshot and one transaction from beginning to end.
+The V1 composition protocol remains the default. A Graph V1 coordinator begins a transaction, calls strict graph refresh, reads complete terminal state, updates its own durable state, and commits. When Delta V1 applies, it may consume exact output deltas or perform a full resynchronization and acknowledge the range before commit. This is the simplest and strongest execution model because every layer shares one transaction from beginning to end.
 
-Prepared generations are an optional escape hatch for workloads that exceed the practical duration of that transaction. They are not a replacement for V1, and implementing them must not change V1 semantics. An ordinary strict graph refresh still rolls back completely when the caller's domain publication fails. An output-delta consumer still advances only through explicit acknowledgement. A graph in `MANAGED` mode still belongs to the normal scheduler. A graph in `EXTERNAL` mode remains refreshable through the V1 strict API whenever no prepared lease is active.
+Prepared generations are an optional escape hatch for workloads that exceed the practical duration of that transaction. They are not a replacement for V1, and implementing them must not change either V1 contract. An ordinary strict graph refresh still rolls back completely when the caller's domain publication fails. A Delta V1 consumer still advances only through explicit acknowledgement. A graph in `MANAGED` mode still belongs to the normal scheduler. A graph in `EXTERNAL` mode remains refreshable through the Graph V1 strict API whenever no prepared lease is active.
 
-The V2 capability depends on exact V1 capability majors rather than only on the package version. Capability discovery should report `prepared_graph_generation` as disabled unless all prerequisite contracts are available and compatible. At minimum, capability major 1 depends on compatible majors of `graph_contract`, `external_orchestration`, `transactional_graph_refresh`, `source_boundary_manifest`, and `output_delta_consumer`.
+Each V2 capability depends on exact prerequisite capability majors rather than only on the package version. `prepared_graph_generation` major 1 requires `external_graph_refresh` major 1. `prepared_output_delta_binding` major 1 requires `prepared_graph_generation` major 1 and `output_delta_consumer` major 1. Capability discovery reports either V2 capability as disabled unless its own prerequisites and recovery checks pass.
 
-A coordinating extension may support both paths for the same logical product. Small entities can continue through V1's one-transaction path. Large entities can opt into the prepared path after admission checks show that source-buffer retention, output-delta retention, and graph-freeze duration are acceptable. Both paths must produce the same higher-level result when given the same graph contract, source boundary, domain inputs, and policy versions.
+A coordinating extension may support both paths for the same logical product. Small entities can continue through V1's one-transaction path. Large entities can opt into the prepared path after admission checks show that source-buffer retention and graph-freeze duration are acceptable. Prepared delta binding additionally checks output-log retention. Both paths must produce the same higher-level result when given the same graph contract, source boundary, domain inputs, and policy versions.
 
 ---
 
@@ -117,7 +113,7 @@ Exporting the terminal rows into coordinator-owned staging tables is possible, b
 
 ### 5.1 Goals
 
-The prepared-generation capability has ten goals. It must let an authorized coordinator prepare a complete `EXTERNAL` graph under the same source-boundary and strict-refresh rules as V1; assign an immutable generation identity and digest; preserve the prepared state across backend disconnect, restart, physical failover, backup, and supported upgrades; block every graph mutation that could change the evidence; permit short read transactions to reopen and verify the same generation; pin the relevant output-delta intervals; allow source writes after the prepared boundary to remain pending; atomically promote the generation with the coordinator's publication and delta acknowledgements; explicitly abandon without acknowledgement; and fail closed whenever the generation can no longer be proved.
+The core prepared-generation capability has nine goals. It must let an authorized coordinator prepare a complete `EXTERNAL` graph under the same source-boundary and strict-refresh rules as Graph V1; assign an immutable generation identity and digest; preserve the prepared state across backend disconnect, restart, physical failover, backup, and supported upgrades; block every graph mutation that could change the evidence; permit short read transactions to reopen and verify the same generation; allow source writes after the prepared boundary to remain pending; atomically promote the generation with the coordinator's publication; explicitly abandon it; and fail closed whenever the generation can no longer be proved. Prepared delta binding adds one goal: pin and transactionally acknowledge Delta V1 consumer evidence without requiring a complete terminal scan.
 
 The design should remain useful beyond MDM. Any PostgreSQL extension that compiles a domain model into a private `pg_trickle` graph and then performs expensive deterministic work can use the same lifecycle. The API therefore speaks about graphs, generations, contracts, source boundaries, output consumers, leases, and transitions. It does not mention entities, matches, goldens, features, policies, or any other consuming domain.
 
@@ -135,29 +131,29 @@ The first capability also does not hide prepared stream-table contents from role
 
 The motivating `pg_mdm` V2 flow separates evidence preparation from identity publication. `pg_trickle` refreshes the private evidence graph and seals one prepared generation. `pg_mdm` stores the generation identifier and digest in its own run manifest, processes deterministic component ranges in logged checkpoint tables, and may use several workers or several transactions to finish the domain result. Every processing transaction opens the same prepared generation before reading its terminal relations. The number of workers, checkpoint boundaries, and retry order remain `pg_mdm` concerns and are not semantic inputs to `pg_trickle`.
 
-When `pg_mdm` is ready to publish, it begins a short transaction and verifies its own compare-and-swap conditions, such as the expected active MDM publication revision, desired definition version, and stewardship decision epoch. It writes the new memberships, golden rows, reviews, provenance, identity history, and semantic events, then calls `promote_prepared_graph()` with the exact output-delta acknowledgements recorded by the generation. If any MDM validation or DML fails, PostgreSQL rolls back the promotion and the generation remains prepared. If a newer MDM definition or decision makes the run obsolete before publication, `pg_mdm` calls `abandon_prepared_graph()` and does not acknowledge the evidence.
+When `pg_mdm` is ready to publish, it begins a short transaction and verifies its own compare-and-swap conditions, such as the expected active MDM publication revision, desired definition version, and stewardship decision epoch. It writes the new memberships, golden rows, reviews, provenance, identity history, and semantic events, then calls `promote_prepared_graph()`. When prepared delta binding applies, the call includes the exact acknowledgements recorded by the generation. If any MDM validation or DML fails, PostgreSQL rolls back the promotion and the generation remains prepared. If a newer MDM definition or decision makes the run obsolete before publication, `pg_mdm` calls `abandon_prepared_graph()` and does not accept the evidence.
 
 The critical responsibility boundary is therefore:
 
 > **`pg_trickle` proves and freezes relational evidence. `pg_mdm` decides whether that evidence may become an identity publication.**
 
-`pg_trickle` does not inspect the MDM decision epoch, stable-ID ledger, checkpoint tables, or public MDM outputs. `pg_mdm` does not inspect private `pg_trickle` leases, change buffers, frontier encodings, or storage-generation catalogs. The generation identifier, generation digest, supported status APIs, and final promotion call are the complete supported bridge.
+`pg_trickle` does not inspect the MDM decision epoch, stable-ID ledger, checkpoint tables, or public MDM outputs. `pg_mdm` does not inspect private `pg_trickle` leases, change buffers, frontier encodings, or content-epoch catalogs. The generation identifier, generation digest, supported status APIs, and final promotion call are the complete supported bridge.
 
 ---
 
 ## 7. Existing foundations
 
-The proposal is intentionally built on existing `pg_trickle` architecture and the companion V1 integration proposal. `pg_trickle` already maintains stream tables through full and differential refresh paths, tracks per-source frontiers, captures local changes through trigger or WAL mechanisms, maintains stream-table-to-stream-table deltas, serializes refreshes, records durable refresh history, uses exact versioned row identity, and performs owner-equivalent execution. The V1 proposal adds the graph-wide contract, strict synchronous refresh, external orchestration, source-boundary manifest, and durable output-delta cursor required before a prepared lifecycle can be safe.
+The proposal is intentionally built on existing `pg_trickle` architecture and the companion V1 integration proposal. `pg_trickle` already maintains stream tables through full and differential refresh paths, tracks per-source frontiers, captures local changes through trigger or WAL mechanisms, maintains stream-table-to-stream-table deltas, serializes refreshes, records durable refresh history, uses exact versioned row identity, and performs owner-equivalent execution. Graph V1 adds the graph execution contract, strict synchronous refresh, external orchestration, and source-boundary manifest required before a prepared lifecycle can be safe. Delta V1 separately adds durable output consumers that prepared delta binding can reuse.
 
-The most important implementation discipline is reuse. `prepare_graph()` must not become a fourth independent refresh engine beside manual, scheduled, and V1 strict graph refresh. It should invoke the same graph resolver, contract validator, source-boundary planner, member executor, output-delta finalizer, and transaction semantics as `refresh_graph_strict()`. Its additional work is performed after the graph result has been successfully finalized but before the transaction commits: construct the generation manifest, bind terminal consumer ranges, insert durable member leases, and return the prepared identity.
+The most important implementation discipline is reuse. `prepare_graph()` must not become a fourth independent refresh engine beside manual, scheduled, and Graph V1 strict graph refresh. It invokes the same graph resolver, contract validator, source-boundary planner, member executor, common finalizer, and transaction semantics as `refresh_graph_strict()`. Its additional work is performed after the graph result has been successfully finalized but before the transaction commits: construct the generation manifest, optionally bind terminal consumers, insert durable member leases, and return the prepared identity.
 
-The initial freeze-in-place design also relies on existing stream-table write protection. Every supported mutation of a stream-table storage relation must flow through `pg_trickle` and advance a durable storage-generation marker. Superuser tampering remains outside the ordinary trust model, but supported lifecycle paths, repair paths, DDL hooks, and refresh paths must all participate in generation validation. A prepared generation cannot be considered immutable if one supported code path can recreate or rewrite a member without checking its lease.
+The initial freeze-in-place design also relies on existing stream-table write protection. Every supported mutation of a stream-table storage relation must flow through `pg_trickle` and advance its durable content epoch. Superuser tampering remains outside the ordinary trust model, but supported lifecycle paths, repair paths, DDL hooks, and refresh paths must all participate in generation validation. A prepared generation cannot be considered immutable if one supported code path can recreate or rewrite a member without checking its lease.
 
 ---
 
 ## 8. Terminology
 
-A **prepared graph generation** is one completed graph refresh whose stream-table contents, graph contract, member contracts, source-boundary manifest, storage-generation markers, and bound output-delta positions have been sealed against further graph mutation. The generation is durable and identified by a UUID and an immutable digest.
+A **prepared graph generation** is one completed graph refresh whose stream-table contents, graph execution contract, member execution contracts, source-boundary manifest, content epochs, and optional bound output-delta positions have been sealed against further graph mutation. The generation is durable and identified by a UUID and an immutable digest.
 
 A **generation member** is a stream table in the canonical dependency closure of the prepared roots. Capability major 1 requires every member to use durable `EXTERNAL` orchestration and permits at most one active prepared lease for a member.
 
@@ -165,9 +161,9 @@ A **member lease** is a logged catalog record that prohibits refresh, defining-q
 
 A **prepared read** is a transaction that calls `open_prepared_graph()` and then reads one or more generation members or bound output-delta relations. Opening validates the generation and holds a transaction-scoped shared transition lock so that promotion or abandonment cannot release the member leases until the reader's transaction ends.
 
-A **prepared consumer range** is the interval from one output-delta consumer's acknowledged batch token, exclusive, through the terminal token produced or observed by the prepared graph, inclusive. The range records whether exact rows are continuously available or whether the coordinator must resynchronize from the complete prepared terminal relation.
+A **prepared consumer binding** records one Delta V1 consumer and the prepared terminal token. For an `ACTIVE` consumer it also records the interval after the acknowledged token and whether every batch is exact or the interval contains `FULL_INVALIDATION`. For a consumer already in `RESNAPSHOT_REQUIRED`, it records that no continuous historical range is claimed and that the complete prepared terminal relation is the required baseline.
 
-**Promotion** is the transactionally atomic acceptance transition from `PREPARED` to `PROMOTED`. It validates the immutable generation, applies every required output-delta acknowledgement, records completion, and releases member leases in the caller's transaction. Capability major 1 does not perform a physical table swap because the prepared result already occupies the private graph storage.
+**Promotion** is the transactionally atomic acceptance transition from `PREPARED` to `PROMOTED`. It validates the immutable generation, records completion, and releases member leases in the caller's transaction. When prepared delta binding applies, it also applies every required output-delta acknowledgement or prepared resnapshot completion. Capability major 1 does not perform a physical table swap because the prepared result already occupies the private graph storage.
 
 **Abandonment** is the explicit rejection transition from `PREPARED` or `INVALID` to `ABANDONED`. It releases member leases without acknowledging any prepared consumer range and without attempting to reverse the graph refresh.
 
@@ -179,7 +175,7 @@ A **prepared consumer range** is the interval from one output-delta consumer's a
 
 The capability is governed by the following invariants. They define the contract more strongly than any proposed catalog layout.
 
-1. **One immutable generation.** Every successful `prepare_graph()` identifies exactly one graph contract, member set, source-boundary manifest, member content generation, and prepared consumer range. Those inputs cannot change while the generation remains prepared.
+1. **One immutable generation.** Every successful `prepare_graph()` identifies exactly one graph execution contract, member set, source-boundary manifest, member content epoch, and optional prepared consumer binding set. Those inputs cannot change while the generation remains prepared.
 
 2. **No invisible graph mutation.** A refresh, query alteration, storage recreation, ownership transfer, orchestration change, drop, restore, or repair that could alter a prepared member is rejected before mutation.
 
@@ -187,15 +183,15 @@ The capability is governed by the following invariants. They define the contract
 
 4. **Source writes remain independent.** Committed source changes after the prepared boundary may accumulate for a later graph refresh, but they do not modify or invalidate the prepared member contents merely because they exist.
 
-5. **Prepared reads are repeatable by contract.** Every transaction that successfully opens a prepared generation reads the same member contents and bound output ranges as every other successful prepared read of that generation.
+5. **Prepared reads are repeatable by contract.** Every transaction that successfully opens a prepared generation reads the same member contents and optional bound output ranges as every other successful prepared read of that generation.
 
-6. **Promotion shares the caller's commit.** Generation promotion, bound output acknowledgements, and the coordinating extension's publication commit or roll back together.
+6. **Promotion shares the caller's commit.** Generation promotion and the coordinating extension's publication commit or roll back together. When prepared delta binding applies, bound output acknowledgements share that transaction.
 
 7. **Abandonment is not acceptance.** Abandoning a generation never advances an output consumer cursor and never claims that a higher-level publication consumed its evidence.
 
 8. **No rollback reconstruction.** Abandonment does not reverse the private stream tables. The durable consumer cursor and later cumulative delta sequence record what the coordinator has or has not accepted.
 
-9. **Exact history or explicit resynchronization.** A prepared consumer range is either a continuous exact sequence or an explicit requirement to read the complete prepared terminal relation. Missing history is never represented as an empty exact range.
+9. **Exact history or explicit resnapshot.** A prepared consumer binding reports `EXACT`, `FULL_INVALIDATION`, or `RESNAPSHOT_REQUIRED`. Missing history is never represented as an empty exact range.
 
 10. **Transition serialization.** A prepared read blocks promotion or abandonment for the duration of its transaction, and promotion or abandonment blocks new prepared reads while the transition is validated and committed.
 
@@ -203,7 +199,7 @@ The capability is governed by the following invariants. They define the contract
 
 12. **Durable recovery.** Restart, failover, backup, restore, and supported extension upgrade preserve prepared state and leases or report a stable invalid condition. They never silently release, promote, or acknowledge a generation.
 
-13. **Semantic contract pinning.** A semantic mutation to the graph, a member, a result-affecting function, row-identity behavior, collation dependency, or output contract prevents promotion under the old generation digest.
+13. **Stored execution proof.** The generation stores the complete Graph V1 execution-contract projections used at preparation. Opening and promotion verify those stored contracts against the generation digest without requiring mutable dependency catalogs to remain unchanged. A change that mutates member contents or changes how stored output values are interpreted prevents promotion.
 
 14. **Physical tuning is not semantic.** A supported statistics update, index maintenance operation, worker-count change, or other proven physical-only change does not alter the generation digest or domain meaning.
 
@@ -250,14 +246,15 @@ A failed preparation transaction creates no durable generation. `PREPARING` may 
 
 ## 11. Capability discovery and versioning
 
-The V1 capability-discovery function should add one row when the feature is installed and usable:
+The V1 capability-discovery function adds one row for each V2 capability:
 
 ```text
-capability                    major  minor  enabled  details
-prepared_graph_generation       1      0      true   {...}
+capability                      major  minor  enabled  details
+prepared_graph_generation         1      0      true   {...}
+prepared_output_delta_binding     1      0      false  {...}
 ```
 
-The details object is advisory and may include:
+The core capability details are advisory and may include:
 
 ```json
 {
@@ -267,16 +264,14 @@ The details object is advisory and may include:
   "multi_generation_storage": false,
   "prepared_graph_refresh_resumable": false,
   "required_capabilities": {
-    "graph_contract": 1,
-    "external_orchestration": 1,
-    "transactional_graph_refresh": 1,
-    "source_boundary_manifest": 1,
-    "output_delta_consumer": 1
+    "external_graph_refresh": 1
   }
 }
 ```
 
-A capability major changes when the prepared-generation state model, member immutability rules, read-opening semantics, generation digest, promotion atomicity, abandonment behavior, or prepared consumer-range contract changes incompatibly. A minor version may add optional diagnostics, support more source kinds, permit more physical maintenance operations, or add non-required result fields without weakening the major contract.
+`prepared_output_delta_binding` reports its own required majors for `prepared_graph_generation` and `output_delta_consumer`, plus supported prepared-range encoding versions. It reports `enabled = true` only when both prerequisites also report enabled compatible majors and its catalog migration and recovery checks pass. A caller checks all three rows; package version alone is insufficient. A release may advertise stable core preparation while prepared delta binding remains absent, disabled, or experimental.
+
+The core capability major changes when the generation state model, member immutability rules, read-opening semantics, generation digest, promotion atomicity, or abandonment behavior changes incompatibly. The prepared-delta major changes when prepared consumer-range, retention, resynchronization, or promotion-acknowledgement behavior changes incompatibly. A minor version may add optional diagnostics, support more source kinds already admitted by Graph V1, permit more contract-neutral maintenance operations, or add non-required result fields without weakening its major contract.
 
 The capability is disabled when a prerequisite capability is absent, an upgrade has not completed the durable catalog migration, recovery has not validated the generation registry, or the server configuration cannot preserve the documented semantics. A new package version must not be treated as sufficient evidence that preparation is safe; runtime capability discovery remains authoritative.
 
@@ -284,28 +279,30 @@ The capability is disabled when a prerequisite capability is absent, an upgrade 
 
 ## 12. Prepared-generation identity
 
-Every generation has both a durable identifier and an immutable digest. The identifier is an opaque UUID suitable for catalog lookup. The digest is computed from a canonical, versioned encoding of the generation's immutable contract and protects callers against stale references, cross-object mistakes, and accidental catalog drift.
+Every generation has a durable identifier and an immutable digest. The identifier is an opaque UUID suitable for catalog lookup. The digest uses the ordered typed encoding defined by Graph V1 with a separate `generation_encoding_version`. It protects callers against stale references, cross-object mistakes, and accidental catalog drift.
 
 The generation digest includes at least:
 
 ```text
-generation-contract major and minor
+generation encoding version
 prepared_generation_id
 preparation request_id
-database lineage identifier
+preparation request digest
+database_instance_id
 owner role identity
 canonical roots and member order
 graph contract digest
 source-boundary digest
 for every member:
-  stable stream-table identity
+  stable stream-table object identity
+  stream-table contract generation
   stream-table contract digest
   storage relation identity
-  storage generation
+  content epoch
   producing refresh identifier
   output schema digest
   row-identity and probe versions
-for every bound consumer:
+when prepared output-delta binding applies, for every bound consumer:
   consumer identity
   output contract digest
   row-identity version
@@ -314,11 +311,11 @@ for every bound consumer:
   required disposition class
 ```
 
-Mutable operational fields such as state, age, warning counters, active readers, retained-byte estimates, and completion timestamps do not affect the digest. The canonical representation must be specified and tested with independent golden vectors. A refactor of JSON rendering, catalog row order, or internal relation naming must not change the digest.
+Mutable operational fields such as state, age, warning counters, active readers, retained-byte estimates, and completion timestamps do not affect the digest. Capability minor versions do not affect it. The canonical representation must be specified and tested with independent golden vectors. A refactor of JSON rendering, catalog row order, or internal relation naming must not change the digest. The same generation digest remains valid after transition to `PROMOTED`, `ABANDONED`, or `INVALID` because state is not an immutable evidence input.
 
 The caller stores both the UUID and digest in its own run manifest. Every later open, promotion, or abandonment supplies the expected digest. An identifier that exists with a different digest is a hard error rather than an invitation to use the current row.
 
-Preparation also accepts a caller-provided `request_id`. The pair `(owner_role, request_id)` is unique. Repeating a request after an uncertain network outcome returns the existing generation only when the roots, graph digest, consumers, and options are identical. Reusing the request identifier with different inputs raises a stable idempotency error. This prevents a lost response after commit from leaving the coordinator unable to rediscover which prepared generation owns the graph.
+Preparation also accepts a caller-provided `request_id`. The pair `(owner_role, request_id)` is unique. Before graph mutation, `prepare_graph()` computes a canonical `request_digest` over `database_instance_id`, owner, canonical roots, expected graph digest, sorted output-consumer identities, `full_policy`, and requested V2 capability majors. A repeated request returns the existing generation in its current state only when this digest matches. Reusing the identifier with different inputs raises a stable idempotency error. This prevents a lost response after commit from leaving the coordinator unable to rediscover which prepared generation owns the graph.
 
 ---
 
@@ -341,7 +338,6 @@ FROM pgtrickle.prepare_graph(
         :pair_evidence_consumer_id,
         :golden_candidate_consumer_id
     ]::uuid[],
-    require_complete_boundaries  => true,
     full_policy                  => 'ALLOW'
 );
 ```
@@ -354,7 +350,6 @@ pgtrickle.prepare_graph(
     roots                        regclass[],
     expected_graph_digest        bytea,
     output_consumers             uuid[] DEFAULT ARRAY[]::uuid[],
-    require_complete_boundaries  boolean DEFAULT true,
     full_policy                  text DEFAULT 'ALLOW'
 )
 RETURNS pgtrickle.prepared_graph_result
@@ -379,17 +374,17 @@ Detailed member and consumer rows are returned by separate set-returning status 
 
 ### 13.2 Admission checks
 
-Before any graph member is mutated, `prepare_graph()` resolves the complete canonical closure and verifies that every member is in `EXTERNAL` orchestration mode, every expected graph contract matches, the graph is acyclic under the supported V1 rules, no member is suspended or already leased, no conflicting refresh or lifecycle operation is active, and every requested output consumer belongs to an eligible terminal or explicitly named member with a compatible output contract.
+Before any graph member is mutated, `prepare_graph()` resolves the complete canonical closure and verifies that every member is in `EXTERNAL` orchestration mode, every expected graph contract matches, the graph is acyclic under the supported Graph V1 rules, no member is suspended or already leased, and no conflicting refresh or lifecycle operation is active. A non-empty `output_consumers` array requires enabled `prepared_output_delta_binding`. Every requested consumer must belong to an eligible terminal or explicitly named member, have a compatible output contract, and be `ACTIVE` or `RESNAPSHOT_REQUIRED`. `PAUSED`, `INVALIDATED`, and `DROPPED` consumers are rejected before member refresh begins.
 
-The initial capability also rejects a graph that has a scheduler-managed downstream stream table outside the prepared closure. Such a dependent could consume and publish the newly prepared private state before the coordinating extension accepts it. Direct SQL readers remain governed by PostgreSQL grants, but automatic downstream propagation must stay within the same externally controlled boundary. A later capability may define explicit multi-coordinator dependencies; capability major 1 fails closed instead.
+A **managed downstream dependent** is a stream table outside the canonical prepared member set that reads output from any prepared member and remains in `MANAGED` orchestration mode. The initial capability rejects such a graph before refresh. That dependent could otherwise consume and publish the newly prepared private state before the coordinating extension accepts it. Direct SQL readers remain governed by PostgreSQL grants, but automatic downstream propagation must stay within the same externally controlled boundary. A later capability may define explicit multi-coordinator dependencies; capability major 1 fails closed instead.
 
-If complete boundaries are required, every accepted source kind must provide the same proof required by V1 strict graph refresh. A partial remote snapshot, an unverifiable polling source, missing CDC state, or any source-boundary uncertainty aborts preparation. `full_policy` has the same meaning as in the V1 strict API: a caller may allow a correct full refresh or require differential execution, but no policy may publish incomplete relational state.
+Every source must provide the complete proof required by Graph V1 strict refresh. Missing CDC state or any source-boundary uncertainty aborts preparation. Source classes not admitted by the negotiated Graph V1 minor are rejected. Completeness is not optional. `full_policy` has the same meaning as in the Graph V1 strict API: a caller may allow a correct full refresh or require differential execution, but no policy may publish incomplete relational state.
 
 ### 13.3 Execution and commit
 
 After admission, `prepare_graph()` invokes the ordinary strict graph-refresh engine using one immutable boundary context and the standard deterministic lock order. Every member refresh, output-delta batch, frontier update, and refresh-history record is finalized through the normal common path. If any node fails, the entire preparation transaction rolls back and no generation or lease exists.
 
-After the graph result is complete, but before returning, the function captures each member's contract and storage-generation markers, binds the requested output-consumer ranges, constructs the canonical generation digest, inserts the durable generation and member rows, and acquires one persistent lease record per member. The stream-table rows and lease records commit together. There is no interval in which the refreshed contents are committed but the graph is not protected.
+After the graph result is complete, but before returning, the function captures each member's execution contract and content epoch, constructs the canonical generation digest, inserts the durable generation and member rows, and acquires one persistent lease record per member. When prepared delta binding applies, it also binds the requested consumers. The stream-table rows and lease records commit together. There is no interval in which the refreshed contents are committed but the graph is not protected.
 
 The call itself does not commit. The caller controls its transaction as usual. The recommended pattern is a small standalone preparation transaction that stores the returned generation identity in the coordinating extension's run record and commits both records together. If that transaction rolls back, the graph refresh, output batches, generation, leases, and coordinator run record all disappear.
 
@@ -400,12 +395,13 @@ If the client loses its connection after the server may have committed, it queri
 ```sql
 SELECT *
 FROM pgtrickle.prepared_graph_by_request(
-    owner_role => current_user::regrole,
-    request_id => :mdm_run_id
+  owner_role              => current_user::regrole,
+  request_id              => :mdm_run_id,
+  expected_request_digest => :request_digest
 );
 ```
 
-When the request did not commit, no row exists and the caller may retry with the same inputs. When it committed, the existing generation and digest are returned. When the identifier exists for different inputs, the function reports a request conflict. This behavior is important because a committed but undiscovered prepared generation intentionally blocks later graph refreshes.
+When the request did not commit, no row exists and the caller may retry with the same inputs. When it committed, the existing generation, generation digest, request digest, and current state are returned. When the identifier exists with a different request digest, the function reports a request conflict. This behavior is important because a committed but undiscovered prepared generation intentionally blocks later graph refreshes.
 
 ---
 
@@ -443,7 +439,7 @@ A prepared member lease is a logged catalog fact. It must not be implemented sol
 
 Preparation acquires ordinary transaction locks on every member in canonical order, verifies that no active lease exists, writes all leases, and commits them with the graph refresh. Every supported code path that can mutate a member must acquire the same member catalog lock and call one central lease guard after locking. That includes scheduled and manual refresh, V1 strict graph refresh, another preparation, `ALTER QUERY`, storage migration, restore, recreation, owner transfer, orchestration-mode change, suspend/resume operations that alter refresh eligibility, and drop. A check performed before acquiring the mutation lock is insufficient because preparation could commit between the check and mutation.
 
-While the lease is active, ordinary reads, `VACUUM`, `ANALYZE`, and other explicitly classified operations that do not change logical contents or semantic contracts may proceed. Physical maintenance that replaces storage, changes relation identity, or cannot prove preservation is blocked in capability major 1. A later minor version may allow more maintenance after tests demonstrate that the pinned storage-generation and contract checks remain sufficient.
+While the lease is active, ordinary reads, `VACUUM`, `ANALYZE`, and other explicitly classified operations that do not change logical contents or execution contracts may proceed. Physical maintenance that replaces storage, changes relation identity, or cannot prove content preservation is blocked in capability major 1. A later minor version may allow more maintenance after tests demonstrate that the pinned content-epoch and contract checks remain sufficient.
 
 The graph remains in `EXTERNAL` orchestration mode after promotion or abandonment. Releasing a prepared lease makes it eligible for a later explicit V1 strict refresh or another preparation; it never transfers the graph to the normal scheduler.
 
@@ -468,7 +464,7 @@ FROM pgtrickle.open_prepared_graph(
 COMMIT;
 ```
 
-`open_prepared_graph()` validates state, digest, ownership, database lineage, member leases, member contracts, member storage generations, and bound output state. It then holds a transaction-scoped shared transition lock on the generation. Several read transactions may open the same generation concurrently. Promotion and abandonment require an exclusive transition lock and therefore wait or return a stable busy error until all prepared readers finish.
+`open_prepared_graph()` validates state, digest, ownership, `database_instance_id`, member leases, stored member execution contracts, member content epochs, and optional bound output state. It then holds a transaction-scoped shared transition lock on the generation. Several read transactions may open the same generation concurrently. Promotion and abandonment require an exclusive transition lock and therefore wait or return a stable busy error until all prepared readers finish.
 
 The open result includes the generation identifier and digest, graph digest, source-boundary digest, state, member count, and public member relation identities. It does not grant `SELECT`; ordinary PostgreSQL privileges still apply. It also does not create a new snapshot token. The persistent member leases ensure that the stream tables do not change, and the transaction-scoped transition lock ensures that the leases cannot be released during the read transaction. This makes the contents stable even under ordinary `READ COMMITTED` statement snapshots.
 
@@ -476,9 +472,9 @@ Status inspection without data reads does not need to open the generation and do
 
 ---
 
-## 17. Prepared output-delta ranges
+## 17. Prepared output-delta bindings
 
-At preparation, each explicitly bound V1 output consumer receives an immutable range associated with the generation. The range starts immediately after the consumer's acknowledged token and ends at the terminal token for the prepared stream-table state. The generation records the output contract digest, row-identity version, source-boundary digest, and whether the range can be applied incrementally.
+This section applies only when `prepared_output_delta_binding` is enabled. At preparation, each explicitly bound Delta V1 consumer receives an immutable binding associated with the generation. For an `ACTIVE` consumer, the range starts immediately after its acknowledged token and ends at the terminal token for the prepared stream-table state. For a consumer in `RESNAPSHOT_REQUIRED`, `from_token_exclusive` is null and no continuity before the terminal token is claimed. The generation records the output contract digest, row-identity version, source-boundary digest, and required processing state.
 
 A status function exposes the bindings:
 
@@ -492,9 +488,9 @@ It returns at least:
 ```text
 consumer_id
 stream_table
-from_token_exclusive
+from_token_exclusive       -- null for RESNAPSHOT_REQUIRED
 through_token_inclusive
-range_mode                 -- EXACT | RESYNCHRONIZE
+range_state                -- EXACT | FULL_INVALIDATION | RESNAPSHOT_REQUIRED
 required_disposition       -- APPLIED | RESYNCHRONIZED
 output_contract_digest
 row_identity_version
@@ -502,9 +498,11 @@ retained_rows
 retained_bytes
 ```
 
-`EXACT` means the V1 batch sequence is continuous and every batch is exact. `RESYNCHRONIZE` means the consumer already required a baseline, the range contains `FULL_INVALIDATION`, or another truthful V1 condition requires the complete terminal relation. The prepared generation itself provides the stable relation needed for a cross-transaction resynchronization, so a coordinator can page through a very large terminal table over several short prepared reads and checkpoint its progress.
+`EXACT` means the Delta V1 batch sequence is continuous and every batch is exact. `FULL_INVALIDATION` means a continuous range exists but contains at least one truthful invalidation marker. `RESNAPSHOT_REQUIRED` means the consumer entered preparation without a proven baseline or retained continuous history. The latter two states require the complete prepared terminal relation and the `RESYNCHRONIZED` disposition.
 
-Every batch and payload row needed by a prepared binding is pinned against cleanup. A direct call to the V1 acknowledgement API that would advance a bound consumer through or beyond the prepared terminal token is rejected while the generation is `PREPARED`. Only promotion may apply the bound acknowledgement. Consumer pause, drop, rebind, output-contract mutation, or resnapshot outside the prepared protocol is also blocked for bound consumers.
+Prepared resnapshot is an explicit extension of Delta V1's same-transaction resnapshot rule. The durable member lease replaces the ordinary resnapshot lock across processing transactions, and the immutable binding pins the terminal token. Every page must be read through `open_prepared_graph()`. Promotion performs the equivalent terminal-token acknowledgement and moves the consumer to `ACTIVE` only after the coordinator declares `RESYNCHRONIZED` in its publication transaction. No ordinary Delta V1 API may acknowledge the consumer while the binding is active.
+
+Every batch and payload row required by an `EXACT` or `FULL_INVALIDATION` binding is pinned against cleanup. A direct call to the Delta V1 acknowledgement API that would advance a bound consumer through or beyond the prepared terminal token is rejected while the generation is `PREPARED`. Only promotion may apply the bound acknowledgement. Consumer pause, reset, drop, rebind, output-contract mutation, history discard, or resnapshot outside the prepared protocol is also blocked for bound consumers. A `RESNAPSHOT_REQUIRED` binding pins its terminal token and terminal relation but does not claim that unavailable older payload exists.
 
 The range is determined at preparation and does not grow when source changes arrive later. Later graph refreshes cannot occur while the member lease is active, so no new output batches for those members are produced until promotion or abandonment releases the graph.
 
@@ -536,17 +534,17 @@ FROM pgtrickle.promote_prepared_graph(
 );
 ```
 
-The final implementation should preferably use a typed array such as `pgtrickle.prepared_consumer_ack[]`; JSONB above is illustrative. Promotion returns the generation identifier, prior and new state, completion timestamp, released member count, and acknowledged consumer count.
+The final implementation should use a typed array such as `pgtrickle.prepared_consumer_ack[]`; JSONB above is illustrative. `acknowledgements` defaults to an empty typed array. A generation without consumer bindings must be promoted with the empty value, while a bound generation requires exactly one matching entry per consumer. Promotion returns the generation identifier, prior and new state, completion timestamp, released member count, and acknowledged consumer count.
 
 ### 18.2 Validation
 
-Promotion takes the generation's exclusive transition lock and then reacquires member locks in the same canonical order used by preparation. It verifies the expected digest, state, owner, database lineage, graph digest, member set, member contracts, member storage generations, producing refresh identifiers, source-boundary digest, active leases, output-consumer contracts, retained ranges, and required acknowledgement disposition. Every bound consumer must be acknowledged exactly through its prepared terminal token. Extra acknowledgements and omitted required acknowledgements are rejected.
+Promotion takes the generation's exclusive transition lock and then reacquires member locks in the same canonical order used by preparation. It verifies the expected digest, state, owner, `database_instance_id`, graph digest, member set, stored member contracts, member content epochs, producing refresh identifiers, source-boundary digest, and active leases. When prepared delta binding applies, it also verifies output-consumer contracts, retained ranges, and required acknowledgement dispositions. Every bound consumer must be acknowledged exactly through its prepared terminal token. Extra acknowledgements and omitted required acknowledgements are rejected.
 
-Source rows may have changed after preparation and do not prevent promotion. Those changes are intentionally pending. A semantic source or graph change that alters a pinned contract, a recreated member relation, a changed row-identity version, missing delta history, or a lost lease does prevent promotion. A separate future-continuity warning caused only by damage to post-boundary pending CDC may be returned, but it does not rewrite the already prepared evidence.
+Source rows may have changed after preparation and do not prevent promotion. Those changes are intentionally pending. A recreated member relation, changed member content epoch, output type or collation change that reinterprets stored values, changed row-identity version, lost lease, or missing bound delta history does prevent promotion. A later source, function, or defining-query dependency change that leaves prepared storage interpretable does not rewrite past evidence; it sets future continuity to `REINITIALIZE_REQUIRED`. Damage only to post-boundary pending CDC has the same future-continuity effect.
 
 ### 18.3 Transactional effect
 
-Promotion applies the bound V1 output-delta acknowledgements, moves any resynchronized consumer back to `ACTIVE`, marks the generation `PROMOTED`, records completion, and releases all member leases in the caller's transaction. It does not call arbitrary external code and it does not publish the coordinating extension's tables itself.
+Promotion marks the generation `PROMOTED`, records completion, and releases all member leases in the caller's transaction. When prepared delta binding applies, it also applies the bound Delta V1 acknowledgements and moves every successfully resynchronized consumer to `ACTIVE`. It does not call arbitrary external code and it does not publish the coordinating extension's tables itself.
 
 The caller may perform its own compare-and-swap checks and domain DML before or after the promotion call in the same transaction. If any later statement fails or the transaction is rolled back, the generation remains `PREPARED`, every lease remains active, and every consumer cursor remains unchanged. This property is the reason promotion must be an ordinary transactional SQL function rather than an asynchronous scheduler action.
 
@@ -579,21 +577,21 @@ An invalid generation can only be abandoned. It cannot be promoted after a repai
 
 ## 20. Source changes while a generation is prepared
 
-Preparing a graph freezes derived stream-table members, not their source systems. Local source transactions continue to insert, update, delete, and truncate rows under the ordinary `pg_trickle` CDC contract. WAL decoders, trigger buffers, upstream stream tables outside the prepared graph, and supported snapshot providers may continue advancing. Those later changes remain beyond the prepared source boundary and are processed by a future graph refresh after the lease is released.
+Preparing a graph freezes derived stream-table members, not their source systems. Local source transactions continue to insert, update, delete, and truncate rows under the ordinary `pg_trickle` CDC contract. WAL decoders and trigger buffers may continue advancing. The canonical Graph V1 closure already contains every upstream stream table, so there is no mutable upstream stream-table member outside the prepared graph. Later source changes remain beyond the prepared source boundary and are processed by a future graph refresh after the lease is released.
 
 This behavior is essential for operational usefulness. A large resolver should not need to stop OLTP writes while it analyzes prepared evidence. The generation manifest records the exact boundary it represents, and the coordinating extension publishes that boundary explicitly. Freshness may lag during a long preparation, but correctness is not weakened.
 
 The cost is retention. Because the prepared graph cannot advance its member frontiers, source change buffers and upstream stream-table output buffers may retain all changes after the prepared boundary. `pg_trickle` must expose the resulting row, byte, age, and WAL-risk estimates. It may refuse a new preparation when current capacity cannot support the requested graph or configured advisory horizon, but it must not discard pending source changes or silently abandon an active generation to relieve pressure.
 
-A semantic source change is different from ordinary row changes. A mapped column type change, source relation replacement, result-affecting view or function change, collation change, source identity change, or other mutation that changes the pinned graph contract invalidates the generation or is blocked by existing DDL guards. An unrelated source-table change that provably does not affect the graph contract need not invalidate it.
+A source or function dependency change after preparation does not alter the frozen member rows. Supported DDL hooks record that the current graph contract diverged and set future continuity to `REINITIALIZE_REQUIRED`. The prepared generation remains valid when its member relations, content epochs, stored output types and collations, leases, and optional bound delta ranges still verify. A change that rewrites a prepared member or changes how its stored values are interpreted is blocked before mutation or makes the generation `INVALID`. Changes to unrelated sources have no effect.
 
 ---
 
 ## 21. Validation, invalidation, and repair
 
-The status model separates **prepared validity** from **future refresh continuity**. Prepared validity answers whether the member contents, contracts, source-boundary proof, and output ranges still match the immutable generation. Future continuity answers whether the graph can perform another safe incremental refresh after the lease is released.
+The status model separates **prepared validity** from **future refresh continuity**. Prepared validity answers whether the stored execution proof, member contents, source-boundary proof, and optional output ranges still match the immutable generation. Future continuity answers whether the current graph definition and CDC state can perform another safe incremental refresh after the lease is released.
 
-A prepared generation becomes invalid when a member relation is missing or recreated, a member storage-generation marker changes, an active lease is missing or points elsewhere, a graph or stream-table contract no longer matches, a bound output log or batch range is unavailable, a row-identity or output contract changes, database lineage is wrong, or any other required proof cannot be reconstructed. It is never automatically refreshed to a newer boundary and still called the same generation.
+A prepared generation becomes invalid when a member relation is missing or recreated, a member content epoch changes, an active lease is missing or points elsewhere, the stored execution-contract projection fails its recorded digest, a stored output type or collation can no longer be interpreted under its pinned contract, `database_instance_id` differs, or another core proof cannot be reconstructed. When prepared delta binding applies, an unavailable bound log or batch range and an incompatible row-identity or output contract also invalidate promotion. The generation is never refreshed to a newer boundary and still called the same generation.
 
 Pending CDC damage after the prepared boundary may instead set future continuity to `REINITIALIZE_REQUIRED` while leaving prepared validity as `VALID`. The coordinator may still publish the proved prepared state. After promotion or abandonment, the next graph refresh must follow the V1 full-reinitialization and explicit invalidation rules rather than pretending incremental continuity survived.
 
@@ -607,7 +605,7 @@ FROM pgtrickle.verify_prepared_graph(
 );
 ```
 
-A fast verification checks catalogs, contracts, leases, storage generations, relation identities, output ranges, sentinels, and database lineage. A deep verification may perform expensive row-identity, schema, or content checks where supported. The function returns a structured validity result rather than raising for every discovered defect, allowing a recovery worker or administrator to commit an `INVALID` state. Promotion still fails on any invalid result.
+A fast verification checks generation and member catalogs, stored contract digests, leases, content epochs, relation identities, output types and collations, `database_instance_id`, and optional bound output ranges and sentinels. A deep verification may perform expensive row-identity, schema, or content checks where supported. It may claim complete content equality only when preparation recorded a content checksum or equivalent reference proof; otherwise its result remains a structural and sampled-content verification. The function returns a structured validity result rather than raising for every discovered defect, allowing a recovery worker or administrator to commit an `INVALID` state. Promotion still fails on any invalid result.
 
 `repair_stream_table()` and storage recreation are blocked while a valid prepared lease exists because changing a member would invalidate the coordinator's work. When a generation is already invalid, the operator first abandons it, then repairs or recreates the graph, and finally prepares a new generation. Repair does not mutate an old generation into valid state.
 
@@ -618,14 +616,14 @@ A fast verification checks catalogs, contracts, leases, storage generations, rel
 Preparation, opening, promotion, abandonment, graph refresh, and lifecycle operations must share one documented lock hierarchy. A recommended order is:
 
 ```text
-database-local integration registry
-  -> canonical graph transition key
-  -> generation row, when one exists
-  -> member stream-table catalog rows in ascending stable identity
+generation transition lock, when an existing generation is targeted
+  -> member refresh, lifecycle, and catalog-row locks in the canonical Graph V1 order
   -> member storage relations in ascending OID where required
-  -> output consumers in ascending UUID byte order
+  -> output consumers in ascending UUID byte order, when delta binding applies
   -> output batch and payload relations
 ```
+
+The member locks are the graph-isolation mechanism. V2 uses the exact canonical database-local member key and ordering implemented by the negotiated Graph V1 capability; it does not derive a second V2 order from `pgt_id`, relation OID, root order, or generation identity. No hash of the root or member set and no database-wide integration-registry lock may substitute for those locks. Preparation also serializes `(owner_role, request_id)` through the unique catalog key while establishing idempotency, but that key does not protect graph members.
 
 `prepare_graph()` locks the complete member set before refreshing any member and inserts the durable leases while those locks remain held. Concurrent preparations with overlapping members serialize at the first common member and one fails with a stable lease conflict. A V1 strict graph refresh, manual refresh, scheduler dispatch, or lifecycle mutation that encounters an active lease fails rather than waiting indefinitely and later mutating evidence whose coordinator assumptions may have changed.
 
@@ -657,11 +655,11 @@ A backend disconnect after a generation is prepared does nothing to its state. T
 
 A crash during a prepared read rolls back only that read transaction and releases its shared transition lock. The durable generation remains prepared. A crash during promotion or abandonment follows ordinary PostgreSQL atomicity. If the transition transaction did not commit, state, leases, and consumer cursors remain exactly as before. If it committed, all effects are visible together.
 
-Startup recovery performs a fast verification of every active generation and lease. It checks catalog referential integrity, member identities, storage generations, output-consumer bindings, output-log continuity, and capability versions. A provable mismatch is recorded as `INVALID` in a separate recovery transaction and surfaced through health diagnostics. Recovery never guesses a replacement generation or advances a consumer cursor.
+Startup recovery performs a fast verification of every active generation and lease. It checks catalog referential integrity, member identities, content epochs, stored contracts, `database_instance_id`, capability versions, and any prepared consumer bindings and output-log continuity. A provable mismatch is recorded as `INVALID` in a separate recovery transaction and surfaced through health diagnostics. Recovery never guesses a replacement generation or advances a consumer cursor.
 
-Physical backup, PITR, and streaming replication include generation catalogs, member storage, leases, output logs, and consumer cursors as ordinary durable PostgreSQL state. A restored writable clone must have a documented database-lineage policy. If the V1 integration contract rekeys lineage for a clone, active prepared generations from the original lineage become invalid until explicitly abandoned; a clone must not accidentally promote a generation intended for another database history.
+Restart and failover that preserve the v0.92 `database_instance_id` preserve generation catalogs, member storage, leases, output logs, and consumer cursors as ordinary durable PostgreSQL state. Any restore, PITR, template copy, physical clone, or logical restore activated with a new writable `database_instance_id` marks imported active generations `INVALID`. Their leases remain until explicit abandonment so the restored graph cannot refresh under ambiguous ownership.
 
-Logical dump and restore support must either preserve every required durable object and dependency in a verified order or reject active prepared generations before dump with a clear instruction. The implementation must not restore the member tables while omitting their leases or bound delta history and then report the graph as freely refreshable.
+Capability major 1 does not preserve active prepared generations through the supported logical dump and restore workflow. Backup preflight rejects logical dump while a generation is `PREPARED` and instructs the operator to promote or abandon it. If unsupported tooling nevertheless restores active rows into a new instance, startup recovery marks them `INVALID` and retains their leases until explicit abandonment. Terminal audit rows may be restored as history.
 
 ---
 
@@ -675,17 +673,17 @@ The V2 API should use the structured error framework established by the V1 integ
 | `PGT_PREP_REQUEST_CONFLICT` | A preparation request identifier already exists with different inputs |
 | `PGT_PREP_GRAPH_INELIGIBLE` | The graph is not a complete supported external preparation boundary |
 | `PGT_PREP_LEASE_CONFLICT` | One or more members already belong to another prepared generation |
-| `PGT_PREP_GENERATION_NOT_FOUND` | The generation identifier is unknown in the current database lineage |
+| `PGT_PREP_GENERATION_NOT_FOUND` | The generation identifier is unknown in the current database instance |
 | `PGT_PREP_DIGEST_MISMATCH` | The supplied generation digest does not match the stored immutable generation |
 | `PGT_PREP_STATE_CONFLICT` | The requested action is invalid for the generation's current state |
 | `PGT_PREP_READ_BUSY` | A transition cannot proceed because prepared readers are active, or a reader cannot open during transition |
-| `PGT_PREP_MEMBER_CHANGED` | A member contract, relation, storage generation, or producing refresh changed |
+| `PGT_PREP_MEMBER_CHANGED` | A member execution contract, relation, content epoch, or producing refresh changed |
 | `PGT_PREP_DELTA_UNAVAILABLE` | A bound output range or its proof is missing or discontinuous |
 | `PGT_PREP_ACK_MISMATCH` | Promotion acknowledgements are missing, extra, out of range, or use the wrong disposition |
 | `PGT_PREP_AUTHORIZATION` | The caller lacks authority over the generation, one member, or one bound consumer |
 | `PGT_PREP_INVALID` | Verification has determined that the generation cannot be promoted |
 | `PGT_PREP_LIFECYCLE_BLOCKED` | Refresh, DDL, repair, drop, or another lifecycle operation is blocked by a prepared lease |
-| `PGT_PREP_LINEAGE_MISMATCH` | The token or generation belongs to another database lineage |
+| `PGT_PREP_DATABASE_INSTANCE_MISMATCH` | The token or generation belongs to another `database_instance_id` |
 | `PGT_PREP_RESOURCE_RISK` | Admission refused because the requested preparation exceeds a configured hard safety bound |
 
 Each error names the affected generation and object when disclosure is authorized, states whether the generation remains prepared, identifies the concrete consequence, and provides one next action. A lease conflict is never downgraded to a notice or successful no-op. Missing delta history is never described as an empty exact range.
@@ -704,11 +702,13 @@ A logged generation catalog may contain:
 pgt_prepared_graphs
   prepared_generation_id uuid primary key
   request_id              uuid not null
+  request_digest          bytea not null
   owner_role              oid not null
-  database_lineage_id     uuid not null
+  database_instance_id    uuid not null
   state                   text not null
   capability_major        smallint not null
   capability_minor        smallint not null
+  generation_encoding_version smallint not null
   graph_refresh_id        bigint not null
   graph_digest            bytea not null
   source_boundary         jsonb not null
@@ -733,10 +733,13 @@ The immutable member manifest records:
 pgt_prepared_graph_members
   prepared_generation_id
   pgt_id
+  stream_object_identity
+  stream_contract_generation
+  stream_contract_encoding
   storage_relid
   stream_contract_digest
   output_schema_digest
-  storage_generation
+  content_epoch
   producing_refresh_id
   row_identity_version
   row_probe_version
@@ -764,9 +767,9 @@ pgt_prepared_graph_consumers
   prepared_generation_id
   consumer_id
   stream_table_id
-  from_token_exclusive
+  from_token_exclusive nullable
   through_token_inclusive
-  range_mode
+  range_state
   required_disposition
   output_contract_digest
   row_identity_version
@@ -776,9 +779,23 @@ pgt_prepared_graph_consumers
 
 A batch or payload row referenced by an active prepared consumer binding participates in the output-log retention minimum even if another consumer has advanced farther.
 
-### 26.4 Storage-generation marker
+### 26.4 Content epoch
 
-If no equivalent durable marker already exists, each stream table should have a monotonically increasing `storage_generation` or content epoch. Every supported operation that can change logical rows, replace storage, restore a snapshot, reinitialize, or recreate generated columns increments it in the same transaction. Preparation pins it, and opening or promotion validates it. A no-data refresh may leave it unchanged when the logical contents and storage identity are unchanged.
+Every stream table must expose one durable, monotonically increasing `content_epoch`; an existing field may satisfy this requirement only if it is already a complete mutation epoch. Every supported operation that can change logical rows, replace storage, restore a snapshot, reinitialize, recreate generated columns, or change the interpretation of stored values increments it in the same transaction. Preparation pins it, and opening or promotion validates it. A no-data refresh may leave it unchanged only when logical contents, storage identity, and stored-value interpretation are unchanged.
+
+The mutation classification is normative:
+
+| Mutation class | Increment `content_epoch` | Behavior while prepared |
+|---|---:|---|
+| Member refresh, supported direct storage DML, or `TRUNCATE` | Yes when logical contents may change | Rejected except the refresh inside `prepare_graph()` before the lease commits |
+| Storage recreation, snapshot restore, reinitialization, generated-column recreation, or stored type/collation reinterpretation | Yes | Rejected |
+| Repair that changes rows, storage identity, frontier-derived contents, or stored-value interpretation | Yes | Rejected |
+| Member defining-query change | Increment when it also changes stored rows or interpretation; always increment `contract_generation` | Rejected |
+| Source or function dependency change that does not mutate or reinterpret prepared member rows | No | Record current-contract divergence and set future continuity to `REINITIALIZE_REQUIRED` |
+| Owner transfer, orchestration change, suspend, or resume | No | Rejected because pinned authority or lifecycle state changes, not because contents change |
+| Index maintenance, `VACUUM`, `ANALYZE`, or planner-statistics change proven content-neutral | No | Allowed |
+
+Every supported SQL mutation entry point must map to one row in this table and have a lease and epoch test. New mutation paths fail review unless they declare both classifications.
 
 The marker is not a content hash and does not protect against malicious superuser writes. It is a complete supported-path invalidation token. A deep verification may add expensive checks when an operator suspects out-of-band tampering.
 
@@ -786,13 +803,13 @@ The marker is not a content hash and does not protect against malicious superuse
 
 ## 27. Integration with the refresh engine
 
-`prepare_graph()` should be a thin coordination layer over the V1 strict graph-refresh implementation. It creates the same canonical graph plan, computes the same source-boundary context, takes the same locks, invokes the same member refresh operations, and uses the same common finalizer. The refresh engine returns a structured graph result; the prepared layer then validates output consumers, writes the immutable manifest and leases, and returns the prepared result.
+`prepare_graph()` should be a thin coordination layer over the Graph V1 strict graph-refresh implementation. It creates the same canonical graph plan, computes the same source-boundary context, takes the same locks, invokes the same member refresh operations, and uses the same common finalizer. The refresh engine returns a structured graph result; the prepared layer writes the immutable manifest and leases and returns the prepared result. When prepared delta binding applies, it also validates and binds output consumers before commit.
 
-This ordering matters. Leases cannot commit before the graph has successfully refreshed, but the refreshed graph cannot commit without leases. Both are therefore finalized in one transaction. Output-delta batches are created by the ordinary V1 finalizer and are merely bound by the generation; the prepared layer does not create another delta format.
+This ordering matters. Leases cannot commit before the graph has successfully refreshed, but the refreshed graph cannot commit without leases. Both are therefore finalized in one transaction. When Delta V1 is enabled, its batches are created by the ordinary finalizer and are merely bound by the optional capability; the prepared layer does not create another delta format.
 
 Every existing member-mutation entry point should call one central `ensure_member_not_prepared()` guard after acquiring the member's catalog lock. Scattering direct queries against a private lease table through the codebase would make it easy for a later lifecycle feature to omit the check. The central guard should return a structured error containing the owning generation and permitted next actions.
 
-Promotion and abandonment should similarly share one internal transition routine that acquires the generation and member locks, validates immutable state, applies the requested transition-specific action, and releases leases. Promotion supplies output acknowledgements; abandonment supplies a required reason and no acknowledgements. Neither path should call the graph-refresh engine.
+Promotion and abandonment should similarly share one internal transition routine that acquires the generation and member locks, validates immutable state, applies the requested transition-specific action, and releases leases. Promotion optionally supplies output acknowledgements; abandonment supplies a required reason and never acknowledges. Neither path should call the graph-refresh engine.
 
 The scheduler must treat an active member lease as a hard exclusion even though eligible graphs are already `EXTERNAL`. This redundant check protects against catalog corruption, orchestration-mode migration, and future scheduler features. A leased member is never refreshed because it happens to appear stale.
 
@@ -802,7 +819,7 @@ The scheduler must treat an active member lease as a hard exclusion even though 
 
 ### 28.1 Create and initial preparation
 
-A coordinating extension creates its graph and output consumers through the V1 contract. The graph normally has no prepared state until a large run begins. Initial population may itself be prepared. If the bound consumer has no baseline or the initial batches require full invalidation, the prepared consumer range requires `RESYNCHRONIZED`, and the coordinator builds its first domain result from the frozen terminal relations.
+A coordinating extension creates its graph through Graph V1 and may create output consumers through Delta V1. The graph normally has no prepared state until a large run begins. Initial population may itself be prepared. Without consumer bindings, the coordinator builds its domain result from the frozen terminal relations. With prepared delta binding, `FULL_INVALIDATION` or `RESNAPSHOT_REQUIRED` requires the coordinator to build from those complete relations and promote with `RESYNCHRONIZED`.
 
 ### 28.2 Strict refresh and repeated preparation
 
@@ -810,7 +827,7 @@ A V1 strict graph refresh is rejected while any member is leased. After promotio
 
 ### 28.3 Query and schema changes
 
-Any semantic or output-changing alteration of a prepared member is blocked. The coordinating extension first abandons the generation, then creates or alters the desired graph according to the V1 contract, establishes new consumers or baselines where required, and prepares a new generation. A physical-only operation may proceed only when it is explicitly classified as safe and does not alter pinned storage generation or relation identity.
+Any output-changing alteration of a prepared member is blocked. The coordinating extension first abandons the generation, then creates or alters the desired graph according to the Graph V1 contract, establishes new consumers or baselines where required, and prepares a new generation. A physical-only operation may proceed only when it is explicitly classified as safe and does not alter the pinned content epoch or relation identity.
 
 ### 28.4 Ownership and orchestration changes
 
@@ -837,7 +854,7 @@ FROM pgtrickle.prepared_graph_status(:generation_id);
 
 It reports state, owner, request identifier, age, roots, member count, graph and generation digests, source-boundary summary, prepared consumer count, active reader count, future-continuity state, invalid reason, pinned output rows and bytes, estimated pending source rows and bytes, and every current lifecycle blocker. A separate list function returns one concise row per active or recently completed generation.
 
-`prepared_graph_members()` reports member relation, contract digest, storage generation, producing refresh identifier, root status, and current validation result. `prepared_graph_consumers()` reports the immutable prepared ranges and required dispositions. Neither function exposes private change-buffer relation names or internal lease keys.
+`prepared_graph_members()` reports member relation, object identity, contract generation and digest, content epoch, producing refresh identifier, root status, and current validation result. `prepared_graph_consumers()` reports the immutable prepared ranges and required dispositions when delta binding applies. Neither function exposes private change-buffer relation names or internal lease keys.
 
 `health_check()` should warn about an invalid generation, an unexpectedly old prepared generation, missing or inconsistent leases, output history approaching a hard retention bound, source-buffer or WAL growth beyond advisory thresholds, a missing owner role, degraded future continuity, or a graph whose members no longer form a valid external closure. Alerts do not change state.
 
@@ -863,7 +880,7 @@ The initial capability should publish admission maxima for graph members, roots,
 
 ## 31. Upgrade and compatibility policy
 
-The proposal is additive. Existing databases have no prepared generations, and existing V1 APIs continue unchanged. The new capability is available only after the required catalogs, lease guards, storage-generation markers, recovery checks, and SQL functions have been installed and validated.
+The proposal is additive. Existing databases have no prepared generations, and existing V1 APIs continue unchanged. Each new capability is available only after its required catalogs, lease guards, content epochs, recovery checks, and SQL functions have been installed and validated.
 
 A compatible extension upgrade preserves active generation identifiers, digests, member manifests, leases, output bindings, and states. It may change physical indexes or internal query plans while preserving capability major 1. An upgrade that changes generation digest encoding, state transitions, prepared-read locking, member immutability, output-range semantics, or promotion behavior requires a new capability major.
 
@@ -894,7 +911,6 @@ FROM pgtrickle.prepare_graph(
     roots                       => :roots,
     expected_graph_digest       => :graph_digest,
     output_consumers            => :consumer_ids,
-    require_complete_boundaries => true,
     full_policy                 => 'ALLOW'
 );
 
@@ -919,7 +935,7 @@ SELECT pgtrickle.open_prepared_graph(
 );
 
 -- Claim and process one coordinator-owned deterministic work range.
--- Read prepared stream tables or prepared output-delta rows.
+-- Read prepared stream tables and, when bound, prepared output-delta rows.
 -- Store an idempotent checkpoint in coordinator-owned tables.
 
 COMMIT;
@@ -988,23 +1004,23 @@ No output cursor advances. A later run sees the complete cumulative delta sequen
 
 ## 33. Delivery plan
 
-The capability should be delivered in four dependency-ordered phases. The feature remains disabled in capability discovery until each normative path is wired through the common mutation guards and the complete recovery matrix passes.
+The capabilities should be delivered in four dependency-ordered phases in a future post-1.0 release. The roadmap must assign a release before implementation begins; this proposal does not invent that commitment. It does not reopen the v0.94 feature freeze or the v0.95 stabilization boundary. Each capability remains disabled in discovery until its normative paths are wired through the common mutation guards and its recovery matrix passes.
 
 ### Phase 1: generation contract and durable leases
 
-Add the capability row in disabled form, generation and member catalogs, canonical generation digest, storage-generation markers, request idempotency, active lease storage, centralized mutation guards, lifecycle blocking, and basic status. This phase proves that a committed lease survives restart and prevents every supported member mutation, but it does not yet permit prepared output consumers or promotion.
+Add the core capability row in disabled form, generation and member catalogs, canonical request and generation digests, content epochs, active lease storage, centralized mutation guards, lifecycle blocking, and basic status. This phase proves that a committed lease survives restart and prevents every supported member mutation, but it does not yet permit graph preparation.
 
 ### Phase 2: preparation and prepared reads
 
-Implement `prepare_graph()` over the V1 strict refresh engine, atomic generation-and-lease finalization, `open_prepared_graph()`, shared versus exclusive transition locking, member inspection, source-write continuation, and basic abandonment. At the end of this phase a test extension can freeze a graph and read identical contents over several transactions, but it must still establish its own full baseline and cannot yet atomically consume V1 output cursors.
+Implement `prepare_graph()` over the Graph V1 strict refresh engine, atomic generation-and-lease finalization, `open_prepared_graph()`, shared versus exclusive transition locking, member inspection, source-write continuation, promotion without consumer bindings, and abandonment. At the end of this phase a test extension can freeze a graph, read identical contents over several transactions, and atomically publish and promote through complete terminal scans. This completes the correctness dependency for `pg_mdm` V2.
 
-### Phase 3: prepared consumer ranges and promotion
+### Phase 3: prepared delta binding
 
-Bind V1 output-delta consumers to generations, pin exact or resynchronization ranges, block direct acknowledgement and consumer lifecycle conflicts, implement typed promotion acknowledgements, atomically transition to `PROMOTED`, and prove rollback behavior with coordinator-owned publication tables. This phase completes the functional `pg_mdm` V2 dependency.
+Add the second capability row in disabled form. Bind Delta V1 consumers to generations, classify `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED`, pin required proof, block direct acknowledgement and consumer lifecycle conflicts, implement typed promotion acknowledgements and prepared resnapshot completion, and prove rollback behavior with coordinator-owned publication tables. This phase adds incremental processing without changing the core capability's acceptance gate.
 
 ### Phase 4: recovery, upgrade, and operational hardening
 
-Add fast and deep verification, startup recovery, invalid-state handling, future-continuity reporting, backup and restore tests, physical failover tests, upgrade gates, clone-lineage behavior, capacity forecasting, health checks, metrics, administrator abandonment, and a full conformance test extension. Only after this phase should the capability advertise `enabled = true` for production use.
+Add fast and deep verification, startup recovery, invalid-state handling, future-continuity reporting, backup and restore tests, physical failover tests, upgrade gates, clone-isolation behavior, capacity forecasting, health checks, metrics, administrator abandonment, and a full conformance test extension. `prepared_graph_generation` may advertise `enabled = true` after the core matrix passes. `prepared_output_delta_binding` remains disabled until the additional Delta V1 matrix passes.
 
 ---
 
@@ -1012,11 +1028,11 @@ Add fast and deep verification, startup recovery, invalid-state handling, future
 
 ### 34.1 Unit and property tests
 
-Pure tests should cover canonical generation encoding, digest golden vectors, state-transition legality, request idempotency, member and consumer ordering, required acknowledgement computation, exact versus resynchronization classification, lock-key derivation, and future-validity classification. Property tests should generate valid and invalid state sequences and prove that no path reaches `PROMOTED` without complete matching acknowledgements or releases a member lease while the generation remains prepared.
+Pure core tests should cover canonical request and generation encoding, digest golden vectors, state-transition legality, request idempotency, member ordering, lock-key derivation, and future-validity classification. Property tests must prove that no path releases a member lease while the generation remains prepared. Prepared delta-binding tests additionally cover consumer ordering, required acknowledgement computation, and `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED` classification, and prove that no bound path reaches `PROMOTED` without complete matching dispositions.
 
 ### 34.2 PostgreSQL integration tests
 
-Integration tests should prepare one-node and multi-node external graphs, verify identical member contents across several transactions, allow source writes while prepared, prove that later source changes remain pending, and demonstrate that a later preparation catches up after promotion or abandonment. Tests must cover exact output ranges, ranges containing full invalidation, initial resynchronization, several bound consumers, and a generation without output consumers.
+Core integration tests should prepare one-node and multi-node external graphs without output consumers, verify identical member contents across several transactions, allow source writes while prepared, prove that later source changes remain pending, and demonstrate that a later preparation catches up after promotion or abandonment. Admission tests must accept graphs with no managed downstream dependent and reject a `MANAGED` stream table outside the prepared closure that reads a prepared member. Prepared delta-binding tests add exact ranges, ranges containing `FULL_INVALIDATION`, consumers starting in `RESNAPSHOT_REQUIRED`, and several bound consumers.
 
 Every member mutation path must have a prepared-lease test: manual refresh, scheduler dispatch, V1 strict graph refresh, another preparation, alter query, storage recreation, owner transfer, orchestration-mode change, suspend/resume, repair, restore, rename, and drop. Physical-only operations classified as safe should have positive tests proving that generation digest and contents remain valid.
 
@@ -1030,13 +1046,13 @@ The same test extension should abandon a generation and prove that no cursor adv
 
 ### 34.4 Crash, recovery, and upgrade tests
 
-Tests should restart PostgreSQL after preparation, during an open read, during promotion before commit, and after promotion commit. Physical replica promotion should preserve the lease and state. Backup, PITR, and supported logical dump paths should either restore a valid generation or produce an explicit invalid result; no path may silently free the graph.
+Tests should restart PostgreSQL after preparation, during an open read, during promotion before commit, and after promotion commit. Restart, failover, backup, and PITR preserve an active generation only when they preserve `database_instance_id`. Supported logical dump preflight rejects `PREPARED` generations. Unsupported restore into a new instance must mark imported active generations `INVALID` without releasing their leases.
 
-Upgrade tests should cover no active generation, one valid prepared generation, one invalid generation, terminal audit generations, and a deliberately incompatible future migration. The incompatible path must fail before catalog or storage mutation. Clone-lineage tests must prove that tokens from one writable history cannot be promoted in another without an explicit supported lineage policy.
+Upgrade tests should cover no active generation, one valid prepared generation, one invalid generation, terminal audit generations, and a deliberately incompatible future migration. The incompatible path must fail before catalog or storage mutation. Clone-isolation tests must prove that tokens from one `database_instance_id` cannot be promoted in another.
 
 ### 34.5 Corruption and fail-closed tests
 
-Tests should remove or alter a lease, member relation, storage-generation marker, output batch, payload relation, consumer contract, source-boundary record, and row-identity metadata. Fast verification and promotion must detect each case. Pending source-buffer loss after the prepared boundary should produce degraded future continuity without necessarily invalidating intact prepared member evidence, while loss of a bound prepared output range must invalidate promotion.
+Tests should remove or alter a lease, member relation, content epoch, stored contract encoding, output batch, payload relation, consumer contract, source-boundary record, and row-identity metadata. Fast verification and promotion must detect each applicable case. Pending source-buffer loss after the prepared boundary should produce degraded future continuity without invalidating intact prepared member evidence, while loss of proof required by a bound prepared range must invalidate promotion.
 
 ### 34.6 Security tests
 
@@ -1064,11 +1080,11 @@ Two-phase commit would retain a prepared database transaction and its locks rath
 
 ### 35.4 Copy terminal relations into coordinator-owned staging
 
-This can work as an application pattern, but it duplicates large data, requires every extension to invent its own exact copy boundary and schema evolution, and separates the copy from `pg_trickle`'s output-delta and storage-generation proofs. The proposed lease reuses the authoritative private graph in place.
+This can work as an application pattern, but it duplicates large data, requires every extension to invent its own exact copy boundary and schema evolution, and separates the copy from `pg_trickle`'s source-boundary, execution-contract, content-epoch, and optional output-delta proofs. The proposed lease reuses the authoritative private graph in place.
 
 ### 35.5 Clone every graph generation
 
-Multiple physical copies would permit continued graph refresh and simultaneous preparations. They require a new storage-generation manager, generation-specific relation routing, delta fan-out, source-buffer retention across several frontiers, query and index lifecycle, garbage collection, and much larger storage. Capability major 1 intentionally avoids that scope.
+Multiple physical copies would permit continued graph refresh and simultaneous preparations. They require generation-specific content epochs and relation routing, delta fan-out, source-buffer retention across several frontiers, query and index lifecycle, garbage collection, and much larger storage. Capability major 1 intentionally avoids that scope.
 
 ### 35.6 Trust `EXTERNAL` mode without a lease
 
@@ -1094,23 +1110,22 @@ Age is an operational signal, not proof of acceptance. Automatic promotion is un
 
 ## 36. Risks and open implementation choices
 
-The largest correctness risk is an incomplete mutation guard. One forgotten refresh, repair, restore, or DDL path could change prepared evidence. The mitigation is a centralized guard called after canonical member locking, generated tests that enumerate all SQL mutation entry points, and a storage-generation marker checked by every open and promotion.
+The largest correctness risk is an incomplete mutation guard. One forgotten refresh, repair, restore, or DDL path could change prepared evidence. The mitigation is a centralized guard called after canonical member locking, generated tests that enumerate all SQL mutation entry points, and the mandatory content epoch checked by every open and promotion.
 
 The largest operational risk is retention growth while a graph is prepared. The mitigation is the single-generation freeze model, admission forecasts, exact lag metrics, advisory age policies, and explicit abandonment. Correctness still takes priority over automatic cleanup, so deployments must size the prepared horizon conservatively.
 
 The largest transactional risk is releasing leases while a processing transaction is still reading. The mitigation is the explicit shared `open_prepared_graph()` lock and exclusive transition lock. Documentation and the conformance test must treat opening as mandatory, not an optional status call.
 
-The largest semantic risk is confusing private graph advancement with higher-level acceptance. The mitigation is the immutable prepared consumer range. Only promotion advances the external cursor; abandonment never does. The coordinating extension's own publication remains outside `pg_trickle` and must share the promotion transaction.
+The largest semantic risk is confusing private graph advancement with higher-level acceptance. The generation's `PREPARED` state prevents that confusion in the core capability. When delta binding applies, the immutable consumer binding additionally ensures that only promotion advances the external cursor; abandonment never does. The coordinating extension's own publication remains outside `pg_trickle` and must share the promotion transaction.
 
 The proposal leaves several implementation choices for review:
 
 1. Whether acknowledgement parameters use a typed composite array or a compact JSONB document. The validation and all-or-nothing behavior are unchanged.
 2. Whether generation identifiers use PostgreSQL UUIDv7 support, ordinary UUID generation, or another opaque UUID. Ordering is not semantic.
 3. Whether transaction transition locks use catalog row locks, advisory transaction locks, or both. Durable leases remain authoritative.
-4. Whether `storage_generation` is a new catalog field or an existing complete mutation epoch can satisfy the same invariant.
-5. Which physical maintenance operations are safe during preparation. Capability major 1 may conservatively block uncertain operations.
-6. Whether fast verification marks `INVALID` directly or reports a finding that a startup or administrator transaction then persists. Promotion must fail either way.
-7. How long terminal audit rows remain after promotion or abandonment. Retention may be configurable, but active generation proof is never pruned.
+4. Which physical maintenance operations are safe during preparation. Capability major 1 may conservatively block uncertain operations.
+5. Whether fast verification marks `INVALID` directly or reports a finding that a startup or administrator transaction then persists. Promotion must fail either way.
+6. How long terminal audit rows remain after promotion or abandonment. Retention may be configurable, but active generation proof is never pruned.
 
 None of these choices justify multiple active generations, automatic expiry, private-catalog coupling, or weaker promotion atomicity in capability major 1.
 
@@ -1118,31 +1133,49 @@ None of these choices justify multiple active generations, automatic expiry, pri
 
 ## 37. Acceptance criteria
 
-The prepared-generation capability is ready when an independently developed test extension can:
+### 37.1 Core prepared graph generation
 
-- discover and pin `prepared_graph_generation` major 1 and all prerequisite V1 capability majors;
-- prepare a multi-node `EXTERNAL` graph under one complete source boundary and receive a durable UUID and generation digest;
-- lose the preparation response, rediscover the committed generation by request identifier, and avoid creating a second generation;
-- read exactly the same member contents and prepared output range over several later transactions by calling `open_prepared_graph()`;
+`prepared_graph_generation` major 1 is ready when an independently developed test extension can:
+
+- discover and pin `prepared_graph_generation` major 1 and `external_graph_refresh` major 1 without requiring Delta V1;
+- prepare a multi-node `EXTERNAL` graph with no output consumers under one complete source boundary and receive a durable UUID, request digest, and generation digest;
+- lose the preparation response, rediscover the committed generation by request identifier and matching request digest, and avoid creating a second generation;
+- read exactly the same member contents over several later transactions by calling `open_prepared_graph()`;
 - continue writing to source tables while the graph remains frozen and later prove that those changes were not included in the prepared boundary;
-- observe hard errors for every refresh, DDL, repair, ownership, orchestration, consumer, and storage operation that would invalidate a prepared member;
+- observe hard errors for every refresh, DDL, repair, ownership, orchestration, and storage operation that would invalidate a prepared member;
 - observe a hard overlap conflict when another preparation includes any leased member;
-- process an exact prepared output range and a prepared full-resynchronization range without reading private `pg_trickle` objects;
-- publish coordinator-owned state and promote in one transaction, then force rollback and prove that generation state, leases, and output cursors all remain unchanged;
+- publish coordinator-owned state and promote in one transaction, then force rollback and prove that generation state, leases, and publication all remain unchanged;
 - retry and commit promotion, then refresh the released graph through later pending source changes;
-- abandon without acknowledgement and later consume the complete cumulative range from the last accepted cursor;
-- survive backend disconnect, PostgreSQL restart, physical failover, backup and restore, and a supported extension upgrade with state and leases intact;
-- detect missing member storage, changed contracts, lost output history, lineage mismatch, and other invalid conditions without silently re-preparing;
-- distinguish an invalid prepared generation from degraded future refresh continuity;
-- expose clear ownership checks, stable errors, prepared age, active readers, retained bytes, pending source growth, and next actions.
+- abandon without claiming acceptance and prepare again from the graph's current state;
+- preserve valid state across backend disconnect, same-instance restart, physical failover, backup, PITR, and a supported extension upgrade;
+- reject logical dump with an active prepared generation and invalidate imported active generations when `database_instance_id` changes without releasing their leases;
+- detect missing member storage, changed content epochs, corrupt stored contracts, database-instance mismatch, and other invalid conditions without silently re-preparing;
+- distinguish invalid prepared evidence from degraded future refresh continuity;
+- expose clear ownership checks, stable errors, prepared age, active readers, pending source growth, and next actions.
 
-The feature is not ready merely because `prepare_graph()` returns a row. Every supported mutation path, rollback boundary, consumer transition, restart path, and upgrade path must preserve the invariants above. `pg_mdm` V2 should not claim resumable publication until this complete conformance matrix passes against packaged `pg_trickle` builds.
+The core capability is not ready merely because `prepare_graph()` returns a row. Every supported member mutation path, rollback boundary, restart path, restore policy, and upgrade path must preserve these invariants. `pg_mdm` V2 may claim correct resumable publication after this core matrix passes against packaged `pg_trickle` builds.
+
+### 37.2 Prepared output-delta binding
+
+`prepared_output_delta_binding` major 1 is ready only after the core gate passes and an independent test extension can:
+
+- discover and pin compatible majors of `prepared_graph_generation` and `output_delta_consumer`;
+- bind consumers in `ACTIVE` and `RESNAPSHOT_REQUIRED`, while rejecting `PAUSED`, `INVALIDATED`, and `DROPPED`;
+- process `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED` bindings without reading private `pg_trickle` objects;
+- prevent direct acknowledgement, reset, pause, drop, rebind, history discard, and ordinary resnapshot while a binding is active;
+- publish coordinator-owned state and promote with exactly matching dispositions in one transaction;
+- force rollback after promotion and prove that generation state, leases, publication, and consumer cursors all remain unchanged;
+- abandon without acknowledgement and later consume the complete cumulative range or perform an explicit resnapshot from the last accepted cursor;
+- retain every required batch, payload, terminal token, and relation proof while prepared and fail closed when required proof is lost;
+- move a prepared `RESNAPSHOT_REQUIRED` consumer to `ACTIVE` only through a committed `RESYNCHRONIZED` promotion.
+
+Failure to stabilize this second matrix must not delay or weaken the core prepared-generation capability. A coordinator may claim delta-efficient resumable publication only after the prepared delta-binding gate also passes.
 
 ---
 
 ## 38. Recommended disposition
 
-Accept the prepared-generation capability as a separate V2 proposal after the V1 composition contract is stable. Implement the first version as a single durable freeze over current external graph storage, one active generation per member, explicit prepared reads, bound output-delta ranges, transactional promotion, and explicit abandonment. Do not expand the first release into multi-generation storage, asynchronous graph construction, or coordinator worker management.
+Accept the two prepared-generation capabilities as a separate post-1.0 V2 proposal after Graph V1 is stable. Implement `prepared_graph_generation` first as a single durable freeze over current external graph storage, one active generation per member, explicit prepared reads, transactional promotion, and explicit abandonment. Layer `prepared_output_delta_binding` over that core only after Delta V1 is stable. Do not expand either first major into multi-generation storage, asynchronous graph construction, or coordinator worker management.
 
 This boundary preserves the responsibilities of both projects:
 

--- a/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
+++ b/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
@@ -1,0 +1,1163 @@
+# Proposal: V2 Prepared Graph Generations for `pg_trickle`
+
+## Immutable cross-transaction graph state and atomic acceptance for coordinating PostgreSQL extensions
+
+**Status:** Proposed  
+**Scope:** V2-only integration capability. This proposal does not alter or enlarge the V1 acceptance boundary.  
+**Target:** Additive capability after the V1 composable refresh and durable delta contract  
+**Decision:** Add a versioned prepared-generation lifecycle that lets an authorized extension refresh an externally orchestrated stream-table graph, commit and freeze that exact result, process it across several later transactions, and finally promote or abandon it without losing source or output-delta continuity  
+**Compatibility:** Existing stream tables and the V1 integration APIs retain their behavior. Prepared generations are opt-in and apply only to eligible `EXTERNAL` graphs.  
+**Motivating consumer:** `pg_mdm` V2, particularly large entity-resolution runs that cannot safely or economically remain inside one PostgreSQL transaction  
+**Prerequisite:** [V1 Composable Refresh and Durable Delta Contracts](PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)  
+**Baseline reviewed:** `pg_trickle` 0.90.0 at commit [`a6a53e0`](https://github.com/trickle-labs/pg-trickle/commit/a6a53e0f6697eed4407a664b1af5172ca137fd9c)  
+**Last updated:** 2026-09-01
+
+---
+
+> **Terminology note:** “V2” in this document means the second-stage integration needed by `pg_mdm` V2. It does not mean `pg_trickle` 2.0, PostgreSQL row-identity V2, or a replacement for the V1 composition contract.
+
+## Contents
+
+1. [Executive decision](#1-executive-decision)
+2. [V2 release boundary](#2-v2-release-boundary)
+3. [Relationship to the V1 contract](#3-relationship-to-the-v1-contract)
+4. [Motivation](#4-motivation)
+5. [Goals and non-goals](#5-goals-and-non-goals)
+6. [Relationship to `pg_mdm` V2](#6-relationship-to-pg_mdm-v2)
+7. [Existing foundations](#7-existing-foundations)
+8. [Terminology](#8-terminology)
+9. [Required invariants](#9-required-invariants)
+10. [Proposed V2 surface](#10-proposed-v2-surface)
+11. [Capability discovery and versioning](#11-capability-discovery-and-versioning)
+12. [Prepared-generation identity](#12-prepared-generation-identity)
+13. [`prepare_graph()`](#13-prepare_graph)
+14. [Prepared-generation state machine](#14-prepared-generation-state-machine)
+15. [Durable member leases and graph isolation](#15-durable-member-leases-and-graph-isolation)
+16. [Cross-transaction read protocol](#16-cross-transaction-read-protocol)
+17. [Prepared output-delta ranges](#17-prepared-output-delta-ranges)
+18. [`promote_prepared_graph()`](#18-promote_prepared_graph)
+19. [`abandon_prepared_graph()`](#19-abandon_prepared_graph)
+20. [Source changes while a generation is prepared](#20-source-changes-while-a-generation-is-prepared)
+21. [Validation, invalidation, and repair](#21-validation-invalidation-and-repair)
+22. [Concurrency and lock ordering](#22-concurrency-and-lock-ordering)
+23. [Security and authorization](#23-security-and-authorization)
+24. [Failure, crash, and recovery behavior](#24-failure-crash-and-recovery-behavior)
+25. [Stable errors](#25-stable-errors)
+26. [Suggested catalog and storage changes](#26-suggested-catalog-and-storage-changes)
+27. [Integration with the refresh engine](#27-integration-with-the-refresh-engine)
+28. [Lifecycle interactions](#28-lifecycle-interactions)
+29. [Observability and administration](#29-observability-and-administration)
+30. [Performance and resource behavior](#30-performance-and-resource-behavior)
+31. [Upgrade and compatibility policy](#31-upgrade-and-compatibility-policy)
+32. [End-to-end protocols](#32-end-to-end-protocols)
+33. [Delivery plan](#33-delivery-plan)
+34. [Test plan](#34-test-plan)
+35. [Alternatives considered](#35-alternatives-considered)
+36. [Risks and open implementation choices](#36-risks-and-open-implementation-choices)
+37. [Acceptance criteria](#37-acceptance-criteria)
+38. [Recommended disposition](#38-recommended-disposition)
+39. [Appendix A: possible later generations](#appendix-a-possible-later-generations)
+
+---
+
+## 1. Executive decision
+
+`pg_trickle` should add one separately versioned integration capability called **prepared graph generations**. The capability is for trusted PostgreSQL extensions that already use the V1 composition contract but need to perform expensive domain work after relational evidence has been refreshed. Instead of keeping one PostgreSQL transaction open while that work runs, the caller can ask `pg_trickle` to refresh an eligible private graph to one complete source boundary, commit the resulting stream-table state, and seal it as an immutable prepared generation. The caller may then inspect that exact generation and maintain its own checkpoints over several later transactions. When its complete domain result is ready, it promotes the prepared generation and acknowledges the bound output deltas inside the same short transaction that publishes its own result.
+
+The first implementation should deliberately use a simple physical model. Preparing a graph freezes the graph's existing stream-table storage in place. It does not clone a second writable copy, and it does not permit another refresh over any overlapping member while the generation remains prepared. Source tables may continue to accept writes, and `pg_trickle` continues to capture those later changes in its ordinary CDC state. The next graph refresh processes them only after the prepared generation has been promoted or abandoned. This model supports one active prepared generation per stream-table member, avoids creating a second data-storage architecture, and is sufficient for private graphs whose higher-level resolver needs time rather than simultaneous graph versions.
+
+The capability does not make `pg_trickle` responsible for another extension's business computation. `pg_trickle` owns the immutable evidence generation, its source boundary, member contracts, output-delta positions, and lifecycle lease. The coordinating extension owns its checkpoint format, worker allocation, domain validation, compare-and-swap conditions, public tables, and final business publication. Promotion is intentionally called by the coordinating extension rather than triggered through a callback. PostgreSQL remains the mechanism that commits the final domain publication, delta acknowledgement, and prepared-generation transition together.
+
+---
+
+## 2. V2 release boundary
+
+This proposal is only for the cross-transaction lifecycle that begins after the V1 composition contract exists. It assumes that `pg_trickle` can already discover integration capabilities, compute canonical stream-table and graph contracts, keep a graph in durable `EXTERNAL` orchestration mode, refresh a complete graph strictly inside the caller's transaction, return one coherent source-boundary manifest, expose durable typed output deltas, and acknowledge those deltas transactionally. Those capabilities remain governed by their V1 contract and are not redefined here.
+
+The V2 capability adds the following behavior:
+
+| V2 capability | Purpose |
+|---|---|
+| Prepare an eligible graph | Refresh the graph once and commit a named immutable result |
+| Durable generation identity | Let later transactions prove that they are reading the same evidence |
+| Durable member leases | Prevent refresh or semantic mutation of every prepared member |
+| Transaction-scoped read opening | Prevent promotion or abandonment while one processing transaction is reading |
+| Prepared consumer ranges | Pin the exact output-delta interval or resnapshot requirement associated with the generation |
+| Atomic promotion | Acknowledge prepared deltas and release the graph in the caller's final publication transaction |
+| Explicit abandonment | Release a generation without claiming that its evidence was accepted |
+| Recovery and verification | Preserve or fail closed across restart, failover, restore, upgrade, or detected corruption |
+
+This proposal does not implement several broader `pg_mdm` V2 ideas. It does not add valid-time source processing, custom MDM functions, entity-level stewardship, semantic business events, MDM worker coordination, or domain checkpoint tables to `pg_trickle`. It also does not make the graph refresh itself resumable across committed transactions. `prepare_graph()` still performs one ordinary strict graph refresh in one PostgreSQL transaction; the cross-transaction benefit begins after that refresh has committed. A graph whose relational refresh cannot fit within the existing transaction and resource envelope needs a later, separate design.
+
+---
+
+## 3. Relationship to the V1 contract
+
+The V1 composition protocol is intentionally the default. A coordinating extension begins a transaction, calls strict graph refresh, consumes exact output deltas or performs a full resynchronization, updates its own durable state, acknowledges the deltas, and commits. That is the simplest and strongest execution model because every layer shares one snapshot and one transaction from beginning to end.
+
+Prepared generations are an optional escape hatch for workloads that exceed the practical duration of that transaction. They are not a replacement for V1, and implementing them must not change V1 semantics. An ordinary strict graph refresh still rolls back completely when the caller's domain publication fails. An output-delta consumer still advances only through explicit acknowledgement. A graph in `MANAGED` mode still belongs to the normal scheduler. A graph in `EXTERNAL` mode remains refreshable through the V1 strict API whenever no prepared lease is active.
+
+The V2 capability depends on exact V1 capability majors rather than only on the package version. Capability discovery should report `prepared_graph_generation` as disabled unless all prerequisite contracts are available and compatible. At minimum, capability major 1 depends on compatible majors of `graph_contract`, `external_orchestration`, `transactional_graph_refresh`, `source_boundary_manifest`, and `output_delta_consumer`.
+
+A coordinating extension may support both paths for the same logical product. Small entities can continue through V1's one-transaction path. Large entities can opt into the prepared path after admission checks show that source-buffer retention, output-delta retention, and graph-freeze duration are acceptable. Both paths must produce the same higher-level result when given the same graph contract, source boundary, domain inputs, and policy versions.
+
+---
+
+## 4. Motivation
+
+A higher-level resolver can require much more time than the relational refresh that creates its input. In `pg_mdm`, for example, `pg_trickle` may incrementally maintain normalized source values, bounded candidate pairs, pair evidence, authoritative conflicts, and golden-value candidates. Once that evidence is ready, `pg_mdm` may still need to discover a large affected closure, recompute conservative components, reconcile stable identifiers across merges and splits, validate manual constraints, calculate golden records, create review items, and compare the result with the prior publication. On a large graph, that work may need to be partitioned, checkpointed, retried, or reviewed over many transactions.
+
+Keeping one transaction open for the whole operation retains an old snapshot, holds graph and catalog locks longer than necessary, delays vacuum cleanup, increases the impact of process failure, and makes operational progress difficult to expose. Committing the graph refresh and then simply trusting that the private stream tables will not change is not safe. The scheduler, a manual refresh, a definition alteration, a repair operation, or another coordinator could advance or recreate the graph before the higher-level result is published. A source-boundary digest alone cannot protect the data if the physical stream-table contents are mutable.
+
+Exporting the terminal rows into coordinator-owned staging tables is possible, but it duplicates potentially large evidence relations and transfers responsibility for row identity, output-delta continuity, schema changes, cleanup, and source-boundary proof to every integrating extension. It also weakens the clean boundary established by the V1 proposal. `pg_trickle` already owns the stream-table contents and the metadata that proves how they were produced. The missing primitive is a durable lease that turns one completed graph refresh into a stable, named generation until the coordinator explicitly accepts or rejects it.
+
+---
+
+## 5. Goals and non-goals
+
+### 5.1 Goals
+
+The prepared-generation capability has ten goals. It must let an authorized coordinator prepare a complete `EXTERNAL` graph under the same source-boundary and strict-refresh rules as V1; assign an immutable generation identity and digest; preserve the prepared state across backend disconnect, restart, physical failover, backup, and supported upgrades; block every graph mutation that could change the evidence; permit short read transactions to reopen and verify the same generation; pin the relevant output-delta intervals; allow source writes after the prepared boundary to remain pending; atomically promote the generation with the coordinator's publication and delta acknowledgements; explicitly abandon without acknowledgement; and fail closed whenever the generation can no longer be proved.
+
+The design should remain useful beyond MDM. Any PostgreSQL extension that compiles a domain model into a private `pg_trickle` graph and then performs expensive deterministic work can use the same lifecycle. The API therefore speaks about graphs, generations, contracts, source boundaries, output consumers, leases, and transitions. It does not mention entities, matches, goldens, features, policies, or any other consuming domain.
+
+### 5.2 Non-goals
+
+Capability major 1 does not clone several physical generations, permit simultaneous preparations over overlapping graph members, refresh a leased graph in the background, or let source changes be incorporated into the prepared state after preparation. It does not checkpoint or resume `pg_trickle`'s own graph refresh. It does not create a worker protocol for the coordinating extension, store the coordinator's partial business results, or decide whether a changed domain definition or stewardship decision supersedes a run.
+
+The proposal does not use PostgreSQL prepared transactions or two-phase commit to keep the original graph-refresh transaction open. It does not export a PostgreSQL snapshot for later sessions, and it does not rely on session-level advisory locks as durable ownership. It does not add arbitrary callbacks from the `pg_trickle` finalizer into another extension. It does not provide cross-database or cross-cluster generations, and it does not promise that an indefinitely prepared graph can retain unlimited CDC or output-delta history without operational consequences.
+
+The first capability also does not hide prepared stream-table contents from roles that already have ordinary `SELECT` privileges. The motivating design uses private schemas and restricted grants, but `pg_trickle` remains a PostgreSQL extension rather than a separate confidentiality boundary. It guarantees immutability and authorized lifecycle transitions, not invisibility from database owners or superusers.
+
+---
+
+## 6. Relationship to `pg_mdm` V2
+
+The motivating `pg_mdm` V2 flow separates evidence preparation from identity publication. `pg_trickle` refreshes the private evidence graph and seals one prepared generation. `pg_mdm` stores the generation identifier and digest in its own run manifest, processes deterministic component ranges in logged checkpoint tables, and may use several workers or several transactions to finish the domain result. Every processing transaction opens the same prepared generation before reading its terminal relations. The number of workers, checkpoint boundaries, and retry order remain `pg_mdm` concerns and are not semantic inputs to `pg_trickle`.
+
+When `pg_mdm` is ready to publish, it begins a short transaction and verifies its own compare-and-swap conditions, such as the expected active MDM publication revision, desired definition version, and stewardship decision epoch. It writes the new memberships, golden rows, reviews, provenance, identity history, and semantic events, then calls `promote_prepared_graph()` with the exact output-delta acknowledgements recorded by the generation. If any MDM validation or DML fails, PostgreSQL rolls back the promotion and the generation remains prepared. If a newer MDM definition or decision makes the run obsolete before publication, `pg_mdm` calls `abandon_prepared_graph()` and does not acknowledge the evidence.
+
+The critical responsibility boundary is therefore:
+
+> **`pg_trickle` proves and freezes relational evidence. `pg_mdm` decides whether that evidence may become an identity publication.**
+
+`pg_trickle` does not inspect the MDM decision epoch, stable-ID ledger, checkpoint tables, or public MDM outputs. `pg_mdm` does not inspect private `pg_trickle` leases, change buffers, frontier encodings, or storage-generation catalogs. The generation identifier, generation digest, supported status APIs, and final promotion call are the complete supported bridge.
+
+---
+
+## 7. Existing foundations
+
+The proposal is intentionally built on existing `pg_trickle` architecture and the companion V1 integration proposal. `pg_trickle` already maintains stream tables through full and differential refresh paths, tracks per-source frontiers, captures local changes through trigger or WAL mechanisms, maintains stream-table-to-stream-table deltas, serializes refreshes, records durable refresh history, uses exact versioned row identity, and performs owner-equivalent execution. The V1 proposal adds the graph-wide contract, strict synchronous refresh, external orchestration, source-boundary manifest, and durable output-delta cursor required before a prepared lifecycle can be safe.
+
+The most important implementation discipline is reuse. `prepare_graph()` must not become a fourth independent refresh engine beside manual, scheduled, and V1 strict graph refresh. It should invoke the same graph resolver, contract validator, source-boundary planner, member executor, output-delta finalizer, and transaction semantics as `refresh_graph_strict()`. Its additional work is performed after the graph result has been successfully finalized but before the transaction commits: construct the generation manifest, bind terminal consumer ranges, insert durable member leases, and return the prepared identity.
+
+The initial freeze-in-place design also relies on existing stream-table write protection. Every supported mutation of a stream-table storage relation must flow through `pg_trickle` and advance a durable storage-generation marker. Superuser tampering remains outside the ordinary trust model, but supported lifecycle paths, repair paths, DDL hooks, and refresh paths must all participate in generation validation. A prepared generation cannot be considered immutable if one supported code path can recreate or rewrite a member without checking its lease.
+
+---
+
+## 8. Terminology
+
+A **prepared graph generation** is one completed graph refresh whose stream-table contents, graph contract, member contracts, source-boundary manifest, storage-generation markers, and bound output-delta positions have been sealed against further graph mutation. The generation is durable and identified by a UUID and an immutable digest.
+
+A **generation member** is a stream table in the canonical dependency closure of the prepared roots. Capability major 1 requires every member to use durable `EXTERNAL` orchestration and permits at most one active prepared lease for a member.
+
+A **member lease** is a logged catalog record that prohibits refresh, defining-query change, ownership transfer, orchestration-mode change, storage recreation, drop, and other result-affecting lifecycle operations while a generation is `PREPARED`. The lease is durable state rather than a session lock. Ordinary transaction locks are still used to serialize acquisition, reading, promotion, and abandonment.
+
+A **prepared read** is a transaction that calls `open_prepared_graph()` and then reads one or more generation members or bound output-delta relations. Opening validates the generation and holds a transaction-scoped shared transition lock so that promotion or abandonment cannot release the member leases until the reader's transaction ends.
+
+A **prepared consumer range** is the interval from one output-delta consumer's acknowledged batch token, exclusive, through the terminal token produced or observed by the prepared graph, inclusive. The range records whether exact rows are continuously available or whether the coordinator must resynchronize from the complete prepared terminal relation.
+
+**Promotion** is the transactionally atomic acceptance transition from `PREPARED` to `PROMOTED`. It validates the immutable generation, applies every required output-delta acknowledgement, records completion, and releases member leases in the caller's transaction. Capability major 1 does not perform a physical table swap because the prepared result already occupies the private graph storage.
+
+**Abandonment** is the explicit rejection transition from `PREPARED` or `INVALID` to `ABANDONED`. It releases member leases without acknowledging any prepared consumer range and without attempting to reverse the graph refresh.
+
+**Future continuity** describes whether `pg_trickle` can safely refresh the graph after its lease is released. Capability major 1 reports `CONTINUOUS`, `REINITIALIZE_REQUIRED`, or `UNKNOWN`. A prepared generation may remain valid evidence even if later source CDC state becomes damaged; in that case promotion can still be valid while the graph's next refresh requires a complete reinitialization. Prepared validity and future continuity are therefore reported separately.
+
+---
+
+## 9. Required invariants
+
+The capability is governed by the following invariants. They define the contract more strongly than any proposed catalog layout.
+
+1. **One immutable generation.** Every successful `prepare_graph()` identifies exactly one graph contract, member set, source-boundary manifest, member content generation, and prepared consumer range. Those inputs cannot change while the generation remains prepared.
+
+2. **No invisible graph mutation.** A refresh, query alteration, storage recreation, ownership transfer, orchestration change, drop, restore, or repair that could alter a prepared member is rejected before mutation.
+
+3. **One active lease per member.** Two active prepared generations cannot overlap on any stream-table member in capability major 1.
+
+4. **Source writes remain independent.** Committed source changes after the prepared boundary may accumulate for a later graph refresh, but they do not modify or invalidate the prepared member contents merely because they exist.
+
+5. **Prepared reads are repeatable by contract.** Every transaction that successfully opens a prepared generation reads the same member contents and bound output ranges as every other successful prepared read of that generation.
+
+6. **Promotion shares the caller's commit.** Generation promotion, bound output acknowledgements, and the coordinating extension's publication commit or roll back together.
+
+7. **Abandonment is not acceptance.** Abandoning a generation never advances an output consumer cursor and never claims that a higher-level publication consumed its evidence.
+
+8. **No rollback reconstruction.** Abandonment does not reverse the private stream tables. The durable consumer cursor and later cumulative delta sequence record what the coordinator has or has not accepted.
+
+9. **Exact history or explicit resynchronization.** A prepared consumer range is either a continuous exact sequence or an explicit requirement to read the complete prepared terminal relation. Missing history is never represented as an empty exact range.
+
+10. **Transition serialization.** A prepared read blocks promotion or abandonment for the duration of its transaction, and promotion or abandonment blocks new prepared reads while the transition is validated and committed.
+
+11. **Owner-equivalent authority.** Preparation, opening, promotion, abandonment, and inspection grant no authority beyond the permissions explicitly checked for every member and output consumer.
+
+12. **Durable recovery.** Restart, failover, backup, restore, and supported extension upgrade preserve prepared state and leases or report a stable invalid condition. They never silently release, promote, or acknowledge a generation.
+
+13. **Semantic contract pinning.** A semantic mutation to the graph, a member, a result-affecting function, row-identity behavior, collation dependency, or output contract prevents promotion under the old generation digest.
+
+14. **Physical tuning is not semantic.** A supported statistics update, index maintenance operation, worker-count change, or other proven physical-only change does not alter the generation digest or domain meaning.
+
+15. **Future damage is distinguished.** Loss of pending CDC needed only for a later refresh does not rewrite the already prepared evidence. It is reported as degraded future continuity and requires reinitialization after release.
+
+16. **No private dependency.** Coordinating extensions use only documented capability, contract, generation, output-delta, and status APIs. They do not infer private lease tables, relation names, internal tokens, or frontier encodings.
+
+---
+
+## 10. Proposed V2 surface
+
+Capability major 1 adds the following public integration operations. The exact PostgreSQL composite syntax may be refined during implementation, but the behaviors and transaction boundaries are normative.
+
+| Operation | Purpose |
+|---|---|
+| `integration_capabilities()` | Advertise `prepared_graph_generation` and its prerequisite majors |
+| `prepare_graph()` | Strictly refresh an eligible graph and commit it as `PREPARED` |
+| `prepared_graph_status()` | Inspect state, validity, boundaries, retention, and blockers without opening it for data reads |
+| `prepared_graph_members()` | Return the public identities and pinned contracts of generation members |
+| `prepared_graph_consumers()` | Return bound consumer intervals and required acknowledgement dispositions |
+| `open_prepared_graph()` | Validate and transactionally open the immutable generation for reading |
+| `verify_prepared_graph()` | Perform fast or deep integrity verification and report validity separately from future continuity |
+| `promote_prepared_graph()` | Atomically acknowledge bound deltas, record acceptance, and release leases |
+| `abandon_prepared_graph()` | Release leases without acknowledgement |
+
+The primary lifecycle can be summarized as:
+
+```text
+strict graph refresh
+        |
+        v
+PREPARED  ---- promote in caller publication transaction ---->  PROMOTED
+    |
+    +------ abandon without acknowledgement ------------------>  ABANDONED
+    |
+    +------ integrity loss ------------------------------------>  INVALID
+                                                                  |
+                                                                  +--> ABANDONED
+```
+
+A failed preparation transaction creates no durable generation. `PREPARING` may appear in an operation record or future asynchronous implementation, but it is not a committed generation state in capability major 1.
+
+---
+
+## 11. Capability discovery and versioning
+
+The V1 capability-discovery function should add one row when the feature is installed and usable:
+
+```text
+capability                    major  minor  enabled  details
+prepared_graph_generation       1      0      true   {...}
+```
+
+The details object is advisory and may include:
+
+```json
+{
+  "storage_mode": "LEASE_CURRENT",
+  "max_active_generations_per_member": 1,
+  "asynchronous_prepare": false,
+  "multi_generation_storage": false,
+  "prepared_graph_refresh_resumable": false,
+  "required_capabilities": {
+    "graph_contract": 1,
+    "external_orchestration": 1,
+    "transactional_graph_refresh": 1,
+    "source_boundary_manifest": 1,
+    "output_delta_consumer": 1
+  }
+}
+```
+
+A capability major changes when the prepared-generation state model, member immutability rules, read-opening semantics, generation digest, promotion atomicity, abandonment behavior, or prepared consumer-range contract changes incompatibly. A minor version may add optional diagnostics, support more source kinds, permit more physical maintenance operations, or add non-required result fields without weakening the major contract.
+
+The capability is disabled when a prerequisite capability is absent, an upgrade has not completed the durable catalog migration, recovery has not validated the generation registry, or the server configuration cannot preserve the documented semantics. A new package version must not be treated as sufficient evidence that preparation is safe; runtime capability discovery remains authoritative.
+
+---
+
+## 12. Prepared-generation identity
+
+Every generation has both a durable identifier and an immutable digest. The identifier is an opaque UUID suitable for catalog lookup. The digest is computed from a canonical, versioned encoding of the generation's immutable contract and protects callers against stale references, cross-object mistakes, and accidental catalog drift.
+
+The generation digest includes at least:
+
+```text
+generation-contract major and minor
+prepared_generation_id
+preparation request_id
+database lineage identifier
+owner role identity
+canonical roots and member order
+graph contract digest
+source-boundary digest
+for every member:
+  stable stream-table identity
+  stream-table contract digest
+  storage relation identity
+  storage generation
+  producing refresh identifier
+  output schema digest
+  row-identity and probe versions
+for every bound consumer:
+  consumer identity
+  output contract digest
+  row-identity version
+  acknowledged start token
+  prepared terminal token
+  required disposition class
+```
+
+Mutable operational fields such as state, age, warning counters, active readers, retained-byte estimates, and completion timestamps do not affect the digest. The canonical representation must be specified and tested with independent golden vectors. A refactor of JSON rendering, catalog row order, or internal relation naming must not change the digest.
+
+The caller stores both the UUID and digest in its own run manifest. Every later open, promotion, or abandonment supplies the expected digest. An identifier that exists with a different digest is a hard error rather than an invitation to use the current row.
+
+Preparation also accepts a caller-provided `request_id`. The pair `(owner_role, request_id)` is unique. Repeating a request after an uncertain network outcome returns the existing generation only when the roots, graph digest, consumers, and options are identical. Reusing the request identifier with different inputs raises a stable idempotency error. This prevents a lost response after commit from leaving the coordinator unable to rediscover which prepared generation owns the graph.
+
+---
+
+## 13. `prepare_graph()`
+
+### 13.1 Proposed API
+
+An illustrative call is:
+
+```sql
+SELECT *
+FROM pgtrickle.prepare_graph(
+    request_id                   => :mdm_run_id,
+    roots                        => ARRAY[
+        'mdm_internal.customer_pair_evidence_v7'::regclass,
+        'mdm_internal.customer_golden_candidates_v7'::regclass
+    ],
+    expected_graph_digest        => decode(:graph_digest_hex, 'hex'),
+    output_consumers             => ARRAY[
+        :pair_evidence_consumer_id,
+        :golden_candidate_consumer_id
+    ]::uuid[],
+    require_complete_boundaries  => true,
+    full_policy                  => 'ALLOW'
+);
+```
+
+The initial signature may be represented as:
+
+```sql
+pgtrickle.prepare_graph(
+    request_id                   uuid,
+    roots                        regclass[],
+    expected_graph_digest        bytea,
+    output_consumers             uuid[] DEFAULT ARRAY[]::uuid[],
+    require_complete_boundaries  boolean DEFAULT true,
+    full_policy                  text DEFAULT 'ALLOW'
+)
+RETURNS pgtrickle.prepared_graph_result
+```
+
+The result contains at least:
+
+```text
+prepared_generation_id   uuid
+generation_digest        bytea
+graph_refresh_id         bigint
+graph_digest             bytea
+source_boundary          jsonb
+source_boundary_digest   bytea
+node_results             jsonb
+state                    text        -- PREPARED
+prepared_at              timestamptz
+future_continuity         text
+```
+
+Detailed member and consumer rows are returned by separate set-returning status functions so that the primary result does not grow into an unstable nested document.
+
+### 13.2 Admission checks
+
+Before any graph member is mutated, `prepare_graph()` resolves the complete canonical closure and verifies that every member is in `EXTERNAL` orchestration mode, every expected graph contract matches, the graph is acyclic under the supported V1 rules, no member is suspended or already leased, no conflicting refresh or lifecycle operation is active, and every requested output consumer belongs to an eligible terminal or explicitly named member with a compatible output contract.
+
+The initial capability also rejects a graph that has a scheduler-managed downstream stream table outside the prepared closure. Such a dependent could consume and publish the newly prepared private state before the coordinating extension accepts it. Direct SQL readers remain governed by PostgreSQL grants, but automatic downstream propagation must stay within the same externally controlled boundary. A later capability may define explicit multi-coordinator dependencies; capability major 1 fails closed instead.
+
+If complete boundaries are required, every accepted source kind must provide the same proof required by V1 strict graph refresh. A partial remote snapshot, an unverifiable polling source, missing CDC state, or any source-boundary uncertainty aborts preparation. `full_policy` has the same meaning as in the V1 strict API: a caller may allow a correct full refresh or require differential execution, but no policy may publish incomplete relational state.
+
+### 13.3 Execution and commit
+
+After admission, `prepare_graph()` invokes the ordinary strict graph-refresh engine using one immutable boundary context and the standard deterministic lock order. Every member refresh, output-delta batch, frontier update, and refresh-history record is finalized through the normal common path. If any node fails, the entire preparation transaction rolls back and no generation or lease exists.
+
+After the graph result is complete, but before returning, the function captures each member's contract and storage-generation markers, binds the requested output-consumer ranges, constructs the canonical generation digest, inserts the durable generation and member rows, and acquires one persistent lease record per member. The stream-table rows and lease records commit together. There is no interval in which the refreshed contents are committed but the graph is not protected.
+
+The call itself does not commit. The caller controls its transaction as usual. The recommended pattern is a small standalone preparation transaction that stores the returned generation identity in the coordinating extension's run record and commits both records together. If that transaction rolls back, the graph refresh, output batches, generation, leases, and coordinator run record all disappear.
+
+### 13.4 Idempotent recovery after an uncertain result
+
+If the client loses its connection after the server may have committed, it queries by its durable request identifier rather than issuing a different preparation. A helper may be provided:
+
+```sql
+SELECT *
+FROM pgtrickle.prepared_graph_by_request(
+    owner_role => current_user::regrole,
+    request_id => :mdm_run_id
+);
+```
+
+When the request did not commit, no row exists and the caller may retry with the same inputs. When it committed, the existing generation and digest are returned. When the identifier exists for different inputs, the function reports a request conflict. This behavior is important because a committed but undiscovered prepared generation intentionally blocks later graph refreshes.
+
+---
+
+## 14. Prepared-generation state machine
+
+The durable state machine is deliberately small:
+
+```text
+                 +------------+
+                 |  PREPARED  |
+                 +-----+------+
+                       |
+             +---------+----------+
+             |                    |
+             v                    v
+       +-----------+        +-----------+
+       | PROMOTED  |        | ABANDONED |
+       +-----------+        +-----------+
+
+PREPARED may become INVALID when its immutable proof is lost.
+INVALID may only become ABANDONED.
+```
+
+A successful synchronous preparation commits directly to `PREPARED`. A failed call leaves no generation record. `PROMOTED` and `ABANDONED` are terminal audit states. `INVALID` means that `pg_trickle` can no longer prove the generation's immutable evidence, contract, or bound delta range. An invalid generation cannot be repaired in place or promoted; an authorized caller must abandon it, repair or recreate the graph, and prepare a new generation.
+
+There is no automatic expiry transition. A maximum age may be an advisory policy that produces warnings, but time alone does not prove that a generation was accepted or rejected. An operator, scheduler, or recovery worker must never silently convert an old `PREPARED` generation into `ABANDONED` or `PROMOTED`.
+
+Every state change records the actor, transaction identifier where practical, timestamp, reason or external request reference, and prior state. The generation digest remains the digest of the prepared immutable inputs and does not change when the state changes.
+
+---
+
+## 15. Durable member leases and graph isolation
+
+A prepared member lease is a logged catalog fact. It must not be implemented solely with session advisory locks because sessions end, backends crash, and failover starts new processes. The recommended representation is one active lease row keyed by stable stream-table identity and referencing the prepared generation. A uniqueness constraint on the member identity prevents overlapping preparations even when two callers race.
+
+Preparation acquires ordinary transaction locks on every member in canonical order, verifies that no active lease exists, writes all leases, and commits them with the graph refresh. Every supported code path that can mutate a member must acquire the same member catalog lock and call one central lease guard after locking. That includes scheduled and manual refresh, V1 strict graph refresh, another preparation, `ALTER QUERY`, storage migration, restore, recreation, owner transfer, orchestration-mode change, suspend/resume operations that alter refresh eligibility, and drop. A check performed before acquiring the mutation lock is insufficient because preparation could commit between the check and mutation.
+
+While the lease is active, ordinary reads, `VACUUM`, `ANALYZE`, and other explicitly classified operations that do not change logical contents or semantic contracts may proceed. Physical maintenance that replaces storage, changes relation identity, or cannot prove preservation is blocked in capability major 1. A later minor version may allow more maintenance after tests demonstrate that the pinned storage-generation and contract checks remain sufficient.
+
+The graph remains in `EXTERNAL` orchestration mode after promotion or abandonment. Releasing a prepared lease makes it eligible for a later explicit V1 strict refresh or another preparation; it never transfers the graph to the normal scheduler.
+
+---
+
+## 16. Cross-transaction read protocol
+
+A durable member lease prevents refresh while the generation is prepared, but a processing transaction also needs protection against a concurrent promotion or abandonment that would release those leases before the transaction finishes reading. The proposal therefore adds an explicit open operation:
+
+```sql
+BEGIN;
+
+SELECT *
+FROM pgtrickle.open_prepared_graph(
+    prepared_generation_id => :generation_id,
+    expected_generation_digest => decode(:generation_digest_hex, 'hex')
+);
+
+-- Read member stream tables and bound output-delta relations here.
+-- Store or validate coordinator-owned checkpoint work.
+
+COMMIT;
+```
+
+`open_prepared_graph()` validates state, digest, ownership, database lineage, member leases, member contracts, member storage generations, and bound output state. It then holds a transaction-scoped shared transition lock on the generation. Several read transactions may open the same generation concurrently. Promotion and abandonment require an exclusive transition lock and therefore wait or return a stable busy error until all prepared readers finish.
+
+The open result includes the generation identifier and digest, graph digest, source-boundary digest, state, member count, and public member relation identities. It does not grant `SELECT`; ordinary PostgreSQL privileges still apply. It also does not create a new snapshot token. The persistent member leases ensure that the stream tables do not change, and the transaction-scoped transition lock ensures that the leases cannot be released during the read transaction. This makes the contents stable even under ordinary `READ COMMITTED` statement snapshots.
+
+Status inspection without data reads does not need to open the generation and does not block promotion. A coordinating extension that reads generation data without calling `open_prepared_graph()` is outside the supported cross-transaction protocol, even though the tables may happen to remain unchanged.
+
+---
+
+## 17. Prepared output-delta ranges
+
+At preparation, each explicitly bound V1 output consumer receives an immutable range associated with the generation. The range starts immediately after the consumer's acknowledged token and ends at the terminal token for the prepared stream-table state. The generation records the output contract digest, row-identity version, source-boundary digest, and whether the range can be applied incrementally.
+
+A status function exposes the bindings:
+
+```sql
+SELECT *
+FROM pgtrickle.prepared_graph_consumers(:generation_id);
+```
+
+It returns at least:
+
+```text
+consumer_id
+stream_table
+from_token_exclusive
+through_token_inclusive
+range_mode                 -- EXACT | RESYNCHRONIZE
+required_disposition       -- APPLIED | RESYNCHRONIZED
+output_contract_digest
+row_identity_version
+retained_rows
+retained_bytes
+```
+
+`EXACT` means the V1 batch sequence is continuous and every batch is exact. `RESYNCHRONIZE` means the consumer already required a baseline, the range contains `FULL_INVALIDATION`, or another truthful V1 condition requires the complete terminal relation. The prepared generation itself provides the stable relation needed for a cross-transaction resynchronization, so a coordinator can page through a very large terminal table over several short prepared reads and checkpoint its progress.
+
+Every batch and payload row needed by a prepared binding is pinned against cleanup. A direct call to the V1 acknowledgement API that would advance a bound consumer through or beyond the prepared terminal token is rejected while the generation is `PREPARED`. Only promotion may apply the bound acknowledgement. Consumer pause, drop, rebind, output-contract mutation, or resnapshot outside the prepared protocol is also blocked for bound consumers.
+
+The range is determined at preparation and does not grow when source changes arrive later. Later graph refreshes cannot occur while the member lease is active, so no new output batches for those members are produced until promotion or abandonment releases the graph.
+
+---
+
+## 18. `promote_prepared_graph()`
+
+### 18.1 Proposed API
+
+Promotion is intended to be called inside the coordinating extension's final publication transaction:
+
+```sql
+SELECT *
+FROM pgtrickle.promote_prepared_graph(
+    prepared_generation_id      => :generation_id,
+    expected_generation_digest  => decode(:generation_digest_hex, 'hex'),
+    acknowledgements            => jsonb_build_array(
+        jsonb_build_object(
+            'consumer_id',  :pair_consumer_id,
+            'through_token', :pair_through_token,
+            'disposition',   'APPLIED'
+        ),
+        jsonb_build_object(
+            'consumer_id',  :golden_consumer_id,
+            'through_token', :golden_through_token,
+            'disposition',   'RESYNCHRONIZED'
+        )
+    )
+);
+```
+
+The final implementation should preferably use a typed array such as `pgtrickle.prepared_consumer_ack[]`; JSONB above is illustrative. Promotion returns the generation identifier, prior and new state, completion timestamp, released member count, and acknowledged consumer count.
+
+### 18.2 Validation
+
+Promotion takes the generation's exclusive transition lock and then reacquires member locks in the same canonical order used by preparation. It verifies the expected digest, state, owner, database lineage, graph digest, member set, member contracts, member storage generations, producing refresh identifiers, source-boundary digest, active leases, output-consumer contracts, retained ranges, and required acknowledgement disposition. Every bound consumer must be acknowledged exactly through its prepared terminal token. Extra acknowledgements and omitted required acknowledgements are rejected.
+
+Source rows may have changed after preparation and do not prevent promotion. Those changes are intentionally pending. A semantic source or graph change that alters a pinned contract, a recreated member relation, a changed row-identity version, missing delta history, or a lost lease does prevent promotion. A separate future-continuity warning caused only by damage to post-boundary pending CDC may be returned, but it does not rewrite the already prepared evidence.
+
+### 18.3 Transactional effect
+
+Promotion applies the bound V1 output-delta acknowledgements, moves any resynchronized consumer back to `ACTIVE`, marks the generation `PROMOTED`, records completion, and releases all member leases in the caller's transaction. It does not call arbitrary external code and it does not publish the coordinating extension's tables itself.
+
+The caller may perform its own compare-and-swap checks and domain DML before or after the promotion call in the same transaction. If any later statement fails or the transaction is rolled back, the generation remains `PREPARED`, every lease remains active, and every consumer cursor remains unchanged. This property is the reason promotion must be an ordinary transactional SQL function rather than an asynchronous scheduler action.
+
+### 18.4 Meaning of promotion in the first physical model
+
+Because capability major 1 freezes the current private graph storage, the prepared rows are already present in the stream tables before promotion. Promotion does not swap a hidden table into place. It records that the authorized coordinating extension accepted this exact generation, consumes the bound delta ranges, and releases the graph for its next refresh. The API uses generational terminology so a later storage implementation can preserve the same logical lifecycle, but callers must not infer a physical table swap from the word “promote.”
+
+---
+
+## 19. `abandon_prepared_graph()`
+
+An authorized caller may reject a prepared or invalid generation explicitly:
+
+```sql
+SELECT *
+FROM pgtrickle.abandon_prepared_graph(
+    prepared_generation_id      => :generation_id,
+    expected_generation_digest  => decode(:generation_digest_hex, 'hex'),
+    reason                       => 'superseded by a newer MDM decision epoch'
+);
+```
+
+Abandonment takes the exclusive transition lock, validates the generation identity and authority, marks the generation `ABANDONED`, records the required reason, and releases every member lease. It does not acknowledge any output consumer, does not delete the prepared output batches, and does not attempt to restore the stream tables to their previous contents.
+
+Leaving the private graph at the abandoned boundary is safe because the durable output-consumer cursor still records what the higher-level publication accepted. Suppose a consumer was acknowledged through batch 40, generation A prepared batches 41 and 42, and A was abandoned. A later preparation may advance the graph again and produce batches 43 and 44. The consumer still begins after 40 and therefore sees the cumulative range 41 through 44, or an explicit resynchronization if any batch invalidated exact application. Reversing the graph would require a second retained physical generation or a guaranteed inverse delta and would add complexity without improving the acceptance contract.
+
+An invalid generation can only be abandoned. It cannot be promoted after a repair because repair would create different evidence from the immutable generation that the coordinator processed. If invalidation involved lost or unverifiable output history, the affected V1 consumer remains or becomes `RESNAPSHOT_REQUIRED` after abandonment. The audit row remains available according to normal retention policy even after its active leases are removed.
+
+---
+
+## 20. Source changes while a generation is prepared
+
+Preparing a graph freezes derived stream-table members, not their source systems. Local source transactions continue to insert, update, delete, and truncate rows under the ordinary `pg_trickle` CDC contract. WAL decoders, trigger buffers, upstream stream tables outside the prepared graph, and supported snapshot providers may continue advancing. Those later changes remain beyond the prepared source boundary and are processed by a future graph refresh after the lease is released.
+
+This behavior is essential for operational usefulness. A large resolver should not need to stop OLTP writes while it analyzes prepared evidence. The generation manifest records the exact boundary it represents, and the coordinating extension publishes that boundary explicitly. Freshness may lag during a long preparation, but correctness is not weakened.
+
+The cost is retention. Because the prepared graph cannot advance its member frontiers, source change buffers and upstream stream-table output buffers may retain all changes after the prepared boundary. `pg_trickle` must expose the resulting row, byte, age, and WAL-risk estimates. It may refuse a new preparation when current capacity cannot support the requested graph or configured advisory horizon, but it must not discard pending source changes or silently abandon an active generation to relieve pressure.
+
+A semantic source change is different from ordinary row changes. A mapped column type change, source relation replacement, result-affecting view or function change, collation change, source identity change, or other mutation that changes the pinned graph contract invalidates the generation or is blocked by existing DDL guards. An unrelated source-table change that provably does not affect the graph contract need not invalidate it.
+
+---
+
+## 21. Validation, invalidation, and repair
+
+The status model separates **prepared validity** from **future refresh continuity**. Prepared validity answers whether the member contents, contracts, source-boundary proof, and output ranges still match the immutable generation. Future continuity answers whether the graph can perform another safe incremental refresh after the lease is released.
+
+A prepared generation becomes invalid when a member relation is missing or recreated, a member storage-generation marker changes, an active lease is missing or points elsewhere, a graph or stream-table contract no longer matches, a bound output log or batch range is unavailable, a row-identity or output contract changes, database lineage is wrong, or any other required proof cannot be reconstructed. It is never automatically refreshed to a newer boundary and still called the same generation.
+
+Pending CDC damage after the prepared boundary may instead set future continuity to `REINITIALIZE_REQUIRED` while leaving prepared validity as `VALID`. The coordinator may still publish the proved prepared state. After promotion or abandonment, the next graph refresh must follow the V1 full-reinitialization and explicit invalidation rules rather than pretending incremental continuity survived.
+
+The proposal adds:
+
+```sql
+SELECT *
+FROM pgtrickle.verify_prepared_graph(
+    prepared_generation_id => :generation_id,
+    verification_level     => 'FAST'  -- FAST | DEEP
+);
+```
+
+A fast verification checks catalogs, contracts, leases, storage generations, relation identities, output ranges, sentinels, and database lineage. A deep verification may perform expensive row-identity, schema, or content checks where supported. The function returns a structured validity result rather than raising for every discovered defect, allowing a recovery worker or administrator to commit an `INVALID` state. Promotion still fails on any invalid result.
+
+`repair_stream_table()` and storage recreation are blocked while a valid prepared lease exists because changing a member would invalidate the coordinator's work. When a generation is already invalid, the operator first abandons it, then repairs or recreates the graph, and finally prepares a new generation. Repair does not mutate an old generation into valid state.
+
+---
+
+## 22. Concurrency and lock ordering
+
+Preparation, opening, promotion, abandonment, graph refresh, and lifecycle operations must share one documented lock hierarchy. A recommended order is:
+
+```text
+database-local integration registry
+  -> canonical graph transition key
+  -> generation row, when one exists
+  -> member stream-table catalog rows in ascending stable identity
+  -> member storage relations in ascending OID where required
+  -> output consumers in ascending UUID byte order
+  -> output batch and payload relations
+```
+
+`prepare_graph()` locks the complete member set before refreshing any member and inserts the durable leases while those locks remain held. Concurrent preparations with overlapping members serialize at the first common member and one fails with a stable lease conflict. A V1 strict graph refresh, manual refresh, scheduler dispatch, or lifecycle mutation that encounters an active lease fails rather than waiting indefinitely and later mutating evidence whose coordinator assumptions may have changed.
+
+`open_prepared_graph()` takes a shared transition lock that lasts until transaction end. Promotion and abandonment take the exclusive form. The implementation may use row locks, transaction advisory locks derived from stable generation identity, or both, but the durable member lease remains the source of truth after transaction end. Session locks are not state.
+
+Deadlock tests must cover graphs with overlapping roots, consumer UUID order differing from member order, promotion racing with readers, abandonment racing with source DDL, and restore or repair paths attempting to lock members in another sequence. No public operation may discover members incrementally and mutate the prefix before learning that a later member is unavailable.
+
+---
+
+## 23. Security and authorization
+
+Preparation and transition APIs preserve the V1 owner-equivalent execution model. The caller must own every member and every bound output consumer, be a member of their owner roles under the documented policy, or hold a future explicit maintenance privilege that is checked per object. `USAGE` on the `pgtrickle` schema is not sufficient. A `SECURITY DEFINER` function in another extension cannot borrow `pg_trickle`'s installation authority to prepare or release unrelated graphs.
+
+Defining SQL still executes as each stored stream-table owner under the stored defining search path and row-security contract. The generation owner is the authorized coordinating role, not necessarily the role used to evaluate every defining query. Ownership and role identities are pinned in the generation contract and cannot be changed while prepared.
+
+Prepared output ranges may contain complete values from deleted or superseded rows. Opening a generation does not bypass the V1 consumer authorization rules, and the generated typed delta relation remains accessible only to roles trusted to see the complete output history. Application RLS is not applied as an incomplete filter over a logical delta. A coordinator that cannot see complete terminal evidence cannot own a prepared consumer binding.
+
+Status functions reveal only information allowed by the existing stream-table contract-inspection policy. Public capability discovery remains safe. Full graph definitions, source relation names, consumer lag, and source-boundary details may be sensitive and require ownership or an explicit inspection privilege. Logs and errors use identifiers, counts, state, and digests rather than raw row values.
+
+An administrator or superuser can always destroy extension state at the PostgreSQL level. The contract prevents accidental or ordinary authorized lifecycle mutation and detects supported-path inconsistencies; it does not claim protection from a malicious database superuser.
+
+---
+
+## 24. Failure, crash, and recovery behavior
+
+A failure before the preparation transaction commits is simple: PostgreSQL rolls back the graph refresh, frontiers, output batches, generation rows, and member leases. The prior graph state remains usable. A network failure after an uncertain commit is handled through the caller-provided request identifier and `prepared_graph_by_request()` lookup.
+
+A backend disconnect after a generation is prepared does nothing to its state. The logged generation and lease rows remain. On server restart or physical failover, the scheduler and every mutation path load the durable leases before dispatching work. A `PREPARED` generation is not marked abandoned merely because no coordinator session is connected.
+
+A crash during a prepared read rolls back only that read transaction and releases its shared transition lock. The durable generation remains prepared. A crash during promotion or abandonment follows ordinary PostgreSQL atomicity. If the transition transaction did not commit, state, leases, and consumer cursors remain exactly as before. If it committed, all effects are visible together.
+
+Startup recovery performs a fast verification of every active generation and lease. It checks catalog referential integrity, member identities, storage generations, output-consumer bindings, output-log continuity, and capability versions. A provable mismatch is recorded as `INVALID` in a separate recovery transaction and surfaced through health diagnostics. Recovery never guesses a replacement generation or advances a consumer cursor.
+
+Physical backup, PITR, and streaming replication include generation catalogs, member storage, leases, output logs, and consumer cursors as ordinary durable PostgreSQL state. A restored writable clone must have a documented database-lineage policy. If the V1 integration contract rekeys lineage for a clone, active prepared generations from the original lineage become invalid until explicitly abandoned; a clone must not accidentally promote a generation intended for another database history.
+
+Logical dump and restore support must either preserve every required durable object and dependency in a verified order or reject active prepared generations before dump with a clear instruction. The implementation must not restore the member tables while omitting their leases or bound delta history and then report the graph as freely refreshable.
+
+---
+
+## 25. Stable errors
+
+The V2 API should use the structured error framework established by the V1 integration proposal. Callers must not parse English messages. Capability major 1 adds stable identifiers such as:
+
+| Error identifier | Meaning |
+|---|---|
+| `PGT_PREP_CAPABILITY_UNAVAILABLE` | The prepared-generation capability or one prerequisite major is unavailable |
+| `PGT_PREP_REQUEST_CONFLICT` | A preparation request identifier already exists with different inputs |
+| `PGT_PREP_GRAPH_INELIGIBLE` | The graph is not a complete supported external preparation boundary |
+| `PGT_PREP_LEASE_CONFLICT` | One or more members already belong to another prepared generation |
+| `PGT_PREP_GENERATION_NOT_FOUND` | The generation identifier is unknown in the current database lineage |
+| `PGT_PREP_DIGEST_MISMATCH` | The supplied generation digest does not match the stored immutable generation |
+| `PGT_PREP_STATE_CONFLICT` | The requested action is invalid for the generation's current state |
+| `PGT_PREP_READ_BUSY` | A transition cannot proceed because prepared readers are active, or a reader cannot open during transition |
+| `PGT_PREP_MEMBER_CHANGED` | A member contract, relation, storage generation, or producing refresh changed |
+| `PGT_PREP_DELTA_UNAVAILABLE` | A bound output range or its proof is missing or discontinuous |
+| `PGT_PREP_ACK_MISMATCH` | Promotion acknowledgements are missing, extra, out of range, or use the wrong disposition |
+| `PGT_PREP_AUTHORIZATION` | The caller lacks authority over the generation, one member, or one bound consumer |
+| `PGT_PREP_INVALID` | Verification has determined that the generation cannot be promoted |
+| `PGT_PREP_LIFECYCLE_BLOCKED` | Refresh, DDL, repair, drop, or another lifecycle operation is blocked by a prepared lease |
+| `PGT_PREP_LINEAGE_MISMATCH` | The token or generation belongs to another database lineage |
+| `PGT_PREP_RESOURCE_RISK` | Admission refused because the requested preparation exceeds a configured hard safety bound |
+
+Each error names the affected generation and object when disclosure is authorized, states whether the generation remains prepared, identifies the concrete consequence, and provides one next action. A lease conflict is never downgraded to a notice or successful no-op. Missing delta history is never described as an empty exact range.
+
+---
+
+## 26. Suggested catalog and storage changes
+
+This section is illustrative. Public behavior and invariants are normative; private table names may change.
+
+### 26.1 Prepared generations
+
+A logged generation catalog may contain:
+
+```text
+pgt_prepared_graphs
+  prepared_generation_id uuid primary key
+  request_id              uuid not null
+  owner_role              oid not null
+  database_lineage_id     uuid not null
+  state                   text not null
+  capability_major        smallint not null
+  capability_minor        smallint not null
+  graph_refresh_id        bigint not null
+  graph_digest            bytea not null
+  source_boundary         jsonb not null
+  source_boundary_digest  bytea not null
+  generation_digest       bytea not null
+  roots                    oid[] not null
+  prepared_at              timestamptz not null
+  completed_at             timestamptz
+  completion_reason        text
+  invalid_reason           text
+  future_continuity        text not null
+  unique (owner_role, request_id)
+```
+
+The state check permits `PREPARED`, `PROMOTED`, `ABANDONED`, and `INVALID`. Mutable status fields are excluded from the immutable generation digest.
+
+### 26.2 Member manifests and leases
+
+The immutable member manifest records:
+
+```text
+pgt_prepared_graph_members
+  prepared_generation_id
+  pgt_id
+  storage_relid
+  stream_contract_digest
+  output_schema_digest
+  storage_generation
+  producing_refresh_id
+  row_identity_version
+  row_probe_version
+  is_root
+  primary key (prepared_generation_id, pgt_id)
+```
+
+Active leases are normalized separately so the database can enforce one active generation per member:
+
+```text
+pgt_prepared_graph_leases
+  pgt_id primary key
+  prepared_generation_id references pgt_prepared_graphs
+  acquired_at
+```
+
+Promotion or abandonment deletes active lease rows but retains the immutable member manifest for audit.
+
+### 26.3 Prepared consumer bindings
+
+The consumer manifest records:
+
+```text
+pgt_prepared_graph_consumers
+  prepared_generation_id
+  consumer_id
+  stream_table_id
+  from_token_exclusive
+  through_token_inclusive
+  range_mode
+  required_disposition
+  output_contract_digest
+  row_identity_version
+  source_boundary_digest
+  primary key (prepared_generation_id, consumer_id)
+```
+
+A batch or payload row referenced by an active prepared consumer binding participates in the output-log retention minimum even if another consumer has advanced farther.
+
+### 26.4 Storage-generation marker
+
+If no equivalent durable marker already exists, each stream table should have a monotonically increasing `storage_generation` or content epoch. Every supported operation that can change logical rows, replace storage, restore a snapshot, reinitialize, or recreate generated columns increments it in the same transaction. Preparation pins it, and opening or promotion validates it. A no-data refresh may leave it unchanged when the logical contents and storage identity are unchanged.
+
+The marker is not a content hash and does not protect against malicious superuser writes. It is a complete supported-path invalidation token. A deep verification may add expensive checks when an operator suspects out-of-band tampering.
+
+---
+
+## 27. Integration with the refresh engine
+
+`prepare_graph()` should be a thin coordination layer over the V1 strict graph-refresh implementation. It creates the same canonical graph plan, computes the same source-boundary context, takes the same locks, invokes the same member refresh operations, and uses the same common finalizer. The refresh engine returns a structured graph result; the prepared layer then validates output consumers, writes the immutable manifest and leases, and returns the prepared result.
+
+This ordering matters. Leases cannot commit before the graph has successfully refreshed, but the refreshed graph cannot commit without leases. Both are therefore finalized in one transaction. Output-delta batches are created by the ordinary V1 finalizer and are merely bound by the generation; the prepared layer does not create another delta format.
+
+Every existing member-mutation entry point should call one central `ensure_member_not_prepared()` guard after acquiring the member's catalog lock. Scattering direct queries against a private lease table through the codebase would make it easy for a later lifecycle feature to omit the check. The central guard should return a structured error containing the owning generation and permitted next actions.
+
+Promotion and abandonment should similarly share one internal transition routine that acquires the generation and member locks, validates immutable state, applies the requested transition-specific action, and releases leases. Promotion supplies output acknowledgements; abandonment supplies a required reason and no acknowledgements. Neither path should call the graph-refresh engine.
+
+The scheduler must treat an active member lease as a hard exclusion even though eligible graphs are already `EXTERNAL`. This redundant check protects against catalog corruption, orchestration-mode migration, and future scheduler features. A leased member is never refreshed because it happens to appear stale.
+
+---
+
+## 28. Lifecycle interactions
+
+### 28.1 Create and initial preparation
+
+A coordinating extension creates its graph and output consumers through the V1 contract. The graph normally has no prepared state until a large run begins. Initial population may itself be prepared. If the bound consumer has no baseline or the initial batches require full invalidation, the prepared consumer range requires `RESYNCHRONIZED`, and the coordinator builds its first domain result from the frozen terminal relations.
+
+### 28.2 Strict refresh and repeated preparation
+
+A V1 strict graph refresh is rejected while any member is leased. After promotion or abandonment, the graph may be refreshed normally or prepared again. The next preparation starts from the graph's current private state and the output consumer's last acknowledged position, not from the most recent abandoned generation's acceptance state.
+
+### 28.3 Query and schema changes
+
+Any semantic or output-changing alteration of a prepared member is blocked. The coordinating extension first abandons the generation, then creates or alters the desired graph according to the V1 contract, establishes new consumers or baselines where required, and prepares a new generation. A physical-only operation may proceed only when it is explicitly classified as safe and does not alter pinned storage generation or relation identity.
+
+### 28.4 Ownership and orchestration changes
+
+Owner transfer, role dependency changes, and returning a member to `MANAGED` orchestration are blocked while prepared. The generation's authorization and execution identities are immutable inputs. Promotion and abandonment do not change orchestration mode.
+
+### 28.5 Suspend, resume, repair, snapshot, and restore
+
+Operations that only report state may run. Operations that alter refresh eligibility, storage contents, frontier, output history, or relation identity are blocked until the generation is released. An invalid generation must be abandoned before repair. A stream-table snapshot API must not restore over a prepared member, and a snapshot taken from a prepared member does not become a second supported prepared generation.
+
+### 28.6 Drop
+
+Dropping a member or a bound output consumer fails while a prepared lease or binding exists. An administrator who intends to destroy the graph must explicitly abandon active generations first, preserving an audit reason. `DROP EXTENSION ... CASCADE` remains a superuser-level destruction operation and cannot preserve integration guarantees.
+
+---
+
+## 29. Observability and administration
+
+The primary inspection API is:
+
+```sql
+SELECT *
+FROM pgtrickle.prepared_graph_status(:generation_id);
+```
+
+It reports state, owner, request identifier, age, roots, member count, graph and generation digests, source-boundary summary, prepared consumer count, active reader count, future-continuity state, invalid reason, pinned output rows and bytes, estimated pending source rows and bytes, and every current lifecycle blocker. A separate list function returns one concise row per active or recently completed generation.
+
+`prepared_graph_members()` reports member relation, contract digest, storage generation, producing refresh identifier, root status, and current validation result. `prepared_graph_consumers()` reports the immutable prepared ranges and required dispositions. Neither function exposes private change-buffer relation names or internal lease keys.
+
+`health_check()` should warn about an invalid generation, an unexpectedly old prepared generation, missing or inconsistent leases, output history approaching a hard retention bound, source-buffer or WAL growth beyond advisory thresholds, a missing owner role, degraded future continuity, or a graph whose members no longer form a valid external closure. Alerts do not change state.
+
+Useful metrics include preparation count and duration, prepared age, active generation count, lease conflicts, open-reader count, promotion and abandonment counts, promotion rollback retries, exact versus resynchronization ranges, pinned output bytes, pending source bytes, invalid generations, and future-reinitialization requirements. The coordinating extension remains responsible for reporting its domain-processing progress; `pg_trickle` may expose only the opaque request identifier that links the two systems.
+
+An administrator may need a supported way to abandon a generation whose owner extension has been removed or whose role no longer exists. The ordinary abandonment function may permit a superuser or designated `pg_trickle` administrator after the same validation and audit requirements. There is no administrative “force promote,” because only the coordinating extension can prove that its domain publication was completed.
+
+---
+
+## 30. Performance and resource behavior
+
+The freeze-in-place model avoids duplicating all graph rows. The direct storage overhead is limited to generation manifests, member and consumer rows, active leases, audit history, and the V1 output-delta and source-change data that must remain retained. Opening and status checks should be small catalog operations and should not scan member contents in fast mode.
+
+The principal cost is deferred cleanup. Source CDC, upstream stream-table buffers, and external output logs can grow while the graph is frozen. Before preparation, `pg_trickle` should report or optionally enforce conservative admission bounds based on current pending bytes, recent source change rate, configured maximum prepared age, available storage, WAL retention risk, number of members, and number of bound consumers. Such estimates are advisory unless a hard resource policy is explicitly configured; an estimate must never be presented as a proof that indefinite retention is safe.
+
+Once a generation is prepared, resource pressure cannot silently alter its meaning. `pg_trickle` may warn, pause unrelated work, or require an operator to abandon the generation, but it may not discard needed source changes, delete pinned output batches, release leases, or switch the generation to promoted state. If the database is approaching an unavoidable hard limit, preserving correctness may reduce availability.
+
+Prepared reads should support keyset pagination through the terminal stream tables and batch/ordinal pagination through output deltas. The generation does not require one read transaction to scan the full relation. Repeated short reads are the purpose of the feature.
+
+The initial capability should publish admission maxima for graph members, roots, bound consumers, generation-manifest size, concurrent prepared readers, and status result size. Exceeding a maximum fails before preparation rather than producing a partially leased graph.
+
+---
+
+## 31. Upgrade and compatibility policy
+
+The proposal is additive. Existing databases have no prepared generations, and existing V1 APIs continue unchanged. The new capability is available only after the required catalogs, lease guards, storage-generation markers, recovery checks, and SQL functions have been installed and validated.
+
+A compatible extension upgrade preserves active generation identifiers, digests, member manifests, leases, output bindings, and states. It may change physical indexes or internal query plans while preserving capability major 1. An upgrade that changes generation digest encoding, state transitions, prepared-read locking, member immutability, output-range semantics, or promotion behavior requires a new capability major.
+
+An upgrade that cannot preserve an active prepared generation must fail before mutating extension state and instruct the operator to promote or abandon the generation. It may not auto-abandon or mark it promoted. A mandatory correctness repair that proves an existing generation invalid may mark it `INVALID` with an explicit reason, but it cannot silently reinterpret or rebuild that generation under new semantics.
+
+Upgrade scripts and dump support must preserve the lease-before-scheduler invariant. There must be no startup window after an upgrade or restore in which the scheduler can refresh a member before active leases have been loaded and validated. Recovery and upgrade tests should deliberately crash or restart at each migration boundary.
+
+The public contract is SQL-facing. A coordinating extension pins capability majors and generation digests and does not link to private Rust symbols. Package dependency ranges may narrow installation combinations, but runtime negotiation remains authoritative.
+
+---
+
+## 32. End-to-end protocols
+
+### 32.1 Prepare and process
+
+A higher-level coordinator first creates a durable run identifier in its own catalog. It then prepares the graph and commits the returned generation with that run record:
+
+```sql
+BEGIN;
+
+INSERT INTO mdm_internal.runs(run_id, state)
+VALUES (:run_id, 'preparing');
+
+SELECT *
+INTO TEMP TABLE _prepared
+FROM pgtrickle.prepare_graph(
+    request_id                  => :run_id,
+    roots                       => :roots,
+    expected_graph_digest       => :graph_digest,
+    output_consumers            => :consumer_ids,
+    require_complete_boundaries => true,
+    full_policy                 => 'ALLOW'
+);
+
+UPDATE mdm_internal.runs
+SET state             = 'evidence_ready',
+    generation_id     = (SELECT prepared_generation_id FROM _prepared),
+    generation_digest = (SELECT generation_digest FROM _prepared),
+    source_boundary   = (SELECT source_boundary FROM _prepared)
+WHERE run_id = :run_id;
+
+COMMIT;
+```
+
+Each later work transaction opens the generation before reading:
+
+```sql
+BEGIN;
+
+SELECT pgtrickle.open_prepared_graph(
+    :generation_id,
+    :generation_digest
+);
+
+-- Claim and process one coordinator-owned deterministic work range.
+-- Read prepared stream tables or prepared output-delta rows.
+-- Store an idempotent checkpoint in coordinator-owned tables.
+
+COMMIT;
+```
+
+The graph remains immutable between these transactions. The coordinator can crash and resume by loading its run manifest and opening the same generation again.
+
+### 32.2 Final publication and promotion
+
+When all work is complete, the coordinator performs one final transaction:
+
+```sql
+BEGIN;
+
+-- Coordinator-owned compare-and-swap checks.
+SELECT mdm_internal.assert_run_publishable(
+    run_id                    => :run_id,
+    expected_publication      => :base_publication,
+    expected_definition       => :definition_version,
+    expected_decision_epoch   => :decision_epoch
+);
+
+-- Publish the complete domain result.
+SELECT mdm_internal.publish_run(:run_id);
+
+-- Accept exactly the prepared relational evidence.
+SELECT pgtrickle.promote_prepared_graph(
+    prepared_generation_id     => :generation_id,
+    expected_generation_digest => :generation_digest,
+    acknowledgements           => :prepared_acknowledgements
+);
+
+UPDATE mdm_internal.runs
+SET state = 'published'
+WHERE run_id = :run_id;
+
+COMMIT;
+```
+
+If any assertion, domain validation, output DML, acknowledgement, or promotion check fails, the complete transaction rolls back. The old domain publication remains visible and the generation remains prepared for inspection or retry.
+
+### 32.3 Supersession and abandonment
+
+When a newer definition or decision makes the run obsolete, the coordinator records the reason and abandons in one transaction:
+
+```sql
+BEGIN;
+
+UPDATE mdm_internal.runs
+SET state = 'superseded',
+    failure_reason = :reason
+WHERE run_id = :run_id;
+
+SELECT pgtrickle.abandon_prepared_graph(
+    prepared_generation_id     => :generation_id,
+    expected_generation_digest => :generation_digest,
+    reason                      => :reason
+);
+
+COMMIT;
+```
+
+No output cursor advances. A later run sees the complete cumulative delta sequence from the last accepted publication or performs a prepared resynchronization.
+
+---
+
+## 33. Delivery plan
+
+The capability should be delivered in four dependency-ordered phases. The feature remains disabled in capability discovery until each normative path is wired through the common mutation guards and the complete recovery matrix passes.
+
+### Phase 1: generation contract and durable leases
+
+Add the capability row in disabled form, generation and member catalogs, canonical generation digest, storage-generation markers, request idempotency, active lease storage, centralized mutation guards, lifecycle blocking, and basic status. This phase proves that a committed lease survives restart and prevents every supported member mutation, but it does not yet permit prepared output consumers or promotion.
+
+### Phase 2: preparation and prepared reads
+
+Implement `prepare_graph()` over the V1 strict refresh engine, atomic generation-and-lease finalization, `open_prepared_graph()`, shared versus exclusive transition locking, member inspection, source-write continuation, and basic abandonment. At the end of this phase a test extension can freeze a graph and read identical contents over several transactions, but it must still establish its own full baseline and cannot yet atomically consume V1 output cursors.
+
+### Phase 3: prepared consumer ranges and promotion
+
+Bind V1 output-delta consumers to generations, pin exact or resynchronization ranges, block direct acknowledgement and consumer lifecycle conflicts, implement typed promotion acknowledgements, atomically transition to `PROMOTED`, and prove rollback behavior with coordinator-owned publication tables. This phase completes the functional `pg_mdm` V2 dependency.
+
+### Phase 4: recovery, upgrade, and operational hardening
+
+Add fast and deep verification, startup recovery, invalid-state handling, future-continuity reporting, backup and restore tests, physical failover tests, upgrade gates, clone-lineage behavior, capacity forecasting, health checks, metrics, administrator abandonment, and a full conformance test extension. Only after this phase should the capability advertise `enabled = true` for production use.
+
+---
+
+## 34. Test plan
+
+### 34.1 Unit and property tests
+
+Pure tests should cover canonical generation encoding, digest golden vectors, state-transition legality, request idempotency, member and consumer ordering, required acknowledgement computation, exact versus resynchronization classification, lock-key derivation, and future-validity classification. Property tests should generate valid and invalid state sequences and prove that no path reaches `PROMOTED` without complete matching acknowledgements or releases a member lease while the generation remains prepared.
+
+### 34.2 PostgreSQL integration tests
+
+Integration tests should prepare one-node and multi-node external graphs, verify identical member contents across several transactions, allow source writes while prepared, prove that later source changes remain pending, and demonstrate that a later preparation catches up after promotion or abandonment. Tests must cover exact output ranges, ranges containing full invalidation, initial resynchronization, several bound consumers, and a generation without output consumers.
+
+Every member mutation path must have a prepared-lease test: manual refresh, scheduler dispatch, V1 strict graph refresh, another preparation, alter query, storage recreation, owner transfer, orchestration-mode change, suspend/resume, repair, restore, rename, and drop. Physical-only operations classified as safe should have positive tests proving that generation digest and contents remain valid.
+
+Concurrency tests should race overlapping preparations, prepared readers, promotion, abandonment, source DML, source DDL, output acknowledgement, consumer drop, and extension lifecycle operations. They should use condition-based synchronization rather than sleeps and run under PostgreSQL's supported isolation levels. Deadlock detection and deterministic lock order are release gates.
+
+### 34.3 Atomic publication tests
+
+A small independent test extension should maintain its own publication table and run manifest. It prepares a graph, performs checkpointed work over multiple transactions, writes a final publication, promotes, and commits. A forced error after `promote_prepared_graph()` must leave the generation prepared, leases active, publication unchanged, and consumer cursors unadvanced. A retry must then succeed without re-preparation.
+
+The same test extension should abandon a generation and prove that no cursor advances. A later preparation must expose the cumulative exact range or require a full resynchronization. This is the key proof that abandonment does not lose evidence even though private stream-table contents are not reversed.
+
+### 34.4 Crash, recovery, and upgrade tests
+
+Tests should restart PostgreSQL after preparation, during an open read, during promotion before commit, and after promotion commit. Physical replica promotion should preserve the lease and state. Backup, PITR, and supported logical dump paths should either restore a valid generation or produce an explicit invalid result; no path may silently free the graph.
+
+Upgrade tests should cover no active generation, one valid prepared generation, one invalid generation, terminal audit generations, and a deliberately incompatible future migration. The incompatible path must fail before catalog or storage mutation. Clone-lineage tests must prove that tokens from one writable history cannot be promoted in another without an explicit supported lineage policy.
+
+### 34.5 Corruption and fail-closed tests
+
+Tests should remove or alter a lease, member relation, storage-generation marker, output batch, payload relation, consumer contract, source-boundary record, and row-identity metadata. Fast verification and promotion must detect each case. Pending source-buffer loss after the prepared boundary should produce degraded future continuity without necessarily invalidating intact prepared member evidence, while loss of a bound prepared output range must invalidate promotion.
+
+### 34.6 Security tests
+
+Cross-role tests should verify mixed member ownership, revoked role membership, `SECURITY DEFINER` wrappers, unauthorized status inspection, deleted-row access through output deltas, generation ownership transfer attempts, and administrator abandonment. Search-path shadowing and dynamic SQL identifier tests remain mandatory.
+
+### 34.7 Performance and longevity tests
+
+Benchmarks should measure preparation overhead relative to V1 strict refresh, open and status latency, promotion latency with several consumers, lease-guard overhead on ordinary unprepared refreshes, output and source retention growth, and repeated paginated prepared reads. A longevity test should hold a generation while sustained source writes continue, report buffer and WAL growth accurately, promote or abandon, and then prove complete catch-up.
+
+---
+
+## 35. Alternatives considered
+
+### 35.1 Keep the V1 transaction open
+
+This remains the preferred path for small and medium workloads. It becomes operationally expensive when domain processing is long, checkpointed, or manually reviewed. The V2 capability exists only for cases where that measured cost is unacceptable.
+
+### 35.2 Export a PostgreSQL snapshot
+
+An exported snapshot can be imported only while the exporting transaction remains open, so it does not remove the long-lived transaction. It also does not by itself prevent stream-table lifecycle mutation after the exporter ends. A durable generation lease addresses the actual problem.
+
+### 35.3 Use `PREPARE TRANSACTION`
+
+Two-phase commit would retain a prepared database transaction and its locks rather than produce an ordinary committed private graph. Long-lived prepared transactions complicate vacuum, lock management, recovery, and operator safety and are disabled in many deployments. They are not an appropriate routine work queue for domain processing.
+
+### 35.4 Copy terminal relations into coordinator-owned staging
+
+This can work as an application pattern, but it duplicates large data, requires every extension to invent its own exact copy boundary and schema evolution, and separates the copy from `pg_trickle`'s output-delta and storage-generation proofs. The proposed lease reuses the authoritative private graph in place.
+
+### 35.5 Clone every graph generation
+
+Multiple physical copies would permit continued graph refresh and simultaneous preparations. They require a new storage-generation manager, generation-specific relation routing, delta fan-out, source-buffer retention across several frontiers, query and index lifecycle, garbage collection, and much larger storage. Capability major 1 intentionally avoids that scope.
+
+### 35.6 Trust `EXTERNAL` mode without a lease
+
+External orchestration prevents scheduler dispatch, but it does not stop another authorized manual refresh, strict graph refresh, repair, alteration, or coordinator. A persistent prepared lease is the explicit proof that the graph must not change.
+
+### 35.7 Hold a session advisory lock
+
+A session lock disappears on disconnect and does not survive failover. It is useful for transaction serialization but cannot represent durable prepared state. The proposal uses catalog leases as truth and ordinary locks only for transitions.
+
+### 35.8 Let the coordinator acknowledge deltas before publication
+
+Early acknowledgement would permit cleanup of evidence that the domain publication has not accepted. A later failure could leave no exact path from the accepted publication to the next result. Promotion therefore owns the prepared acknowledgements and shares the final publication transaction.
+
+### 35.9 Reverse the graph on abandonment
+
+Restoring the prior graph would require retaining a second copy or a complete invertible delta for every member and execution path. The output consumer's unadvanced cursor already preserves the logical difference safely. Reversal adds risk and is unnecessary.
+
+### 35.10 Add an automatic timeout
+
+Age is an operational signal, not proof of acceptance. Automatic promotion is unsafe and automatic abandonment may discard a coordinator's recoverable work or release evidence while it is still being read. The first contract alerts but requires an explicit transition.
+
+---
+
+## 36. Risks and open implementation choices
+
+The largest correctness risk is an incomplete mutation guard. One forgotten refresh, repair, restore, or DDL path could change prepared evidence. The mitigation is a centralized guard called after canonical member locking, generated tests that enumerate all SQL mutation entry points, and a storage-generation marker checked by every open and promotion.
+
+The largest operational risk is retention growth while a graph is prepared. The mitigation is the single-generation freeze model, admission forecasts, exact lag metrics, advisory age policies, and explicit abandonment. Correctness still takes priority over automatic cleanup, so deployments must size the prepared horizon conservatively.
+
+The largest transactional risk is releasing leases while a processing transaction is still reading. The mitigation is the explicit shared `open_prepared_graph()` lock and exclusive transition lock. Documentation and the conformance test must treat opening as mandatory, not an optional status call.
+
+The largest semantic risk is confusing private graph advancement with higher-level acceptance. The mitigation is the immutable prepared consumer range. Only promotion advances the external cursor; abandonment never does. The coordinating extension's own publication remains outside `pg_trickle` and must share the promotion transaction.
+
+The proposal leaves several implementation choices for review:
+
+1. Whether acknowledgement parameters use a typed composite array or a compact JSONB document. The validation and all-or-nothing behavior are unchanged.
+2. Whether generation identifiers use PostgreSQL UUIDv7 support, ordinary UUID generation, or another opaque UUID. Ordering is not semantic.
+3. Whether transaction transition locks use catalog row locks, advisory transaction locks, or both. Durable leases remain authoritative.
+4. Whether `storage_generation` is a new catalog field or an existing complete mutation epoch can satisfy the same invariant.
+5. Which physical maintenance operations are safe during preparation. Capability major 1 may conservatively block uncertain operations.
+6. Whether fast verification marks `INVALID` directly or reports a finding that a startup or administrator transaction then persists. Promotion must fail either way.
+7. How long terminal audit rows remain after promotion or abandonment. Retention may be configurable, but active generation proof is never pruned.
+
+None of these choices justify multiple active generations, automatic expiry, private-catalog coupling, or weaker promotion atomicity in capability major 1.
+
+---
+
+## 37. Acceptance criteria
+
+The prepared-generation capability is ready when an independently developed test extension can:
+
+- discover and pin `prepared_graph_generation` major 1 and all prerequisite V1 capability majors;
+- prepare a multi-node `EXTERNAL` graph under one complete source boundary and receive a durable UUID and generation digest;
+- lose the preparation response, rediscover the committed generation by request identifier, and avoid creating a second generation;
+- read exactly the same member contents and prepared output range over several later transactions by calling `open_prepared_graph()`;
+- continue writing to source tables while the graph remains frozen and later prove that those changes were not included in the prepared boundary;
+- observe hard errors for every refresh, DDL, repair, ownership, orchestration, consumer, and storage operation that would invalidate a prepared member;
+- observe a hard overlap conflict when another preparation includes any leased member;
+- process an exact prepared output range and a prepared full-resynchronization range without reading private `pg_trickle` objects;
+- publish coordinator-owned state and promote in one transaction, then force rollback and prove that generation state, leases, and output cursors all remain unchanged;
+- retry and commit promotion, then refresh the released graph through later pending source changes;
+- abandon without acknowledgement and later consume the complete cumulative range from the last accepted cursor;
+- survive backend disconnect, PostgreSQL restart, physical failover, backup and restore, and a supported extension upgrade with state and leases intact;
+- detect missing member storage, changed contracts, lost output history, lineage mismatch, and other invalid conditions without silently re-preparing;
+- distinguish an invalid prepared generation from degraded future refresh continuity;
+- expose clear ownership checks, stable errors, prepared age, active readers, retained bytes, pending source growth, and next actions.
+
+The feature is not ready merely because `prepare_graph()` returns a row. Every supported mutation path, rollback boundary, consumer transition, restart path, and upgrade path must preserve the invariants above. `pg_mdm` V2 should not claim resumable publication until this complete conformance matrix passes against packaged `pg_trickle` builds.
+
+---
+
+## 38. Recommended disposition
+
+Accept the prepared-generation capability as a separate V2 proposal after the V1 composition contract is stable. Implement the first version as a single durable freeze over current external graph storage, one active generation per member, explicit prepared reads, bound output-delta ranges, transactional promotion, and explicit abandonment. Do not expand the first release into multi-generation storage, asynchronous graph construction, or coordinator worker management.
+
+This boundary preserves the responsibilities of both projects:
+
+> **`pg_trickle` owns the immutable relational generation and its continuity proofs. A coordinating extension owns the long-running domain computation and the decision to publish. PostgreSQL owns the final atomic commit.**
+
+---
+
+# Appendix A: possible later generations
+
+**This appendix is non-normative and does not affect capability major 1 acceptance. Each item requires a separate proposal.**
+
+A later implementation might store several physical graph generations simultaneously. That would let the graph continue refreshing while an earlier generation is under analysis, support concurrent previews, and reduce source-buffer retention. It would also require generation-specific member relations, query routing, index lifecycle, output-delta fan-out, source-frontier accounting, promotion or garbage-collection rules, and much larger storage. The capability should be added only after measured workloads show that freeze-in-place is inadequate.
+
+Another later capability might prepare the graph asynchronously or checkpoint `pg_trickle`'s own graph refresh across transactions. That is distinct from this proposal. The current design makes the completed evidence immutable so a higher-level computation can be resumable; it does not make relational evidence construction resumable. An asynchronous design would need durable graph-refresh jobs, source-boundary leases, deterministic batch manifests, restart-safe work claiming, and a final graph-generation assembly proof.
+
+A future capability could permit carefully declared coordinator dependencies, such as one prepared graph consuming another prepared graph or several coordinating extensions sharing a generation. That requires explicit ownership, acknowledgement, retention, and promotion precedence. Capability major 1 instead requires one externally controlled graph boundary and rejects scheduler-managed downstream dependents outside it.
+
+Finally, object-storage snapshots or remote prepared generations may eventually reduce primary-database retention pressure. Such a design would need exact typed serialization, relation and collation compatibility, encryption and access control, restoration proof, and a transactionally safe promotion link back to PostgreSQL. None of those mechanisms should be inferred from the V2 capability proposed here.

--- a/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
+++ b/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
@@ -315,7 +315,7 @@ Mutable operational fields such as state, age, warning counters, active readers,
 
 The caller stores both the UUID and digest in its own run manifest. Every later open, promotion, or abandonment supplies the expected digest. An identifier that exists with a different digest is a hard error rather than an invitation to use the current row.
 
-Preparation also accepts a caller-provided `request_id`. The pair `(owner_role, request_id)` is unique. Before graph mutation, `prepare_graph()` computes a canonical `request_digest` over `database_instance_id`, owner, canonical roots, expected graph digest, sorted output-consumer identities, `full_policy`, and requested V2 capability majors. A repeated request returns the existing generation in its current state only when this digest matches. Reusing the identifier with different inputs raises a stable idempotency error. This prevents a lost response after commit from leaving the coordinator unable to rediscover which prepared generation owns the graph.
+Preparation also accepts a caller-provided `request_id`. The pair `(owner_role, request_id)` is unique. Before graph mutation, `prepare_graph()` computes a canonical `request_digest` over `database_instance_id`, owner, canonical roots, expected graph digest, sorted output-consumer identities, `full_policy`, and requested V2 capability majors. It then acquires a namespaced transaction advisory lock derived from `(database_instance_id, owner_role, request_id)` and checks the generation catalog while holding that lock. The lock remains held through transaction end. A repeated request returns the existing generation in its current state only when this digest matches. When no row exists, the caller retains the request lock while it acquires graph locks, refreshes, and inserts the generation. The unique catalog key is a final integrity constraint, not the primary serialization mechanism. Hash collisions may serialize unrelated requests but cannot weaken correctness. Reusing the identifier with different inputs raises a stable idempotency error. This prevents concurrent identical calls from both refreshing the graph and prevents a lost response after commit from leaving the coordinator unable to rediscover which prepared generation owns the graph.
 
 ---
 
@@ -613,17 +613,19 @@ A fast verification checks generation and member catalogs, stored contract diges
 
 ## 22. Concurrency and lock ordering
 
-Preparation, opening, promotion, abandonment, graph refresh, and lifecycle operations must share one documented lock hierarchy. A recommended order is:
+Preparation, opening, promotion, abandonment, graph refresh, and lifecycle operations must share one documented lock hierarchy. The order is:
 
 ```text
-generation transition lock, when an existing generation is targeted
+integration drain lock, shared by prepare_graph() and exclusive for supported logical dump
+  -> preparation request lock, only when prepare_graph() targets a request_id
+  -> generation transition lock, when an existing generation is targeted
   -> member refresh, lifecycle, and catalog-row locks in the canonical Graph V1 order
   -> member storage relations in ascending OID where required
   -> output consumers in ascending UUID byte order, when delta binding applies
   -> output batch and payload relations
 ```
 
-The member locks are the graph-isolation mechanism. V2 uses the exact canonical database-local member key and ordering implemented by the negotiated Graph V1 capability; it does not derive a second V2 order from `pgt_id`, relation OID, root order, or generation identity. No hash of the root or member set and no database-wide integration-registry lock may substitute for those locks. Preparation also serializes `(owner_role, request_id)` through the unique catalog key while establishing idempotency, but that key does not protect graph members.
+The member locks are the graph-isolation mechanism. V2 uses the exact canonical database-local member key and ordering implemented by the negotiated Graph V1 capability; it does not derive a second V2 order from `pgt_id`, relation OID, root order, or generation identity. No hash of the root or member set and no database-wide integration-registry lock may substitute for those locks. The integration drain lock only closes the supported logical-dump admission window, and the request lock only serializes idempotent preparation; neither protects graph members. Every path that combines these lock classes follows the hierarchy above.
 
 `prepare_graph()` locks the complete member set before refreshing any member and inserts the durable leases while those locks remain held. Concurrent preparations with overlapping members serialize at the first common member and one fails with a stable lease conflict. A V1 strict graph refresh, manual refresh, scheduler dispatch, or lifecycle mutation that encounters an active lease fails rather than waiting indefinitely and later mutating evidence whose coordinator assumptions may have changed.
 
@@ -638,6 +640,8 @@ Deadlock tests must cover graphs with overlapping roots, consumer UUID order dif
 Preparation and transition APIs preserve the V1 owner-equivalent execution model. The caller must own every member and every bound output consumer, be a member of their owner roles under the documented policy, or hold a future explicit maintenance privilege that is checked per object. `USAGE` on the `pgtrickle` schema is not sufficient. A `SECURITY DEFINER` function in another extension cannot borrow `pg_trickle`'s installation authority to prepare or release unrelated graphs.
 
 Defining SQL still executes as each stored stream-table owner under the stored defining search path and row-security contract. The generation owner is the authorized coordinating role, not necessarily the role used to evaluate every defining query. Ownership and role identities are pinned in the generation contract and cannot be changed while prepared.
+
+Durable generation and binding rows that store role OIDs follow Graph V1's owner-lifecycle rule. They register PostgreSQL shared dependencies on their owner roles, or use an equivalent mechanism that prevents role deletion while active state exists. A dangling owner OID invalidates the object, and later OID reuse must never transfer authority. Removing or reassigning an owner requires an explicit lifecycle operation with the same generation and member locks. Terminal audit retention may replace the live dependency with a non-authoritative recorded role name or another immutable audit identity.
 
 Prepared output ranges may contain complete values from deleted or superseded rows. Opening a generation does not bypass the V1 consumer authorization rules, and the generated typed delta relation remains accessible only to roles trusted to see the complete output history. Application RLS is not applied as an incomplete filter over a logical delta. A coordinator that cannot see complete terminal evidence cannot own a prepared consumer binding.
 
@@ -659,7 +663,7 @@ Startup recovery performs a fast verification of every active generation and lea
 
 Restart and failover that preserve the v0.92 `database_instance_id` preserve generation catalogs, member storage, leases, output logs, and consumer cursors as ordinary durable PostgreSQL state. Any restore, PITR, template copy, physical clone, or logical restore activated with a new writable `database_instance_id` marks imported active generations `INVALID`. Their leases remain until explicit abandonment so the restored graph cannot refresh under ambiguous ownership.
 
-Capability major 1 does not preserve active prepared generations through the supported logical dump and restore workflow. Backup preflight rejects logical dump while a generation is `PREPARED` and instructs the operator to promote or abandon it. If unsupported tooling nevertheless restores active rows into a new instance, startup recovery marks them `INVALID` and retains their leases until explicit abandonment. Terminal audit rows may be restored as history.
+Capability major 1 does not preserve active prepared generations through the supported logical dump and restore workflow. `pgtrickle.assert_logical_dump_safe()` raises a stable state-conflict error when any generation is `PREPARED`. The supported `pg_trickle_dump` workflow takes the integration drain lock exclusively, calls the assertion, and holds the lock through export; `prepare_graph()` takes the shared form before its request lock. The extension-config dump filter for the generation catalog also invokes a side-effect-free row predicate that raises on `PREPARED`, so direct `pg_dump` cannot silently serialize an active generation from its consistent dump snapshot while still dumping terminal audit rows. If unsupported tooling bypasses these checks and restores active rows into a new instance, startup recovery marks them `INVALID` and retains their leases until explicit abandonment. Terminal audit rows may be restored as history.
 
 ---
 
@@ -781,7 +785,7 @@ A batch or payload row referenced by an active prepared consumer binding partici
 
 ### 26.4 Content epoch
 
-Every stream table must expose one durable, monotonically increasing `content_epoch`; an existing field may satisfy this requirement only if it is already a complete mutation epoch. Every supported operation that can change logical rows, replace storage, restore a snapshot, reinitialize, recreate generated columns, or change the interpretation of stored values increments it in the same transaction. Preparation pins it, and opening or promotion validates it. A no-data refresh may leave it unchanged only when logical contents, storage identity, and stored-value interpretation are unchanged.
+Every stream table must expose one durable, monotonically increasing `content_epoch`; an existing field may satisfy this requirement only if it is already a complete mutation epoch. The capability migration initializes existing stream tables to zero while holding the ordinary lifecycle and catalog locks and leaves discovery disabled until every row and mutation guard is installed. Zero means only "baseline established by this migration"; it does not claim that the table has never changed. Every supported operation that can change logical rows, replace storage, restore a snapshot, reinitialize, recreate generated columns, or change the interpretation of stored values increments it in the same transaction. Preparation pins it, and opening or promotion validates it. A no-data refresh may leave it unchanged only when logical contents, storage identity, and stored-value interpretation are unchanged.
 
 The mutation classification is normative:
 
@@ -886,7 +890,7 @@ A compatible extension upgrade preserves active generation identifiers, digests,
 
 An upgrade that cannot preserve an active prepared generation must fail before mutating extension state and instruct the operator to promote or abandon the generation. It may not auto-abandon or mark it promoted. A mandatory correctness repair that proves an existing generation invalid may mark it `INVALID` with an explicit reason, but it cannot silently reinterpret or rebuild that generation under new semantics.
 
-Upgrade scripts and dump support must preserve the lease-before-scheduler invariant. There must be no startup window after an upgrade or restore in which the scheduler can refresh a member before active leases have been loaded and validated. Recovery and upgrade tests should deliberately crash or restart at each migration boundary.
+Upgrade scripts and dump support must preserve the lease-before-scheduler invariant. There must be no startup window after an upgrade or restore in which the scheduler can refresh a member before active leases have been loaded and validated. The supported logical-dump workflow calls `assert_logical_dump_safe()` while holding the integration drain lock; the extension-config dump predicate provides a second fail-closed check for direct `pg_dump`. Recovery and upgrade tests should deliberately crash or restart at each migration boundary.
 
 The public contract is SQL-facing. A coordinating extension pins capability majors and generation digests and does not link to private Rust symbols. Package dependency ranges may narrow installation combinations, but runtime negotiation remains authoritative.
 
@@ -1028,7 +1032,7 @@ Add fast and deep verification, startup recovery, invalid-state handling, future
 
 ### 34.1 Unit and property tests
 
-Pure core tests should cover canonical request and generation encoding, digest golden vectors, state-transition legality, request idempotency, member ordering, lock-key derivation, and future-validity classification. Property tests must prove that no path releases a member lease while the generation remains prepared. Prepared delta-binding tests additionally cover consumer ordering, required acknowledgement computation, and `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED` classification, and prove that no bound path reaches `PROMOTED` without complete matching dispositions.
+Pure core tests should cover canonical request and generation encoding, digest golden vectors, state-transition legality, request idempotency, member ordering, lock-key derivation, content-epoch classification, and future-validity classification. Property tests must prove that no path releases a member lease while the generation remains prepared. Prepared delta-binding tests additionally cover consumer ordering, required acknowledgement computation, and `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED` classification, and prove that no bound path reaches `PROMOTED` without complete matching dispositions.
 
 ### 34.2 PostgreSQL integration tests
 
@@ -1036,7 +1040,7 @@ Core integration tests should prepare one-node and multi-node external graphs wi
 
 Every member mutation path must have a prepared-lease test: manual refresh, scheduler dispatch, V1 strict graph refresh, another preparation, alter query, storage recreation, owner transfer, orchestration-mode change, suspend/resume, repair, restore, rename, and drop. Physical-only operations classified as safe should have positive tests proving that generation digest and contents remain valid.
 
-Concurrency tests should race overlapping preparations, prepared readers, promotion, abandonment, source DML, source DDL, output acknowledgement, consumer drop, and extension lifecycle operations. They should use condition-based synchronization rather than sleeps and run under PostgreSQL's supported isolation levels. Deadlock detection and deterministic lock order are release gates.
+Concurrency tests should race duplicate and conflicting uses of one `(owner_role, request_id)`, supported logical-dump preflight, overlapping preparations, prepared readers, promotion, abandonment, source DML, source DDL, output acknowledgement, consumer drop, and extension lifecycle operations. A duplicate request may execute the graph refresh at most once, and no preparation may commit inside the supported dump window. Tests should use condition-based synchronization rather than sleeps and run under PostgreSQL's supported isolation levels. Deadlock detection and deterministic lock order are release gates.
 
 ### 34.3 Atomic publication tests
 
@@ -1046,7 +1050,7 @@ The same test extension should abandon a generation and prove that no cursor adv
 
 ### 34.4 Crash, recovery, and upgrade tests
 
-Tests should restart PostgreSQL after preparation, during an open read, during promotion before commit, and after promotion commit. Restart, failover, backup, and PITR preserve an active generation only when they preserve `database_instance_id`. Supported logical dump preflight rejects `PREPARED` generations. Unsupported restore into a new instance must mark imported active generations `INVALID` without releasing their leases.
+Tests should restart PostgreSQL after preparation, during an open read, during promotion before commit, and after promotion commit. Restart, failover, backup, and PITR preserve an active generation only when they preserve `database_instance_id`. The supported dump wrapper and the extension-config dump predicate both reject `PREPARED` generations, and the drain lock prevents a preparation from committing between wrapper preflight and dump. Unsupported restore into a new instance must mark imported active generations `INVALID` without releasing their leases.
 
 Upgrade tests should cover no active generation, one valid prepared generation, one invalid generation, terminal audit generations, and a deliberately incompatible future migration. The incompatible path must fail before catalog or storage mutation. Clone-isolation tests must prove that tokens from one `database_instance_id` cannot be promoted in another.
 
@@ -1056,7 +1060,7 @@ Tests should remove or alter a lease, member relation, content epoch, stored con
 
 ### 34.6 Security tests
 
-Cross-role tests should verify mixed member ownership, revoked role membership, `SECURITY DEFINER` wrappers, unauthorized status inspection, deleted-row access through output deltas, generation ownership transfer attempts, and administrator abandonment. Search-path shadowing and dynamic SQL identifier tests remain mandatory.
+Cross-role tests should verify mixed member ownership, revoked role membership, blocked owner-role drop, role OID reuse resistance, `SECURITY DEFINER` wrappers, unauthorized status inspection, deleted-row access through output deltas, generation ownership transfer attempts, and administrator abandonment. Search-path shadowing and dynamic SQL identifier tests remain mandatory.
 
 ### 34.7 Performance and longevity tests
 

--- a/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
+++ b/plans/PROPOSAL_V2_PREPARED_GRAPH_GENERATIONS.md
@@ -1008,7 +1008,7 @@ No output cursor advances. A later run sees the complete cumulative delta sequen
 
 ## 33. Delivery plan
 
-The capabilities should be delivered in four dependency-ordered phases in a future post-1.0 release. The roadmap must assign a release before implementation begins; this proposal does not invent that commitment. It does not reopen the v0.94 feature freeze or the v0.95 stabilization boundary. Each capability remains disabled in discovery until its normative paths are wired through the common mutation guards and its recovery matrix passes.
+The capabilities should be delivered in four dependency-ordered phases in a future post-1.0 release. The roadmap must assign a release before implementation begins; this proposal does not invent that commitment. It does not reopen the v0.97 feature freeze or the v0.98 stabilization boundary. Each capability remains disabled in discovery until its normative paths are wired through the common mutation guards and its recovery matrix passes.
 
 ### Phase 1: generation contract and durable leases
 

--- a/roadmap/v0.92.0.md
+++ b/roadmap/v0.92.0.md
@@ -63,7 +63,7 @@ Extension upgrade E2E tests cover every supported source version. Downgrades
 remain unsupported and fail with the rollback runbook named in the error.
 
 The v1.0 support matrix is bounded to source extension versions v0.40.0 through
-the latest v0.95.x release, on PostgreSQL 18. Before LC-6 implementation starts,
+the latest v0.98.x release, on PostgreSQL 18. Before LC-6 implementation starts,
 commit a manifest with every supported source-version and PostgreSQL-major pair.
 Older migration scripts remain chain-checked, but they do not receive full E2E
 support. Later releases publish a new bounded matrix instead of automatically
@@ -91,7 +91,7 @@ an unproven frontier.
 - [ ] PostgreSQL major-upgrade coverage includes active stream tables and
       pending deltas
 - [ ] The checked-in v1.0 support manifest contains only v0.40.0 through the
-      latest v0.95.x release on PostgreSQL 18, and every listed pair passes E2E
+      latest v0.98.x release on PostgreSQL 18, and every listed pair passes E2E
 - [ ] Preflight, quiesce, and resume expose stable results suitable for scripted
       DBA workflows
 - [ ] Every injected CDC failure enters one documented recovery class

--- a/roadmap/v0.93.0.md
+++ b/roadmap/v0.93.0.md
@@ -1,83 +1,77 @@
-# v0.93.0 — Defaults, Bounds & Diagnosis
+# v0.93.0 — Graph Contracts & External Ownership
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"I can run this for years without hidden resource or repair behavior."*
+> **User promise:** *"Coordinating extensions can treat pg_trickle as a versioned incremental component."*
 > **Blocked by:** [v0.92.0](v0.92.0.md)
-> **Renumbered:** previously v0.92.0. Monitoring, assurance, and packaging are
-> in [v0.94.0](v0.94.0.md).
+> **Delivery plan:** Phase 1 of
+> [Proposal: V1 Composable Refresh and Durable Delta Contracts](../plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)
 
 ## Theme
 
-Make the default configuration derive from real resource constraints. Define
-which resources pg_trickle can bound, which it can throttle, and which it can
-only forecast and react to. Long operations, errors, and privilege decisions
-must be inspectable through stable interfaces.
+Expose versioned capability discovery and canonical stream-table and graph
+contracts for trusted PostgreSQL extensions. Add durable `EXTERNAL`
+orchestration ownership without exposing private catalogs, capture buffers,
+frontiers, generated columns, or Rust internals.
 
-This release is part of the mandatory v1.0 operational critical path.
+This release establishes the public contract and ownership foundation. Graph
+V1 is not complete until strict transactional refresh passes the separate
+[v0.94.0](v0.94.0.md) gate.
 
 ## Items
 
-### PP-1: Resource-based defaults
+### GV1-1: Independent capability discovery
 
-Automatic configuration uses available memory, PostgreSQL worker limits, CPU,
-container or cgroup limits when discoverable, connection limits, and the
-configured pg_trickle resource policy. Labels such as `laptop`, `managed`, and
-`dedicated` may explain the selected settings, but labels do not drive the
-decision.
+Add a constant-size discovery API for `external_graph_refresh` and
+`output_delta_consumer`, with independent major and minor versions, lifecycle
+state, source-class admission, bounds, and encoding information. During this
+release, graph refresh remains experimental or disabled and output deltas
+remain absent, experimental, or disabled.
 
-`pgtrickle.active_profile()` and `explain()` report every detected constraint,
-selected value, override, and missing signal. Standard benchmark deployments
-must need no manual tuning.
+### GV1-2: Canonical execution contracts
 
-### PP-2: Honest resource guarantees
+Add `stream_table_contract()` and `graph_contract()` over deterministic typed
+encodings. Contracts include every result-affecting property, source identity,
+dependency edge, rewrite and DVM contract version, orchestration mode, and
+database-instance identity. Contract generations and digests change for every
+tracked mutation and remain stable for operational tuning that cannot affect
+results.
 
-Every resource has one documented enforcement class.
+Graph closure, member order, lock order, and graph digest are canonical.
+Unsupported cycles, source classes, temporary relations, cross-database
+references, and malformed catalog state fail closed.
 
-| Class | Resources | Behavior |
-|-------|-----------|----------|
-| Hard bound | Extension-managed memory, worker count, retained internal history, internal queue size | Reject or pause work before crossing the configured limit. |
-| Throttled | CPU use, concurrent refreshes, connections | Reduce admission and concurrency while preserving committed changes. |
-| Forecast and react | WAL volume and disk growth caused by continued source activity | Warn, throttle, suspend, or breach freshness deliberately before correctness is at risk. |
+### GV1-3: Durable external orchestration
 
-`pgtrickle.disk_usage()` reports current and projected use by stream table.
-`health_check()` warns before forecast growth consumes the configured headroom.
-The documentation does not claim an absolute bound where PostgreSQL or source
-activity prevents one.
+Add `MANAGED` and `EXTERNAL` orchestration modes plus an authorized
+`set_orchestration_mode()` lifecycle operation. `EXTERNAL` members are excluded
+from scheduler dispatch across process restart, failover, backup, restore,
+clone activation, and extension upgrade. Operational pause remains separate
+from durable ownership.
 
-### PP-3: Progress reporting
+Create, bulk-create, alter, repair, drop, status, scheduler admission, dump,
+restore, and upgrade paths must all honor the mode and the canonical lifecycle
+lock protocol. Existing stream tables upgrade to `MANAGED`.
 
-A `pg_stat_progress_pgtrickle`-style view reports initial population, FULL
-refresh, rebuild after `ALTER`, and reinitialization after repair. Each row has
-a stable operation identifier, phase, rows processed, estimated rows, elapsed
-time, and last progress timestamp.
+### GV1-4: Authorization and lifecycle integrity
 
-### PP-4: Stable error surface
-
-Audit every user-visible error and warning. Each operational condition has a
-stable machine-readable identifier, an accurate SQLSTATE, object-specific
-detail, and an actionable hint. Automation must not parse message text.
-
-A CI check prevents undocumented identifiers and errors without a documented
-remediation from entering SQL-facing code.
-
-### PP-6: Predefined roles
-
-Provide `pg_trickle_admin`, `pg_trickle_operator`, and `pg_trickle_reader` as a
-user-facing mapping onto the ACL and ownership model from v0.84.0. The roles do
-not create a second authorization layer. Positive and negative tests cover each
-lifecycle and diagnostic operation, including RLS and `SECURITY DEFINER`
-boundaries.
+Require the caller to own or hold explicit authority over every graph member
+and source operation. Pin role dependencies through PostgreSQL shared
+dependencies or an equivalent reuse-safe mechanism. Harden every function
+against hostile `search_path`, RLS boundaries, guessed object identifiers, and
+private-relation disclosure.
 
 ## Exit criteria
 
-- [ ] Standard benchmark deployments require no manual tuning, and every
-      automatic choice reports its resource evidence
-- [ ] Every resource has a documented enforcement class and a pressure test
-- [ ] Pressure tests degrade by throttling, explicit freshness breach, or
-      suspension without losing committed changes
-- [ ] Progress reporting covers every long-running lifecycle operation
-- [ ] User-facing errors have stable identifiers, SQLSTATEs, details, and
-      actionable hints
-- [ ] Predefined roles match the v0.84.0 ACL matrix and pass positive and
-      negative boundary tests
+- [ ] A conformance extension discovers both capabilities independently and
+      rejects unsupported versions without package-version inference
+- [ ] Canonical contract fixtures pin encoding, generation changes, graph
+      closure, member ordering, and digests
+- [ ] Durable `EXTERNAL` ownership survives restart, backup and restore,
+      failover, clone activation, and supported upgrade
+- [ ] Scheduler, lifecycle, and dump paths cannot refresh or silently transfer
+      ownership of an external graph
+- [ ] Security tests cover unauthorized and mixed-owner graphs, hostile
+      `search_path`, RLS sources, role drop and reuse, and malformed catalogs
+- [ ] No public API exposes or requires private catalogs, buffers, frontiers,
+      scheduler tables, generated columns, or a Rust ABI

--- a/roadmap/v0.94.0.md
+++ b/roadmap/v0.94.0.md
@@ -1,80 +1,82 @@
-# v0.94.0 — Monitoring, Assurance & Packaging
+# v0.94.0 — Strict Transactional Graph Refresh
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"I can monitor, verify, install, and upgrade the supported build."*
+> **User promise:** *"Refresh a private graph atomically inside one transaction with exact boundaries."*
 > **Blocked by:** [v0.93.0](v0.93.0.md)
-> **Renumbered:** previously v0.93.0. This is the final feature release.
+> **Delivery plan:** Phase 2 of
+> [Proposal: V1 Composable Refresh and Durable Delta Contracts](../plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)
 
 ## Theme
 
-Finish the monitoring contract, run release assurance on one candidate commit,
-and prove that each supported package can install and upgrade. After this
-release, CI enforces the feature freeze.
+Complete Graph V1 with strict synchronous graph refresh. Validate and lock the
+entire graph before execution, compute one immutable and complete source
+boundary, refresh every member in topological order through the common
+transactional finalizer, and return one structured result inside the caller's
+outer PostgreSQL transaction.
 
-The 72-hour soak is a release gate. A separate longevity environment looks for
-problems that take longer than one release run to appear. Package readiness is
-based on reproducible artifacts and smoke tests, not a third-party repository's
-acceptance schedule.
+Graph V1 remains disabled or experimental until this release's independent
+acceptance gate passes. Delta V1 is not part of this gate.
 
 ## Items
 
-### PP-5: Monitoring integration
+### GV1-5: Strict graph-refresh context
 
-- Prometheus exposes the full stable metric set. A shipped Grafana dashboard
-  and alert rules cover SLA breach, suspension, CDC lag growth, disk trend,
-  repeated FULL fallback, and backlog growth.
-- CI validates OpenTelemetry spans from v0.81.0 against a real collector. Span
-  names and attributes are a documented compatibility surface.
-- `health_check()` remains the single operational health entry point and has a
-  stable schema suitable for automation.
+Add `refresh_graph_strict()` over one structured internal graph-refresh
+context. Reject duplicate roots, unsupported cycles or sources, temporary or
+cross-database relations, `IMMEDIATE` members, non-`EXTERNAL` members, stale
+contracts, and unauthorized members before the first node executes.
 
-### PP-7: Soak, compatibility, and regression gates
+Acquire all member and admitted-source locks in canonical order before
+execution. Busy work, lock timeout, concurrent lifecycle change, or contract
+mismatch is a stable error, never a notice-and-skip success.
 
-- **Release soak:** Run 72 hours across multiple databases with schema changes,
-  restarts, injected failures, and mixed freshness targets. Require zero result
-  deviations and no unbounded memory, disk, or catalog growth.
-- **Upgrade matrix:** Run every pair in the bounded v1.0 support manifest from
-  v0.92.0 with an active workload and real old binaries. For v1.0, this is
-  v0.40.0 through the latest v0.95.x release on PostgreSQL 18.
-- **Performance gates:** Enforce refresh throughput, write-path impact,
-  TPC-H/Nexmark latency, memory, WAL, and CPU regression budgets.
-- **Real workloads:** Run representative application schemas and query shapes
-  continuously so isolated benchmarks do not define release readiness.
+### GV1-6: Complete source-boundary proof
 
-The 72-hour soak and upgrade matrix must pass on the same candidate commit.
+Compute one immutable source-boundary manifest after locks are held. Every
+admitted source has a typed identity, capture mode, durable position, and proof
+status. Unknown, partial, missing, or unverifiable boundaries abort the graph;
+several incomparable source positions are never collapsed into a timestamp.
 
-### PP-7b: Longevity environment
+Bind graph refresh identifiers and manifests to the v0.92.0
+database-instance identity so clones cannot reuse source-system evidence.
 
-Keep at least one longer-lived deployment running across candidate builds. It
-tracks catalog and retained-state growth, memory creep, repeated repair cycles,
-long-horizon scheduler behavior, WAL amplification, and disk amplification.
+### GV1-7: Atomic graph execution and result
 
-The environment informs release readiness. It does not synchronously block
-every commit.
+Execute the complete closure synchronously in canonical topological order.
+Every member uses the same prepare, owner-execute, and transactional finalize
+path as ordinary refresh. Return the requested and actual graph digests,
+contract generations, graph refresh identifier, complete boundary manifest,
+and exact or explicitly qualified per-node outcomes.
 
-### PP-8: Packaging and install experience
+The function performs no commit. Stream-table contents, frontiers, cleanup,
+history, graph metadata, and coordinator-owned writes commit or roll back with
+the caller's transaction. No-data execution still validates contracts, locks,
+and boundaries.
 
-Produce each supported package reproducibly, then run install and upgrade smoke
-tests that create and refresh a stream table. Publication automation must be
-ready for PGXN, apt/rpm via PGDG, Docker/GHCR, CloudNativePG, and source builds.
+### GV1-8: Graph diagnostics and conformance
 
-Third-party repository acceptance may complete asynchronously. It does not
-delay the internal feature freeze when the artifact, smoke tests, and
-publication automation are ready.
+Expose graph status, health rows, history, stable error identifiers, and
+metrics for strict refreshes, busy conflicts, contract failures, and boundary
+failures. Publish operational documentation, transaction limits, source-class
+admission, and capacity bounds.
 
 ## Exit criteria
 
-- [ ] Grafana dashboard and alert rules ship with tests. CI validates OTel
-      against a real collector
-- [ ] The 72-hour soak and every pair in the bounded v1.0 upgrade matrix pass on
-      the same candidate commit
-- [ ] Performance regression gates cover throughput, median, p95, and p99 where
-      useful, memory, WAL, CPU, and foreground write impact
-- [ ] The longevity environment reports no unexplained cumulative growth or
-      repeated recovery loop
-- [ ] Every supported artifact builds reproducibly and passes install and
-      upgrade smoke tests
-- [ ] Publication automation is ready. External repository acceptance is
-      tracked separately
-- [ ] CI enforces the feature freeze after this release
+- [ ] A conformance extension refreshes one-node, chain, shared-upstream, and
+      diamond graphs against one complete source boundary
+- [ ] It reads complete terminal tables and publishes coordinator-owned state
+      before committing the same outer transaction
+- [ ] Coordinator failure rolls back graph contents, frontiers, history, and
+      coordinator state without a committed member subset
+- [ ] Concurrent refresh, alter, repair, mode change, and drop tests prove the
+      canonical lock order and strict busy behavior
+- [ ] Source writers on both sides of the safe boundary produce no lost or
+      double-consumed changes
+- [ ] Every unadmitted or unverifiable source class fails before member
+      execution
+- [ ] Crash, restore, clone, and supported-upgrade tests preserve contracts and
+      reject stale database-instance identity
+- [ ] `external_graph_refresh` advertises stable major version 1 only after its
+      transaction, concurrency, security, recovery, upgrade, and performance
+      gates pass

--- a/roadmap/v0.95.0.md
+++ b/roadmap/v0.95.0.md
@@ -1,0 +1,89 @@
+# v0.95.0 — Durable Typed Output Deltas
+
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"Consume output changes without private buffers or expensive full scans."*
+> **Blocked by:** [v0.94.0](v0.94.0.md)
+> **Delivery plan:** Phase 3 of
+> [Proposal: V1 Composable Refresh and Durable Delta Contracts](../plans/PROPOSAL_V1_COMPOSABLE_REFRESH_AND_DELTA_CONTRACTS.md)
+
+## Theme
+
+Add durable acknowledged typed output deltas for coordinators that have proven
+complete terminal scans too expensive. Consumers receive exact logical changes
+when available and an explicit `FULL_INVALIDATION` otherwise, with retention,
+backpressure, resnapshot, recovery, and owner-only access.
+
+Delta V1 depends on a compatible enabled Graph V1 but has its own acceptance
+gate. `output_delta_consumer` remains absent, disabled, or experimental until
+every gate in this release passes; failure must not weaken Graph V1's complete
+terminal-read path.
+
+## Items
+
+### DV1-1: Durable consumers and proven baselines
+
+Add consumer registration and status for `EXTERNAL` stream tables. New
+consumers start in `RESNAPSHOT_REQUIRED` unless pg_trickle proves a pristine,
+empty `CURRENT` origin. Registration, state, owner, output-contract digest,
+row-identity version, cursor, and database-instance identity are durable and
+reuse-safe.
+
+### DV1-2: Transactional typed batches
+
+Maintain one shared logical output log per opted-in stream table and expose it
+through a read-only typed relation. Each refresh writes one immutable batch
+with a gap-free transactional token and either complete delete-and-insert rows
+or one truthful `FULL_INVALIDATION`. No-data refresh writes an exact zero-row
+batch. A full path never performs an unbounded diff solely for this API.
+
+Batch creation belongs to the common finalizer so the stream-table frontier
+cannot commit without its batch metadata and complete payload or invalidation.
+Private downstream change buffers and physical storage names remain private.
+
+### DV1-3: Acknowledgement and resnapshot
+
+Add ordered batch inspection, transactional acknowledgement, and a
+transaction-scoped resnapshot protocol. Exact batches transform the prior
+multiset into the full result at the batch boundary. Invalidation requires a
+complete terminal read before acknowledgement. Baseline reads, coordinator
+writes, cursor activation, output batches, and acknowledgements commit or roll
+back together.
+
+### DV1-4: Retention and backpressure
+
+Store payload once regardless of consumer count. Cleanup advances only through
+the slowest `ACTIVE` or `PAUSED` cursor and any prepared binding. Advisory
+limits report lag; hard limits block refresh before log-head, metadata, or
+payload mutation. Only an explicit authorized transition records a
+discarded-through token and makes unacknowledged history eligible for cleanup.
+
+### DV1-5: Recovery, lifecycle, and security
+
+Fail closed on missing history or storage, contract mismatch, unknown row
+identity, stale database-instance identity, relation rebinding, role drop, or
+invalid acknowledgement. Contract-changing alterations and return to
+`MANAGED` mode are rejected while consumers exist. Drop requires an explicit
+authorized cascade. Owner-only access covers retained deleted rows as well as
+current output.
+
+## Exit criteria
+
+- [ ] Exact-batch algebra matches old and new PostgreSQL multisets across
+      inserts, deletes, updates, duplicates, aggregates, joins, set operations,
+      TopK, no-op changes, and supported full paths
+- [ ] Unsupported exact full output produces one `FULL_INVALIDATION` with no
+      partial payload
+- [ ] Multiple consumers share one typed payload while cleanup follows every
+      retaining cursor and prepared binding
+- [ ] Refresh and acknowledgement rollback restore payload, cursor, and log
+      head without a token gap
+- [ ] Hard retention pressure blocks before any batch or frontier mutation;
+      resnapshot requires an explicit separately committed transition
+- [ ] Recovery, restore, clone, relation-rebinding, role-dependency, and upgrade
+      tests produce the documented state and reason code
+- [ ] Security tests cover guessed tokens, direct DML, RLS boundaries, and
+      retained deleted-row access
+- [ ] `output_delta_consumer` advertises stable major version 1 only after its
+      algebra, transaction, retention, recovery, clone, security, upgrade, and
+      zero-disabled-overhead gates pass

--- a/roadmap/v0.96.0.md
+++ b/roadmap/v0.96.0.md
@@ -1,0 +1,84 @@
+# v0.96.0 — Defaults, Bounds & Diagnosis
+
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"I can run this for years without hidden resource or repair behavior."*
+> **Blocked by:** [v0.95.0](v0.95.0.md)
+> **Renumbered:** previously v0.93.0. Graph V1 and Delta V1 are in
+> [v0.93.0](v0.93.0.md) through [v0.95.0](v0.95.0.md). Monitoring, assurance,
+> and packaging are in [v0.97.0](v0.97.0.md).
+
+## Theme
+
+Make the default configuration derive from real resource constraints. Define
+which resources pg_trickle can bound, which it can throttle, and which it can
+only forecast and react to. Long operations, errors, and privilege decisions
+must be inspectable through stable interfaces.
+
+This release is part of the mandatory v1.0 operational critical path.
+
+## Items
+
+### PP-1: Resource-based defaults
+
+Automatic configuration uses available memory, PostgreSQL worker limits, CPU,
+container or cgroup limits when discoverable, connection limits, and the
+configured pg_trickle resource policy. Labels such as `laptop`, `managed`, and
+`dedicated` may explain the selected settings, but labels do not drive the
+decision.
+
+`pgtrickle.active_profile()` and `explain()` report every detected constraint,
+selected value, override, and missing signal. Standard benchmark deployments
+must need no manual tuning.
+
+### PP-2: Honest resource guarantees
+
+Every resource has one documented enforcement class.
+
+| Class | Resources | Behavior |
+|-------|-----------|----------|
+| Hard bound | Extension-managed memory, worker count, retained internal history, internal queue size | Reject or pause work before crossing the configured limit. |
+| Throttled | CPU use, concurrent refreshes, connections | Reduce admission and concurrency while preserving committed changes. |
+| Forecast and react | WAL volume and disk growth caused by continued source activity | Warn, throttle, suspend, or breach freshness deliberately before correctness is at risk. |
+
+`pgtrickle.disk_usage()` reports current and projected use by stream table.
+`health_check()` warns before forecast growth consumes the configured headroom.
+The documentation does not claim an absolute bound where PostgreSQL or source
+activity prevents one.
+
+### PP-3: Progress reporting
+
+A `pg_stat_progress_pgtrickle`-style view reports initial population, FULL
+refresh, rebuild after `ALTER`, and reinitialization after repair. Each row has
+a stable operation identifier, phase, rows processed, estimated rows, elapsed
+time, and last progress timestamp.
+
+### PP-4: Stable error surface
+
+Audit every user-visible error and warning. Each operational condition has a
+stable machine-readable identifier, an accurate SQLSTATE, object-specific
+detail, and an actionable hint. Automation must not parse message text.
+
+A CI check prevents undocumented identifiers and errors without a documented
+remediation from entering SQL-facing code.
+
+### PP-6: Predefined roles
+
+Provide `pg_trickle_admin`, `pg_trickle_operator`, and `pg_trickle_reader` as a
+user-facing mapping onto the ACL and ownership model from v0.84.0. The roles do
+not create a second authorization layer. Positive and negative tests cover each
+lifecycle and diagnostic operation, including RLS and `SECURITY DEFINER`
+boundaries.
+
+## Exit criteria
+
+- [ ] Standard benchmark deployments require no manual tuning, and every
+      automatic choice reports its resource evidence
+- [ ] Every resource has a documented enforcement class and a pressure test
+- [ ] Pressure tests degrade by throttling, explicit freshness breach, or
+      suspension without losing committed changes
+- [ ] Progress reporting covers every long-running lifecycle operation
+- [ ] User-facing errors have stable identifiers, SQLSTATEs, details, and
+      actionable hints
+- [ ] Predefined roles match the v0.84.0 ACL matrix and pass positive and
+      negative boundary tests

--- a/roadmap/v0.97.0.md
+++ b/roadmap/v0.97.0.md
@@ -1,0 +1,86 @@
+# v0.97.0 — Monitoring, Assurance & Packaging
+
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"I can monitor, verify, install, and upgrade the supported build."*
+> **Blocked by:** [v0.96.0](v0.96.0.md)
+> **Renumbered:** previously v0.94.0. This is the final feature release.
+
+## Theme
+
+Finish the monitoring contract, run release assurance on one candidate commit,
+and prove that each supported package can install and upgrade. After this
+release, CI enforces the feature freeze.
+
+The 72-hour soak is a release gate. A separate longevity environment looks for
+problems that take longer than one release run to appear. Package readiness is
+based on reproducible artifacts and smoke tests, not a third-party repository's
+acceptance schedule.
+
+## Items
+
+### PP-5: Monitoring integration
+
+- Prometheus exposes the full stable metric set. A shipped Grafana dashboard
+  and alert rules cover SLA breach, suspension, CDC lag growth, disk trend,
+  repeated FULL fallback, external graph refresh failures, output-delta
+  consumer lag, and backlog growth.
+- CI validates OpenTelemetry spans from v0.81.0 against a real collector. Span
+  names and attributes are a documented compatibility surface.
+- `health_check()` remains the single operational health entry point and has a
+  stable schema suitable for automation.
+
+### PP-7: Soak, compatibility, and regression gates
+
+- **Release soak:** Run 72 hours across multiple databases with schema changes,
+  restarts, injected failures, mixed freshness targets, external graph
+  refreshes, and output-delta consumers. Require zero result deviations and no
+  unbounded memory, disk, retained-output, or catalog growth.
+- **Upgrade matrix:** Run every pair in the bounded v1.0 support manifest from
+  v0.92.0 with an active workload and real old binaries. For v1.0, this is
+  v0.40.0 through the latest v0.98.x release on PostgreSQL 18.
+- **Performance gates:** Enforce refresh throughput, write-path impact,
+  graph-refresh overhead, output-log amplification, TPC-H/Nexmark latency,
+  memory, WAL, and CPU regression budgets.
+- **Real workloads:** Run representative application schemas and query shapes
+  continuously so isolated benchmarks do not define release readiness.
+
+The 72-hour soak and upgrade matrix must pass on the same candidate commit.
+
+### PP-7b: Longevity environment
+
+Keep at least one longer-lived deployment running across candidate builds. It
+tracks catalog and retained-state growth, memory creep, repeated repair cycles,
+long-horizon scheduler behavior, WAL amplification, output-delta retention,
+and disk amplification.
+
+The environment informs release readiness. It does not synchronously block
+every commit.
+
+### PP-8: Packaging and install experience
+
+Produce each supported package reproducibly, then run install and upgrade smoke
+tests that create and refresh a stream table. Publication automation must be
+ready for PGXN, apt/rpm via PGDG, Docker/GHCR, CloudNativePG, and source builds.
+
+Third-party repository acceptance may complete asynchronously. It does not
+delay the internal feature freeze when the artifact, smoke tests, and
+publication automation are ready.
+
+## Exit criteria
+
+- [ ] Grafana dashboard and alert rules ship with tests. CI validates OTel
+      against a real collector
+- [ ] Graph V1 and Delta V1 conformance suites pass against the packaged build
+- [ ] The 72-hour soak and every pair in the bounded v1.0 upgrade matrix pass on
+      the same candidate commit
+- [ ] Performance regression gates cover throughput, median, p95, and p99 where
+      useful, memory, WAL, CPU, output-log amplification, and foreground write
+      impact
+- [ ] The longevity environment reports no unexplained cumulative growth or
+      repeated recovery loop
+- [ ] Every supported artifact builds reproducibly and passes install and
+      upgrade smoke tests
+- [ ] Publication automation is ready. External repository acceptance is
+      tracked separately
+- [ ] CI enforces the feature freeze after this release

--- a/roadmap/v0.98.x.md
+++ b/roadmap/v0.98.x.md
@@ -1,9 +1,10 @@
-# v0.95.x — Stabilization
+# v0.98.x — Stabilization
 
 > **Status:** Planned
 > **Scope:** Variable
 > **User promise:** *"The release candidate contains less risk, not more scope."*
-> **Blocked by:** [v0.94.0](v0.94.0.md)
+> **Blocked by:** [v0.97.0](v0.97.0.md)
+> **Renumbered:** previously v0.95.x.
 
 ## Theme
 
@@ -15,12 +16,15 @@ conservative is a valid release outcome.
 ## Allowed work
 
 - correctness and security fixes
-- bugs found by the soak, longevity environment, upgrade matrix, or users
+- bugs found by the soak, longevity environment, upgrade matrix, conformance
+  suites, or users
 - compatibility, packaging, and documentation fixes
 - missing tests and clearer diagnostics
 - dependency cleanup and removal of unnecessary configuration
 - performance regression fixes
 - disabling or narrowing optimizer and controller rules that lack evidence
+- correctness-preserving Delta V1 fixes; release candidates remain blocked
+      while its independent conformance gate is not green
 - explicit rejection of combinations that cannot be supported safely
 
 New SQL functions, catalog capabilities, query coverage, and operational
@@ -29,13 +33,14 @@ features wait until after v1.0.
 ## Exit criteria
 
 - [ ] No known correctness or security blocker remains
-- [ ] The exact oracle, upgrade matrix, 72-hour soak, package smoke tests, and
-      performance regression gates pass on the release-candidate baseline
+- [ ] The exact oracle, Graph V1 and Delta V1 conformance suites, upgrade
+      matrix, 72-hour soak, package smoke tests, and performance regression
+      gates pass on the release-candidate baseline
 - [ ] Every supported fallback and suspension has a stable reason code and a
       support-matrix entry
 - [ ] Unstable optimizer or controller decisions are narrowed, disabled, or
       removed
 - [ ] API, catalog, GUC, monitoring, and package contracts match the frozen
-      v0.94.0 feature surface
+      v0.97.0 feature surface
 - [ ] Remaining known limitations are documented as explicit v1.0 non-goals or
       post-v1.0 work

--- a/roadmap/v1.0.0.md-full.md
+++ b/roadmap/v1.0.0.md-full.md
@@ -16,8 +16,11 @@ The stable contract is:
 > an explicit reason. Schema evolution, backup, restore, cloning, upgrade,
 > restart, and CDC failure have defined and tested behavior. Resource use is
 > bounded, throttled, or reported with a forecast and reaction. Stable
-> monitoring and diagnostic interfaces expose those decisions, and CI gates
-> correctness, upgrades, and performance.
+> monitoring and diagnostic interfaces expose those decisions. Graph V1 gives
+> coordinating extensions canonical contracts and atomic refresh against one
+> proven boundary. Delta V1 gives them durable exact-or-invalidation output
+> batches without exposing private state. CI gates correctness, upgrades,
+> conformance, and performance.
 
 ### The real 1.0 gate
 
@@ -26,7 +29,7 @@ decides whether 1.0 ships is:
 
 > **No known correctness issues, and boring upgrades.**
 
-After the v0.94.0 feature freeze, v0.95.x accepts only bug fixes,
+After the v0.97.0 feature freeze, v0.98.x accepts only bug fixes,
 documentation, tests, compatibility work, packaging, performance regression
 fixes, and simplification. It also narrows or removes unproven optimizer and
 controller behavior before the release-candidate series.
@@ -46,8 +49,9 @@ promised not to have.
 | G4 | 72-hour soak with schema changes, restarts and failure injection — zero correctness deviations, no unbounded growth. |
 | G5 | Published benchmarks (write-path overhead, refresh throughput, TPC-H/Nexmark) enforced as blocking regression gates. |
 | G6 | Documentation matches reality: every `#[pg_extern]` documented, every user-facing GUC justified, every claim in the README reproducible from a shipped test. |
-| G7 | API, catalog schema, GUC, monitoring, and package surfaces remain compatible with the frozen v0.94.0 feature baseline. |
+| G7 | API, catalog schema, GUC, monitoring, and package surfaces remain compatible with the frozen v0.97.0 feature baseline. |
 | G8 | At least one release candidate has been published and used, with no unresolved blocker reported against it. |
+| G9 | Graph V1 and Delta V1 conformance suites pass against the release artifacts, including transaction, boundary, retention, recovery, clone, security, and upgrade cases. |
 
 ### Explicit non-goals
 
@@ -62,7 +66,7 @@ v1.0 does not require:
 - removal of the correctness-preserving FULL fallback
 
 > **Note on effort estimates.** The hour figures below cover release
-> engineering only. G1–G8 are not estimated in hours because they are
+> engineering only. G1–G9 are not estimated in hours because they are
 > conditions, not tasks: their cost is however long it takes for the soak, the
 > upgrade matrix and the rc series to come back clean. Do not read the
 > "~46–86 hours" total as the cost of reaching 1.0.
@@ -119,7 +123,7 @@ v1.0 does not require:
 > **v1.0.0 total: ~46–86 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h + OTel/signing/SBOM/provenance/MDB ~12–20h)
 
 **Exit criteria:**
-- [ ] G1–G8: the stability-contract gates above are all met
+- [ ] G1–G9: the stability-contract gates above are all met
 - [ ] At least one `v1.0.0-rc.N` published, with no unresolved blocker
 - [ ] Published on PGXN (stable) and apt/rpm via PGDG
 - [ ] Docker Hub image published (`pgtrickle/pg_trickle:1.0.0-pg18` and `:latest`)

--- a/roadmap/v1.7.0.md-full.md
+++ b/roadmap/v1.7.0.md-full.md
@@ -10,7 +10,7 @@
 > This was originally planned for v0.82.0–v0.83.0 (pre-resequencing) and has
 > been moved past 1.0 deliberately. Pre-1.0 effort is better spent making a
 > single PostgreSQL instance go surprisingly far (v0.88.0–v0.89.0) and making
-> the product trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.95.x) than on a second
+> the product trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.98.x) than on a second
 > process most users will never deploy. Everything here remains **strictly
 > optional**: a deployment without external processes continues to work exactly
 > as it does today.

--- a/roadmap/v1.9.0.md-full.md
+++ b/roadmap/v1.9.0.md-full.md
@@ -10,7 +10,7 @@
 > This is explicitly the least certain item on the roadmap. It is recorded here
 > because the design work exists, not because it is committed. It will only be
 > built if real users ask for it — a single PostgreSQL instance, made fast
-> (v0.88.0–v0.89.0) and trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.95.x), covers
+> (v0.88.0–v0.89.0) and trustworthy (v0.82.0–v0.87.0, v0.90.0–v0.98.x), covers
 > the overwhelming majority of the problem pg_trickle exists to solve.
 
 ### Multi-cluster federation


### PR DESCRIPTION
## Summary

Define versioned extension-to-extension contracts for coordinated graph refresh, durable output consumption, and long-running work over immutable prepared graph evidence. The V1 proposal separates correctness-critical graph coordination from optional delta consumption, while the V2 proposal builds on Graph V1 with freeze-in-place prepared generations and an independently gated delta-binding optimization. Together, the proposals give `pg_mdm` and similar coordinators a supported path for both single-transaction publication and resumable cross-transaction processing without exposing `pg_trickle` internals.

## Changes

- Define `external_graph_refresh` as the V1 correctness contract for execution-contract discovery, durable `EXTERNAL` orchestration, strict transactional graph refresh, and mandatory complete source boundaries.
- Define `output_delta_consumer` as a separate V1 optimization with typed output batches, transactional cursors, explicit invalidation, retention, resnapshot, and recovery rules.
- Pin graph and stream-table execution identity through opaque object identities, `contract_generation`, canonical typed digests, and clone-safe `database_instance_id` values.
- Define `prepared_graph_generation` as a post-1.0 core capability that freezes current graph storage under durable member leases for repeatable reads across transactions.
- Define `prepared_output_delta_binding` independently so core prepared publication remains correct through complete terminal scans when Delta V1 is unavailable.
- Specify canonical request and generation digests, idempotent uncertain-commit recovery, content epochs, member lock ordering, prepared validity, future refresh continuity, promotion, abandonment, and fail-closed recovery.
- Align prepared consumer states with Delta V1 `EXACT`, `FULL_INVALIDATION`, and `RESNAPSHOT_REQUIRED` semantics, including explicit cross-transaction prepared resnapshot rules.
- Split delivery, testing, and acceptance into independent Graph V1, Delta V1, core prepared-generation, and prepared-delta gates.

## Testing

- `just fmt` - passes
- `just lint` - passes with zero warnings
- `git diff --check` - passes
- VS Code diagnostics - no errors

## Notes

- This PR changes proposal documentation only; it does not change runtime behavior or SQL APIs.
- The V2 implementation remains intentionally unscheduled until the roadmap assigns a post-1.0 release.
- Database-backed test tiers were not run because the changes are documentation-only.
