### PR TITLE
fix(release): accept current v0.96 disk contract

### DIFF
--- a/scripts/v0_96_release_gate.py
+++ b/scripts/v0_96_release_gate.py
@@ -34,9 +34,10 @@ needles = (
     "pgtrickle_reader",
     "pgtrickle_operator",
     "pgtrickle_admin",
-    "FORECAST_AND_REACT",
 )
 missing_contracts = [needle for needle in needles if needle not in sources]
+if not any(marker in sources for marker in ("FORECAST_AND_REACT", "ACCOUNTED_FOOTPRINT")):
+    missing_contracts.append("forecast disk contract")
 
 roadmap = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")
 if not re.search(r"\[v0\.96\.0\].*?✅ Released", roadmap):


### PR DESCRIPTION
## Summary

- Fix the historical v0.96 release gate after the v0.98 operational contract rename.
- Accept both the original `FORECAST_AND_REACT` marker and the current `ACCOUNTED_FOOTPRINT` marker.

## Verification

- `python3 scripts/v0_96_release_gate.py`
- `python3 scripts/v0_98_qualification_gate.py`
- `just fmt`
- `just lint`
