### PR TITLE
fix(release): wait for stable postgres readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,14 +321,20 @@ jobs:
             postgres -c "shared_preload_libraries=pg_trickle"
 
           echo "Waiting for PostgreSQL..."
+          ready_streak=0
           for i in $(seq 1 30); do
             if docker exec smoketest pg_isready -U postgres 2>/dev/null; then
-              break
+              ready_streak=$((ready_streak + 1))
+              if [[ "$ready_streak" -ge 3 ]]; then
+                break
+              fi
+            else
+              ready_streak=0
             fi
             sleep 1
           done
 
-          if ! docker exec smoketest pg_isready -U postgres; then
+          if [[ "$ready_streak" -lt 3 ]]; then
             echo "ERROR: PostgreSQL did not become ready"
             docker logs smoketest
             exit 1


### PR DESCRIPTION
## Summary

- Make the release PostgreSQL smoke test wait for three consecutive successful readiness probes.
- Avoid treating the initdb server's brief readiness window as the final server startup.

## Verification

- Reproduced the transient readiness race in the failed v0.105.0 release run.
- `just fmt`
- `just lint`
