### PR TITLE
docs: define v0.98 stabilization and qualification releases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -483,11 +483,11 @@ diagnostics, and a support-matrix entry.
 
 A September 2026 assessment extends the pre-1.0 sequence beyond v0.98.x. The
 [assessment](plans/pg-trickle-assessment-and-pre-1.0-roadmap.md) keeps the
-PostgreSQL-native architecture and conservative fallbacks, but identifies
-remaining gaps in WAL receipt durability, graph conformance, refresh-path
-parity, product documentation, and release evidence. v0.98.x remains an
-interim stabilization series. v0.99.0 through v0.104.0 close those gaps and
-improve the core IVM engine. v0.105.x performs final qualification.
+PostgreSQL-native architecture and conservative fallbacks. A follow-up
+[assessment of v0.93.0 through v0.97.0](roadmap/v0.98.x.md) identifies release
+blockers that must close first. v0.98.0 contains those risks, and v0.98.1
+qualifies the corrected baseline. v0.99.0 through v0.104.0 then improve and
+freeze the core IVM engine. v0.105.x performs final qualification.
 
 | Version | Theme | User promise | Status | Scope | Full details |
 |---------|-------|--------------|--------|-------|--------------|
@@ -525,8 +525,9 @@ improve the core IVM engine. v0.105.x performs final qualification.
 | [v0.95.0](roadmap/v0.95.0.md) | Durable Typed Output Deltas: typed output-delta relation, consumer registration and cursors, exact-or-invalidation batches, retention and backpressure, and resnapshot | "Consume output changes without private buffers or expensive full scans." | ✅ Released | Large | [Full details](roadmap/v0.95.0.md) |
 | [v0.96.0](roadmap/v0.96.0.md) | Defaults, Bounds & Diagnosis: resource-based defaults, honest hard-bound, throttled, and forecast-and-react guarantees, progress reporting, stable operational error identifiers, and predefined roles | "I can run this for years without hidden resource or repair behavior." | ✅ Released | Large | [Full details](roadmap/v0.96.0.md) |
 | [v0.97.0](roadmap/v0.97.0.md) | Monitoring, Assurance & Packaging: tested Grafana and OTel contracts, same-commit soak and upgrade matrix, performance gates, a longevity environment, reproducible package smoke tests, and a release-evidence baseline | "I can monitor, verify, install, and upgrade the supported build." | ✅ Released | Large | [Full details](roadmap/v0.97.0.md) |
-| [v0.98.x](roadmap/v0.98.x.md) | Interim Stabilization: blockers, compatibility, tests, diagnostics, packaging, documentation, dependency cleanup, and removal or narrowing of unproven optimizer and controller behavior | "The next development baseline contains less risk, not more scope." | Planned | Variable | [Full details](roadmap/v0.98.x.md) |
-| [v0.99.0](roadmap/v0.99.0.md) | Verified Capabilities and Product Truth: executable capability manifest, accurate documentation, graph conformance, and release evidence | "I can determine whether my query will work and how pg_trickle will maintain it." | Planned | Medium | [Full details](roadmap/v0.99.0.md) |
+| [v0.98.0](roadmap/v0.98.0.md) | Risk Containment and Contract Truth: safe capture defaults, fail-closed Graph V1 and Delta V1 admission, operational contract repair, and a fixed qualification contract | "Known correctness risks are fixed or unavailable in stable operation." | Planned | Medium | [Full details](roadmap/v0.98.0.md) |
+| [v0.98.1](roadmap/v0.98.1.md) | Qualified Interim Baseline: candidate-bound correctness, upgrades, packages, soak, longevity, performance gates, and release evidence | "The published build passed its required tests on the artifact that ships." | Planned | Large | [Full details](roadmap/v0.98.1.md) |
+| [v0.99.0](roadmap/v0.99.0.md) | Verified Capabilities and Product Truth: executable capability manifest, accurate documentation, verified Graph and Delta declarations, and release evidence | "I can determine whether my query will work and how pg_trickle will maintain it." | Planned | Medium | [Full details](roadmap/v0.99.0.md) |
 | [v0.100.0](roadmap/v0.100.0.md) | Unified Transactional IVM Execution: one refresh contract across scheduled, manual, graph, and lifecycle paths | "A graph remains incremental when I refresh it manually or through a coordinator." | Planned | Large | [Full details](roadmap/v0.100.0.md) |
 | [v0.101.0](roadmap/v0.101.0.md) | Exact Relational State and Semantic Depth: incremental multiplicity state, narrow DISTINCT state, numeric fidelity, and deliberate identity coverage | "Ordinary SQL workloads remain incremental through duplicates, deletions, and repeated changes." | Planned | Large | [Full details](roadmap/v0.101.0.md) |
 | [v0.102.0](roadmap/v0.102.0.md) | Output-Sensitive Delta Performance: measured operator locality, better delta statistics, and evidence-gated rewrites | "Small relevant changes avoid unnecessary scans, and expensive refreshes explain their cost." | Planned | Large | [Full details](roadmap/v0.102.0.md) |
@@ -537,17 +538,18 @@ improve the core IVM engine. v0.105.x performs final qualification.
 ### Toward v1.0
 
 The mandatory lifecycle path is v0.87.17 → v0.88.0 → v0.91.0 → v0.92.0
-→ v0.93.0 → v0.94.0 → v0.95.0 → v0.96.0 → v0.97.0 → v0.98.x
+→ v0.93.0 → v0.94.0 → v0.95.0 → v0.96.0 → v0.97.0 → v0.98.0 → v0.98.1
 → v0.99.0 → v0.100.0 → v0.101.0 → v0.102.0 → v0.103.0 → v0.104.0
 → v0.105.x → release candidate → v1.0.0.
 v0.89.0 and v0.90.0 form a parallel performance and product track after
 v0.88.0. Their research and unproven automation do not block lifecycle work.
 
-v0.98.x is an interim stabilization-only series for bugs, benchmarks,
-compatibility, upgrades, documentation, real-world workloads, and
-simplification. v0.99.0 through v0.104.0 then execute the finite IVM program
-defined by the September 2026 assessment. The final feature freeze begins after
-v0.104.0. v0.105.x accepts only qualification work and release-blocking fixes.
+v0.98.0 resolves known correctness and contract risks or disables the affected
+behavior. v0.98.1 freezes that result and qualifies one exact candidate. The
+[series assessment](roadmap/v0.98.x.md) defines the boundary. v0.99.0 through
+v0.104.0 then execute the finite IVM program defined by the September 2026
+assessment. The final feature freeze begins after v0.104.0. v0.105.x accepts
+only qualification work and release-blocking fixes.
 
 The release-candidate series follows v0.105.x. `v1.0.0-rc.N` ships first, and
 1.0.0 is tagged only after a candidate has been in the field without a new
@@ -564,9 +566,10 @@ are outside this project's control and do not delay the finished PG 18 contract.
 > V2 encoding, engine integration, and intentional stream-table recreation
 > workflow before vectorized DVM changes begin. v0.91.0 and v0.92.0 split
 > schema evolution from recovery and upgrade work. v0.93.0 through v0.95.0
-> deliver separately gated Graph V1 and Delta V1 contracts. v0.97.0 establishes
-> the first complete assurance baseline, and v0.98.x stabilizes it before the
-> final IVM program. v0.99.0 through v0.104.0 close the assessed contract,
+> deliver separately gated Graph V1 and Delta V1 contracts. v0.97.0 adds the
+> first release-assurance machinery. v0.98.0 repairs or narrows the contracts
+> that lack proof, and v0.98.1 qualifies the corrected baseline. v0.99.0 through
+> v0.104.0 close the assessed contract,
 > execution, state, performance, workload-control, and extension gaps.
 > v0.105.x qualifies the frozen result.
 
@@ -747,9 +750,11 @@ v0.88    ─── Safe engine optimization: DiffContext split, narrow vector pa
     │   │
     │   v0.97    ─── Monitoring, assurance & packaging: Grafana/OTel, same-commit soak and upgrade matrix, longevity, package smoke tests, evidence baseline
     │   │
-    │   v0.98.x  ─── Interim stabilization: blockers, compatibility, tests, docs, packaging, and narrowing of unproven behavior
+    │   v0.98.0  ─── Risk containment: safe capture defaults, contract truth, fail-closed Graph and Delta behavior, qualification contract
     │   │
-    │   v0.99    ─── Verified capabilities: executable support contract, graph conformance, product and release truth
+    │   v0.98.1  ─── Qualified baseline: exact-candidate qualification, upgrades, packages, 72-hour soak, performance, and evidence
+    │   │
+    │   v0.99    ─── Verified capabilities: executable support contract, truthful Graph and Delta declarations, product and release truth
     │   │
     │   v0.100   ─── Unified IVM execution: refresh-path parity, incremental graph composition, strategy enforcement
     │   │
@@ -1151,9 +1156,10 @@ cloning, upgrades, and CDC recovery as a separate mandatory gate. v0.93.0 adds
 canonical contracts and durable external ownership; v0.94.0 completes Graph V1
 with strict transactional refresh. v0.95.0 independently gates durable typed
 output deltas. v0.96.0 defines defaults, resource guarantees, progress,
-diagnostics, and roles. v0.97.0 closes monitoring, soak, compatibility,
-regression, and package gates on one candidate commit. v0.98.x stabilizes that
-interim baseline. The September 2026 assessment then drives v0.99.0 through
+diagnostics, and roles. v0.97.0 adds monitoring, package, and release-evidence
+machinery, but its required qualification is incomplete. v0.98.0 resolves or
+disables the known unsafe contracts. v0.98.1 then runs the release gates on
+one frozen candidate. The September 2026 assessment drives v0.99.0 through
 v0.105.x: align capabilities with public claims, unify refresh execution, close
 relational-state gaps, improve delta locality and workload coexistence, freeze
 the extension contracts, and qualify the exact release artifacts.

--- a/roadmap/v0.100.0.md
+++ b/roadmap/v0.100.0.md
@@ -10,7 +10,9 @@
 
 Use one transactional refresh contract across scheduled, manual, external
 graph, and lifecycle paths. Preserve the separate consistency contract for
-IMMEDIATE mode.
+IMMEDIATE mode. Replace the conservative Graph V1 rejection introduced in
+v0.98.x with explicit experimental opt-in only after the common execution path
+proves the required invariants. Stable admission remains closed until v0.104.0.
 
 ## Work
 
@@ -29,8 +31,9 @@ IMMEDIATE mode.
 
 ## Exit criteria
 
-- [ ] Small changes in chain and diamond graphs remain differential or scoped
-      where admission permits it.
+- [ ] A one-row INSERT, UPDATE, and DELETE in the checked-in three-node chain
+      and four-node diamond fixtures reports `DIFFERENTIAL` for every populated
+      downstream node.
 - [ ] Scheduled, manual, and external paths agree on result multisets,
       effective strategy, frontiers, downstream changes, and rollback.
 - [ ] `full_policy = 'ERROR'` rejects every whole-query FULL transition without
@@ -44,4 +47,5 @@ IMMEDIATE mode.
 ## Scope control
 
 Keep PostgreSQL as the executor. Do not add another scheduler or dataflow
-runtime.
+runtime. Graph V1 remains experimental until v0.104.0 packages and passes its
+independent conformance suite.

--- a/roadmap/v0.103.0.md
+++ b/roadmap/v0.103.0.md
@@ -16,6 +16,8 @@ point and controller decision.
 
 - Make WAL receipt durable before acknowledgement. Preserve complete source
   transactions, replay identity, and a committed high-water mark.
+- Re-enable WAL capture and automatic transitions only after the receipt fault
+  matrix passes. Trigger capture remains the stable fallback.
 - Measure and improve decoding cost across many sources. Evaluate shared typed
   decoding only if it preserves source isolation and transaction completeness.
 - Shorten source write-conflicting locks only after a replacement snapshot and
@@ -27,16 +29,20 @@ point and controller decision.
   cannot silently consume the full budget.
 - Give each automatic freshness action evidence, bounds, hysteresis, override
   behavior, and a stable reason.
+- Freeze `tests/release/v0.103-workload-budgets.json` before optimization. Give
+  each required workload an identifier, hardware class, sample count, maximum
+  foreground-write regression, and maximum decoding-amplification ratio.
 
 ## Exit criteria
 
 - [ ] Fault injection proves that each committed source transaction remains
       accounted for across receipt, persistence, acknowledgement, retry, and
       restart.
-- [ ] Paired foreground-write benchmarks meet the named workload budget and
-      retain all attempts.
-- [ ] Many-source WAL workloads stay within the declared decoding-amplification
-      bound.
+- [ ] Every required foreground-write workload in
+      `tests/release/v0.103-workload-budgets.json` meets its numeric regression
+      budget and retains all attempts.
+- [ ] Every required many-source WAL workload in the budget file meets its
+      numeric decoding-amplification limit.
 - [ ] Late commits, large transactions, decoder lag, and concurrent source DDL
       preserve capture completeness.
 - [ ] Pressure causes a documented throttle, admission reduction, freshness

--- a/roadmap/v0.104.0.md
+++ b/roadmap/v0.104.0.md
@@ -14,6 +14,8 @@ change consumption, and infrastructure-specific delivery as separate concerns.
 ## Work
 
 - Package independent Graph V1 and Delta V1 conformance suites.
+- Admit Graph V1 or Delta V1 as stable only after its packaged suite passes;
+  otherwise retain the v0.98 fail-closed status.
 - Ship a minimal reference coordinator and output-delta consumer that use only
   public contracts.
 - Verify capability negotiation, typed batches, cursors, acknowledgement,
@@ -28,8 +30,10 @@ change consumption, and infrastructure-specific delivery as separate concerns.
 
 ## Exit criteria
 
-- [ ] Two independent coordinators or consumers use public contracts without
-      private catalog or buffer access.
+- [ ] The reference implementation and one independent coordinator pass the
+      Graph V1 suite, and the reference implementation and one independent
+      consumer pass the Delta V1 suite, without private catalog or buffer
+      access.
 - [ ] Conformance covers rollback, replay, invalidation, slow consumers, schema
       changes, restore, clone, permissions, and upgrades.
 - [ ] Output-delta consumers add no work beyond the documented disabled-overhead

--- a/roadmap/v0.105.x.md
+++ b/roadmap/v0.105.x.md
@@ -12,6 +12,10 @@ Qualify the frozen v0.104.0 contracts on the exact artifacts proposed for 1.0.
 This series accepts release-blocking fixes and removes risk. It adds no SQL
 features or capabilities.
 
+This work intentionally reruns and extends v0.98.1 qualification. Releases
+v0.99.0 through v0.104.0 change the implementation and public contracts, so
+v0.98.1 evidence is historical and cannot qualify a v1.0 candidate.
+
 ## Allowed work
 
 - correctness and security fixes
@@ -23,6 +27,9 @@ features or capabilities.
 
 ## Qualification work
 
+- Freeze a v0.105 qualification contract before the first candidate. Use the
+  v0.98 contract schema for exact suite commands, artifacts, observation
+  windows, numeric slope and absolute-growth limits, and performance budgets.
 - Run the exact oracle, capture fault matrix, Graph V1 and Delta V1 conformance,
   real binary upgrades and recreation paths, a 72-hour mixed-workload soak,
   package maintenance tests, and performance budgets.
@@ -40,8 +47,9 @@ features or capabilities.
       digest.
 - [ ] The upgrade manifest covers the accepted post-v0.98 path and classifies
       every recreation boundary.
-- [ ] Memory, catalog, buffer, output-log, and disk use show no unexplained
-      long-term growth.
+- [ ] Memory, catalog, buffer, output-log, and disk use remain within every
+      numeric slope and absolute-growth limit over the frozen observation
+      windows.
 - [ ] Supported packages maintain real data through the advertised upgrade
       procedure.
 - [ ] Every remaining limitation has a stable diagnostic and supported

--- a/roadmap/v0.98.0.md
+++ b/roadmap/v0.98.0.md
@@ -1,0 +1,124 @@
+# v0.98.0: Risk containment and contract truth
+
+> **Status:** Planned
+> **Scope:** Medium
+> **User promise:** *"Known correctness risks are fixed or unavailable in stable operation."*
+> **Blocked by:** [v0.97.0](v0.97.0.md)
+> **Series assessment:** [v0.98.x](v0.98.x.md)
+
+## Theme
+
+Contain every known correctness and security risk in the v0.97.0 baseline.
+Keep trigger capture as the only stable capture path. Report Graph V1 and Delta
+V1 as experimental and disabled until their assigned implementation and
+conformance releases pass.
+
+This release does not implement durable WAL receipt, unified graph execution,
+or complete Graph V1 and Delta V1 conformance. Those remain v0.103.0,
+v0.100.0, and v0.104.0 work. v0.98.0 prevents the incomplete paths from
+running as stable behavior.
+
+## Work
+
+### STAB-1: Contain unsafe WAL capture
+
+- Make trigger capture the only stable and automatically selected CDC mode.
+- Reject new WAL-polling selection and automatic transitions before creating a
+  slot, consuming WAL, or changing a stream-table frontier. Return a stable
+  unavailable reason that names v0.103.0 as the required implementation.
+- Detect existing WAL-backed stream tables during upgrade. Provide a tested
+  transition to trigger capture. If an online handoff cannot prove a complete
+  boundary, require rebuild before the table can resume.
+- Add fault tests that demonstrate the current consume-before-commit risk and
+  prove that the v0.98 guard cannot advance a slot or stream-table frontier.
+
+### STAB-2: Fail-closed Graph V1 and Delta V1 admission
+
+- Make `integration_capabilities()` report Graph V1 and Delta V1 as
+  `experimental` and `enabled = false` throughout v0.98.x.
+- Route every public Graph V1 and Delta V1 operation through one admission
+  guard. Reject before locks, catalog mutation, cursor or frontier movement,
+  payload generation, or user-table writes.
+- Preserve existing catalog state for a documented rollback or later upgrade,
+  but do not let disabled consumers accumulate unbounded retained payload.
+- Document the compatibility effect for existing coordinators and consumers.
+- Add live PostgreSQL negative tests for every public entry point, hostile
+  `search_path`, non-owner roles, existing registrations, concurrent calls,
+  savepoints, restart, restore, and binary upgrade.
+
+The conservative rejection contains the known graph policy, effective-action,
+boundary, cleanup, acknowledgement, resnapshot, exactness, retention, recovery,
+and ownership defects. v0.100.0 repairs the common graph execution path.
+v0.104.0 repairs and independently qualifies the complete public V1 contracts.
+
+### STAB-3: Make operational contracts truthful
+
+- Make `active_profile()` distinguish configured, recommended, and effective
+  values. Report an effective value only when runtime admission uses it.
+- Give automatic configuration an unambiguous representation. Do not interpret
+  an explicit value as the automatic sentinel.
+- Either implement the documented disk forecast with a measurement time and
+  horizon, or rename the current fields as accounted footprint. Include every
+  extension-managed relation in the accounted total.
+- Either update progress during each advertised operation, or narrow the view
+  and documentation to the state it measures. Test initial population, FULL,
+  rebuild, repair, cancellation, and timestamp movement for the retained
+  contract.
+- Give each enabled stable failure, fallback, rejection, and suspension an
+  identifier, SQLSTATE, detail, hint, and support-matrix entry.
+- Validate monitoring with extension-emitted rows and spans. Text-presence and
+  synthetic-span checks remain package-structure tests, not behavioral proof.
+
+### STAB-4: Reconcile documentation and release gates
+
+- Reconcile active documentation with runtime admission for capture modes,
+  Graph V1, Delta V1, set operations, volatility, windows, recursion, DISTINCT
+  aggregates, identity types, and removed integrations.
+- Keep one authoritative checklist for each active release. Do not mark an item
+  complete without evidence for the exact source commit and artifact.
+- Change the release-evidence writer to derive overall status from structured
+  suite results. It must reject an unknown status and must not hard-code
+  `passed`.
+
+### STAB-5: Freeze an executable qualification contract
+
+- Add `tests/release/v0.98-qualification.json` and a schema-validating release
+  gate. This is a release-test contract, not the product capability manifest
+  assigned to v0.99.0.
+- Record exact required suite commands, expected capability states, source
+  versions, package and platform artifacts, performance metrics and numeric
+  budgets, soak duration, longevity duration, and numeric growth limits.
+- Include a blocker ledger with identifier, severity, affected stable
+  capability, status, and verifying suite. Publication requires zero open P0
+  or P1 entries.
+- Reject duplicate identifiers, unknown states, missing commands, wildcard
+  versions, and absent or nonnumeric thresholds. The v0.98.0 tag may contain no
+  `TBD`, `null`, or disabled required gate.
+- Freeze `duration_hours = 72` for the mixed-workload soak and
+  `duration_days = 7` for longevity. v0.98.1 must execute the frozen contract
+  without weakening it.
+
+## Exit criteria
+
+- [ ] Trigger capture passes the exact-result and transaction-atomicity tests
+      and is the only stable or automatic capture mode.
+- [ ] WAL polling and automatic WAL transition reject before slot consumption
+      or frontier movement, including after upgrade from v0.97.0.
+- [ ] Every Graph V1 and Delta V1 public operation rejects before side effects,
+      and capability discovery reports both contracts disabled and
+      experimental.
+- [ ] Operational diagnostics and monitoring report only behavior that live
+      PostgreSQL tests observe.
+- [ ] Active documentation, generated catalogs, and the authoritative release
+      checklists match runtime behavior.
+- [ ] `tests/release/v0.98-qualification.json` passes its schema and completeness
+      gate, contains exact commands and numeric thresholds, and has zero open
+      P0 or P1 blocker entries.
+- [ ] The release workflow cannot publish when a required structured result is
+      missing, skipped, unavailable, stale, or failed.
+
+## Scope control
+
+Do not add SQL features, query forms, integrations, optimizer classes, or
+controller actions. Do not implement the work assigned to v0.100.0,
+v0.103.0, or v0.104.0. Conservative rejection is the v0.98 safety mechanism.

--- a/roadmap/v0.98.1.md
+++ b/roadmap/v0.98.1.md
@@ -1,0 +1,124 @@
+# v0.98.1: Qualified interim baseline
+
+> **Status:** Planned
+> **Scope:** Large
+> **User promise:** *"The published build passed its required tests on the artifact that ships."*
+> **Blocked by:** [v0.98.0](v0.98.0.md)
+> **Series assessment:** [v0.98.x](v0.98.x.md)
+
+## Theme
+
+Freeze the v0.98.0 implementation and qualify one exact interim release
+candidate against `tests/release/v0.98-qualification.json`. A required missing,
+skipped, unavailable, stale, or failed result blocks publication.
+
+This is not final v1.0 qualification. Releases v0.99.0 through v0.104.0 change
+the implementation and public contracts. v0.105.x must therefore rerun and
+extend these gates against the frozen v1.0 candidate.
+
+Any change to the candidate commit or package contents invalidates all v0.98.1
+evidence and starts a new qualification run.
+
+## Work
+
+### QUAL-1: Candidate-bound evidence
+
+- Record the candidate commit, PostgreSQL version, platform, suite version,
+  workload, configuration, start and end time, result, retained-log location,
+  and digest for every shipped artifact.
+- Derive the overall result from the required structured suite results in the
+  frozen qualification contract. Do not accept caller-supplied success strings.
+- Preserve `passed`, `failed`, `skipped`, `unavailable`, and `historical` as
+  distinct states. Only fresh `passed` evidence satisfies a required gate.
+- Make stable tag publication depend on the complete evidence record. Use
+  prerelease tags while qualification is incomplete.
+
+### QUAL-2: Correctness and admission
+
+- Run the exact-result oracle and transaction-atomicity tests for every stable
+  refresh strategy with trigger capture, as listed in the qualification
+  contract.
+- Run the WAL negative-admission and no-slot-advance fault tests.
+- Run every Graph V1 and Delta V1 negative-admission test against the packaged
+  candidate. Discovery and every public entry point must agree that the
+  contracts are disabled and experimental.
+- Run the contract's security, concurrency, rollback, restart, restore, clone,
+  lifecycle, and resource-pressure suites.
+
+### QUAL-3: Upgrade and package qualification
+
+- Test every exact source version listed in the qualification contract against
+  the v0.98.1 candidate with real old binaries, active stream tables, pending
+  source changes, and a post-upgrade refresh.
+- Validate the list against `docs/upgrade-support-manifest.json`. Classify
+  recreation boundaries separately from in-place upgrades.
+- Treat every package and platform artifact listed in the contract as blocking.
+  Each must pass install, create, insert, update, delete, refresh, restart, and
+  upgrade or documented recreation smoke tests.
+- Build each listed artifact twice in clean environments. Compare normalized
+  package contents and record compiler, dependency, source, and binary
+  provenance.
+
+### QUAL-4: Soak and longevity
+
+- Run the frozen 72-hour mixed-workload soak on the candidate package. Include
+  the databases, schema changes, restarts, cancellation, injected failures,
+  repair, freshness targets, rejected external operations, and resource
+  pressure listed in the contract.
+- Require zero result deviations and zero unaccounted committed changes.
+- Measure memory, catalogs, CDC buffers, output logs, retained history, and disk
+  use over the contract's fixed windows. Each series must remain within its
+  numeric maximum slope and absolute-growth budget.
+- Run the frozen seven-day longevity workload across one upgrade from the
+  released v0.98.0 package to the unchanged v0.98.1 candidate package. A
+  recovery loop, result deviation, or exceeded growth budget fails the gate.
+
+### QUAL-5: Performance gates
+
+- Run every workload, sample count, warm-up rule, retry rule, metric, and
+  numeric budget from the frozen qualification contract. Retain all attempts
+  and evaluate the complete result set.
+- Assert the effective refresh strategy and result multiset in every benchmark.
+  A fallback, skip, or mismatch fails the benchmark.
+- Record infrastructure failure separately from product regression. Neither
+  state satisfies a required result.
+
+### QUAL-6: Contract freeze
+
+- Verify that API signatures, catalog schema, GUCs, error and reason
+  identifiers, monitoring names, package contents, and upgrade policy match the
+  candidate artifacts.
+- Assign every remaining limitation to v0.99.0 through v0.105.x, an explicit
+  v1.0 non-goal, or post-v1.0 work.
+- Record third-party repository publication separately. Repository acceptance
+  does not replace package qualification or alter candidate evidence.
+
+## Exit criteria
+
+- [ ] The qualification-contract validator passes without placeholders,
+      wildcard versions, missing commands, or nonnumeric thresholds.
+- [ ] Every required result names the v0.98.1 candidate commit and shipped
+      artifact digest and has fresh status `passed`.
+- [ ] The exact oracle, capture transaction tests, WAL rejection tests, and
+      Graph V1 and Delta V1 negative-admission tests pass against the packaged
+      candidate.
+- [ ] Every listed source version completes its documented upgrade or
+      recreation path with active data and pending changes.
+- [ ] Every listed artifact is reproducible and passes its required package
+      smoke tests.
+- [ ] The 72-hour soak reports zero result deviations, zero unaccounted
+      committed changes, and no numeric growth-budget violation.
+- [ ] The seven-day longevity run crosses from released v0.98.0 to the
+      unchanged candidate without a result deviation, recovery loop, or
+      numeric growth-budget violation.
+- [ ] Every performance result satisfies its frozen numeric budget under its
+      prespecified evaluation rule.
+- [ ] The blocker ledger has zero open P0 or P1 entries, and the evidence record
+      derives overall `passed` from all required results.
+- [ ] Public contracts and active documentation match the shipped artifacts.
+
+## Scope control
+
+Accept only release-blocking correctness, security, compatibility,
+documentation, package, and test fixes. Each accepted change creates a new
+candidate and restarts qualification. Add no capability during this release.

--- a/roadmap/v0.98.x.md
+++ b/roadmap/v0.98.x.md
@@ -1,48 +1,80 @@
-# v0.98.x — Stabilization
+# v0.98.x: Stabilization assessment and release series
 
 > **Status:** Planned
-> **Scope:** Variable
+> **Scope:** Two releases
 > **User promise:** *"The next development baseline contains less risk, not more scope."*
 > **Blocked by:** [v0.97.0](v0.97.0.md)
-> **Renumbered:** previously v0.95.x.
+> **Assessed revision:** `e5018a7`, the v0.97.0 tag
 
-## Theme
+## Decision
 
-Hold a stabilization-only release series before the extended IVM program in
-[v0.99.0](v0.99.0.md) through [v0.105.x](v0.105.x.md). The goal is to remove
-risk and prove compatibility on an interim qualified baseline.
-Deleting an unstable optimization or making a controller decision more
-conservative is a valid release outcome.
+Use two releases:
 
-## Allowed work
+1. [v0.98.0](v0.98.0.md) contains each known correctness or contract risk and
+   freezes an executable qualification contract.
+2. [v0.98.1](v0.98.1.md) qualifies one exact interim release candidate against
+   that contract.
 
-- correctness and security fixes
-- bugs found by the soak, longevity environment, upgrade matrix, conformance
-  suites, or users
-- compatibility, packaging, and documentation fixes
-- missing tests and clearer diagnostics
-- dependency cleanup and removal of unnecessary configuration
-- performance regression fixes
-- disabling or narrowing optimizer and controller rules that lack evidence
-- correctness-preserving Delta V1 fixes; stable capability admission remains
-  blocked while its independent conformance gate is not green
-- explicit rejection of combinations that cannot be supported safely
+Do not assign themes to later v0.98 patch versions now. Create one only for a
+release-blocking defect found during v0.98.1 qualification.
 
-New SQL functions, catalog capabilities, query coverage, and operational
-features are outside this stabilization series. Later roadmap releases must
-admit them through their own evidence gates.
+This split keeps evidence honest. A correctness fix in v0.98.0 can invalidate
+earlier test results. v0.98.1 therefore collects release evidence only after
+the implementation and public contracts stop changing.
 
-## Exit criteria
+## Assessment of v0.93.0 through v0.97.0
 
-- [ ] No known correctness or security blocker remains
-- [ ] The exact oracle, Graph V1 and Delta V1 conformance suites, upgrade
-      matrix, 72-hour soak, package smoke tests, and performance regression
-      gates pass on the release-candidate baseline
-- [ ] Every supported fallback and suspension has a stable reason code and a
-      support-matrix entry
-- [ ] Unstable optimizer or controller decisions are narrowed, disabled, or
-      removed
-- [ ] API, catalog, GUC, monitoring, and package contracts match the qualified
-      v0.98.x baseline
-- [ ] Remaining known limitations are assigned to v0.99.0 through v0.105.x,
-      explicit v1.0 non-goals, or post-v1.0 work
+This is a source, test, roadmap, and workflow assessment. Checked-in evidence
+does not prove every runtime defect described below. The v0.98.x releases must
+settle each risk with a live PostgreSQL test or reject the affected behavior.
+
+| Release | What shipped | What remains unproven or unsafe |
+|---------|--------------|---------------------------------|
+| v0.93.0 | Capability discovery, canonical contract data, and durable `EXTERNAL` ownership | [The release gate](../scripts/v0_93_release_gate.py) checks files, source markers, and test names. The independent security, lifecycle, restore, clone, and upgrade criteria remain unchecked. |
+| v0.94.0 | `refresh_graph_strict()` and Graph V1 discovery | [Graph execution](../src/api/integration.rs) does not pass `full_policy = 'ERROR'` into every runtime FULL fallback. [Manual refresh](../src/api/refresh_ops.rs) can report the requested action instead of the action that ran. Mixed FULL and differential boundaries, busy behavior, exception cleanup, and graph conformance lack live proof. The capability is still advertised as stable. |
+| v0.95.0 | Delta consumer catalogs, typed payload relations, batches, acknowledgement, and resnapshot APIs | [Delta acknowledgement](../src/api/output_delta.rs) can bypass the resnapshot protocol, and concurrent acknowledgements can move a cursor backward. Exact-batch completeness is not proven, hard retention pressure is incomplete, and clone or ownership transitions do not enforce every stored identity. Delta V1 is still advertised as stable. |
+| v0.96.0 | Resource diagnostics, disk reporting, a progress view, error rows, and predefined roles | [The diagnostic implementation](../src/api/release_096.rs) reports some recommendations as selected values. Disk projection is a current partial sum, and [the progress view](../src/lib.rs) does not update row progress or its timestamp. The [two](v0.96.0.md) [roadmap files](v0.96.0.md-full.md) also disagree about completed exit criteria. |
+| v0.97.0 | Monitoring files, package smoke tests, and a release-evidence file | [The release workflow](../.github/workflows/release.yml) records the required 72-hour soak and full upgrade matrix as skipped, but [the evidence writer](../scripts/release_evidence.py) always records overall status as `passed`. Monitoring checks mostly validate text presence. Only the Linux amd64 artifact receives a live install and refresh smoke test. |
+
+The v0.93.0 through v0.97.0 tags remain historical releases. Do not mark an
+unchecked exit criterion complete without candidate-bound evidence. v0.98.x
+closes the resulting risk. It does not rewrite release history.
+
+## Cross-release blockers
+
+The following findings block a qualified v0.98 baseline:
+
+- WAL polling consumes logical-decoding changes before the local receipt
+  transaction commits. A failure after consumption can roll back local buffer
+  rows after the slot has advanced. Trigger capture must remain the only stable
+  capture path until v0.103.0 implements durable receipt.
+- Graph V1 and Delta V1 advertise stable version 1 without their independent
+  conformance evidence.
+- Graph FULL policy, effective-action reporting, boundary proof, and
+  backend-local cleanup do not cover every runtime path.
+- Delta acknowledgement, resnapshot, exactness, retention, recovery, and
+  ownership rules have concrete fail-open paths.
+- v0.96 operational claims exceed the behavior checked by its tests.
+- v0.97 release evidence can pass while required suites are skipped or absent.
+
+## Scope boundary
+
+v0.98.x may fix correctness, security, compatibility, diagnostics,
+documentation, packaging, tests, and measured regressions. It may narrow,
+disable, or remove behavior that lacks proof.
+
+Keep the following work in its assigned release:
+
+- Generate the product capability and strategy manifest in v0.99.0. The small
+  v0.98 qualification contract only defines release gates.
+- Unify refresh execution and remove the manual stream-source FULL fallback in
+  v0.100.0.
+- Add relational state, aggregate, numeric, and identity coverage in v0.101.0.
+- Add optimizer and delta-locality work in v0.102.0.
+- Implement durable WAL acknowledgement, then consider lock-elision, shared
+  decoding, and controller automation in v0.103.0.
+- Package complete Graph V1 and Delta V1 conformance and consider stable
+  readmission in v0.104.0.
+
+New SQL features, query coverage, integrations, optimizer classes, and
+controller actions remain outside v0.98.x.

--- a/roadmap/v0.99.0.md
+++ b/roadmap/v0.99.0.md
@@ -3,7 +3,7 @@
 > **Status:** Planned
 > **Scope:** Medium
 > **User promise:** *"I can determine whether my query will work, how pg_trickle will maintain it, and which limits apply."*
-> **Blocked by:** [v0.98.x](v0.98.x.md)
+> **Blocked by:** [v0.98.1](v0.98.1.md)
 > **Source:** [September 2026 assessment](../plans/pg-trickle-assessment-and-pre-1.0-roadmap.md)
 
 ## Theme
@@ -18,12 +18,13 @@ to judge every later pre-1.0 change.
   admission examples and stable reason identifiers.
 - Use the manifest to reconcile the README, support matrix, SQL reference,
   generated catalogs, configuration docs, and integration docs.
-- Replace nominal Graph V1 checks with PostgreSQL tests for real graphs,
-  authorization, strategy policy, rollback, and coordinator writes.
-- Record release evidence against a source commit, artifact digest, PostgreSQL
-  version, suite version, workload, result, and retained logs.
-- Add regression coverage for WAL receipt durability, graph strategy policy,
-  graph boundary semantics, source-lock behavior, and backend-local cleanup.
+- Generate Graph V1 and Delta V1 support declarations from the v0.98 runtime
+  admission state. Disabled or experimental is a valid declaration until the
+  later implementation and conformance releases pass.
+- Add the generated capability-manifest version and digest to the candidate
+  evidence record introduced in v0.98.x.
+- Keep the v0.98 safe-capture default and Graph V1 and Delta V1 negative
+  admission tests as blocking regressions.
 - Mark an unproven stable capability unavailable or experimental until its
   conformance tests pass.
 
@@ -33,10 +34,10 @@ to judge every later pre-1.0 change.
       strategy or rejection.
 - [ ] No P0 correctness investigation remains open for an enabled stable
       capability.
-- [ ] Graph policy, authorization, and rollback tests execute the public SQL
-      API against PostgreSQL.
-- [ ] Documentation and catalog checks pass without broad exemptions for
-      active unsupported interfaces.
+- [ ] The v0.98 capture and capability-admission gates remain green against the
+      public SQL API and packaged build.
+- [ ] Documentation and catalog checks pass with zero exemptions for active
+      unsupported interfaces.
 - [ ] The evidence manifest distinguishes executed, skipped, unavailable, and
       historical results.
 


### PR DESCRIPTION
## Summary

- assess the v0.93.0 through v0.97.0 releases against the implementation, tests, workflows, and stated exit criteria
- replace the open-ended v0.98.x placeholder with v0.98.0 risk containment and v0.98.1 candidate qualification
- align v0.99.0 through v0.105.x ownership so later work is not duplicated and each stable capability has an evidence gate

## Assessment

The review found that the v0.93.0 through v0.97.0 release machinery added the intended APIs and assurance infrastructure, but several claims exceed the checked-in behavioral evidence:

- Graph V1 and Delta V1 are advertised as stable unconditionally despite missing independent conformance evidence.
- Graph runtime FULL policy, effective-action reporting, boundary handling, and cleanup are not proven across all paths.
- Delta acknowledgement can bypass resnapshot and concurrent acknowledgements can regress a cursor.
- v0.96 diagnostics and progress claims do not consistently describe runtime values.
- v0.97 release evidence hard-codes an overall pass while recording required soak and upgrade suites as skipped.

## v0.98.x decision

v0.98.0 contains risk without pulling later roadmap work forward:

- trigger capture is the only stable and automatic CDC path until v0.103.0 implements durable WAL receipt
- Graph V1 and Delta V1 become disabled and experimental until v0.100.0 repairs graph execution and v0.104.0 packages independent conformance
- operational contracts and release evidence become truthful
- a checked-in qualification contract freezes exact commands, versions, artifacts, numeric budgets, blocker states, a 72-hour soak, and seven-day longevity run

v0.98.1 then qualifies one unchanged candidate and shipped artifacts against that frozen contract. Any candidate change restarts qualification. v0.105.x repeats and extends qualification because v0.99.0 through v0.104.0 change the implementation and public contracts.

## Verification

- `just fmt`
- `just lint`
- `just check-version-sync`
- `git diff --check`

This is a documentation-only change.
