### PR TITLE
ci: scope release gates to matching tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,11 @@ jobs:
         run: python3 scripts/v0_98_qualification_gate.py
 
       - name: v0.103 durable WAL receipt release gate
+        if: github.ref_name == 'v0.103.0'
         run: python3 scripts/v0_103_release_gate.py
 
       - name: v0.104 contracts and conformance release gate
+        if: github.ref_name == 'v0.104.0'
         run: python3 scripts/v0_104_release_gate.py
 
       - name: Validate monitoring contract


### PR DESCRIPTION
## Summary

- Run the v0.103 release gate only for the v0.103.0 tag.
- Run the v0.104 release gate only for the v0.104.0 tag.

This prevents historical version-specific gates from rejecting later release tags while preserving their checks for the releases they validate.

## Validation

- `just fmt`
- `just lint`
- `python3 scripts/v0_89_release_gate.py`
- `python3 scripts/v0_90_release_gate.py`
- `python3 scripts/v0_96_release_gate.py`
- `python3 scripts/v0_98_qualification_gate.py`
- `python3 scripts/v0_104_release_gate.py`
