### PR TITLE
fix(release): adapt packaged qualification layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,9 @@ jobs:
         run: |
           mkdir -p candidate
           tar xzf dist/*.tar.gz -C candidate --strip-components=1
+          mkdir -p candidate/usr/share/postgresql/18 candidate/usr/lib/postgresql/18
+          cp -a candidate/extension candidate/usr/share/postgresql/18/
+          cp -a candidate/lib candidate/usr/lib/postgresql/18/
           test -f candidate/usr/share/postgresql/18/extension/pg_trickle.control
           test -f candidate/usr/lib/postgresql/18/lib/pg_trickle.so
 


### PR DESCRIPTION
## Summary

- Adapt the packaged qualification job to the release tarball's generic `lib/` and `extension/` layout.
- Copy those files into the PostgreSQL system layout expected by the light-E2E runner before testing.

## Verification

- Reproduced the extraction against the failed v0.105.0 Linux artifact.
- `just fmt`
- `just lint`
