### PR TITLE
docs: align v0.105 qualification with pg-mdm requirements

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -534,7 +534,7 @@ freeze the core IVM engine. v0.105.0 through v0.105.2 perform qualification.
 | [v0.103.0](roadmap/v0.103.0.md) | Low-Interference Capture and Workload Control: economical capture, proven lock reductions, fair resource admission, and bounded controller authority | "IVM stays within a visible database budget while pursuing an achievable freshness target." | ✅ Released | Large | [Full details](roadmap/v0.103.0.md) |
 | [v0.104.0](roadmap/v0.104.0.md) | Extension Conformance and Final Feature Freeze: packaged Graph V1 and Delta V1 suites, reference clients, and frozen public contracts | "Other PostgreSQL tools can build on a small, stable contract." | ✅ Released | Medium | [Full details](roadmap/v0.104.0.md) |
 | [v0.105.0](roadmap/v0.105.0.md) | Qualification contract and release evidence: candidate metadata, conformance wiring, package evidence, and deferred long-running gates | "Every qualification result identifies the build it tested." | ✅ Released | Medium | [Full details](roadmap/v0.105.0.md) |
-| [v0.105.1](roadmap/v0.105.1.md) | Runtime conformance and recovery: Graph V1, Delta V1, DVM correctness, WAL fault handling, rollback, and upgrade behavior | "Supported contracts behave correctly under failure and replay." | Planned | Large | [Full details](roadmap/v0.105.1.md) |
+| [v0.105.1](roadmap/v0.105.1.md) | Runtime conformance and recovery: delegated Graph V1 source authorization, Graph V1 and Delta V1 conformance, DVM correctness, WAL fault handling, rollback, and upgrade behavior | "Supported contracts behave correctly under delegated access, failure, and replay." | Planned | Large | [Full details](roadmap/v0.105.1.md) |
 | [v0.105.2](roadmap/v0.105.2.md) | Package, upgrade, performance, and field validation: supported artifacts, active-data upgrades, workload budgets, and operator procedures | "The released build works in the environments we support." | Planned | Large | [Full details](roadmap/v0.105.2.md) |
 
 ### Toward v1.0
@@ -1169,10 +1169,13 @@ diagnostics, and roles. v0.97.0 adds monitoring, package, and release-evidence
 machinery, but its required qualification is incomplete. v0.98.0 resolves or
 disables the known unsafe contracts. v0.98.1 then runs the release gates on
 one frozen candidate. The September 2026 assessment drives v0.99.0 through
-v0.105.2. These releases qualify the frozen contracts, runtime behavior,
-supported packages, upgrades, and field procedures. The 72-hour mixed-workload
-soak, longevity environment, release candidates, and v1.0 release remain
-deferred indefinitely.
+v0.105.2. v0.105.1 also qualifies delegated Graph V1 source authorization
+without changing the frozen SQL signatures or contract versions. An authorized
+`pg-mdm` execution role owns its graph members while source owners grant schema
+`USAGE` and table `SELECT` plus `MAINTAIN`. These releases qualify the frozen
+contracts, runtime behavior, supported packages, upgrades, and field procedures.
+The 72-hour mixed-workload soak, longevity environment, release candidates, and
+v1.0 release remain deferred indefinitely.
 
 **The distributed work has moved past 1.0.** External workers, external CDC
 consumers, Kubernetes operators, distributed delta computation, cross-cluster

--- a/pg-mdm-feedback.md
+++ b/pg-mdm-feedback.md
@@ -1,0 +1,116 @@
+# Feedback on the `pg_trickle` requirements for `pg-mdm`
+
+## Overall assessment
+
+The [revised requirements](pg-mdm-pg-trickle-requirements-2.md) are ready to plan
+against. They use the right integration boundary: `pg_trickle` maintains a
+private Graph V1 graph, and `pg-mdm` owns identity resolution, review, and
+publication. The live path stays inside one PostgreSQL transaction and uses
+only public SQL contracts.
+
+Do not add Delta V1 consumption, WAL capture, private-catalog access, or MDM
+logic to this integration. None of those features is needed for `pg-mdm` v0.9
+through v0.11.
+
+The work fits the existing `pg_trickle` v0.105 qualification series. It does not
+need a new Graph contract or a new release milestone.
+
+## Dependency version
+
+`pg_trickle` 0.104.0 supports the owner-equivalent Graph V1 path. It does not
+support delegated base-table sources under schema `USAGE` and table `SELECT`
+plus `MAINTAIN`.
+
+Treat a released `pg_trickle` 0.105.1 package as the minimum dependency for the
+delegated-source path. That release is planned to add the authorization fix and
+the runtime conformance required by `pg-mdm`. `pg-mdm` v0.9 does not need to wait
+for the broader package and field qualification in `pg_trickle` 0.105.2 after a
+0.105.1 artifact passes the `pg-mdm` admission suite.
+
+Pin one exact package in CI. Record its upstream version, release commit, tag
+object, package URL, PostgreSQL major, and SHA-256. If the package changes, rerun
+all applicable earlier admission gates. Do not assume that a later patch is
+equivalent because it keeps the same Graph V1 major version.
+
+## Execution identity and row-level security
+
+`pg_trickle` runs definition-derived SQL as the current owner of each graph
+member. It does not provide an arbitrary execution-role switch. The role that
+`pg-mdm` selects for a graph must therefore own every graph member.
+
+`pg_trickle` rechecks current source privileges and tracks result-affecting
+Graph V1 contract data. `pg-mdm` remains responsible for its selected-role
+binding and session-dependent row-level-security inputs. Keep role memberships,
+role bindings, and session claims out of the Graph V1 digest.
+
+The `pg-mdm` admission suite must cover both sides of this boundary:
+
+- Revoke schema `USAGE`, source `SELECT`, or source `MAINTAIN` and require
+  strict refresh to fail before committed graph mutation.
+- Change the source owner, replace the source relation, or change a tracked RLS
+  policy dependency and require a contract rejection.
+- Change the `pg-mdm` role binding or a session-dependent visibility input and
+  require `pg-mdm` to reject the refresh before it calls `pg_trickle`.
+- Verify that delegated source access never grants authority over a graph
+  member.
+
+## Source-boundary proof
+
+Do not accept `source_boundary->>'completeness' = 'PROVEN'` as sufficient proof.
+The suite must interleave committed source writers with strict refresh and show
+that each change is on exactly one side of the returned boundary. Changes after
+the boundary must remain pending for the next refresh.
+
+Test an injected failure after graph maintenance but before MDM publication.
+After rollback, graph rows, source positions, MDM state, publication history,
+and public output rows must all retain their previous committed state. A retry
+must neither skip nor duplicate a source change.
+
+The suite must also validate the returned contract version, graph refresh ID,
+complete source manifest, and 32-byte boundary digest. Compare the terminal
+relations with the independent full-resolution MDM path for inserts, updates,
+deletes, and no-op refreshes.
+
+## Differential behavior
+
+The initial strict refresh may use `FULL` to establish a frontier. After that
+baseline, every qualifying graph shape must report differential or scoped
+maintenance in `node_results`. A qualifying graph shape is one whose compiled
+queries support that maintenance.
+
+Keep `full_policy = 'ALLOW'` because an exact `FULL` refresh is the safe fallback
+when differential proof is unavailable. Still, fail qualification if supported
+steady-state fixtures repeatedly use `FULL`. Otherwise `AUTO` could satisfy the
+correctness tests while providing none of the expected incremental-refresh
+performance.
+
+## Release mapping
+
+Use the following split:
+
+- `pg-mdm` v0.9 depends on the `pg_trickle` 0.105.1 Graph V1 admission profile.
+  Cover public capability discovery, graph contracts, transaction commit and
+  rollback, source boundaries, delegated authorization, RLS, scheduler
+  exclusion, exact results, and effective refresh strategy.
+- `pg-mdm` v0.10 runs cumulative operational tests against its pinned package.
+  Cover concurrent writers, lifecycle races, backend and PostgreSQL failure,
+  retry, resource limits, backup, restore, clone isolation, and extension
+  upgrade.
+- `pg-mdm` v0.11 owns the combined release qualification. Run the shared
+  differential-versus-full MDM suite against the exact package used in CI. This
+  milestone should not require a new `pg_trickle` runtime feature.
+
+The matching upstream work is recorded in the [`pg_trickle` v0.105.1
+roadmap](roadmap/v0.105.1.md) and [`pg_trickle` v0.105.2
+roadmap](roadmap/v0.105.2.md).
+
+## Ownership of the shared suite
+
+Keep the test ownership explicit. `pg_trickle` owns Graph V1 locking, boundary,
+authorization, transaction, recovery, clone, upgrade, stable-error, and package
+evidence. `pg-mdm` owns stewardship, merge, split, golden-value, review, and
+publication semantics.
+
+The shared suite joins those two sets of evidence. It must use public
+`pg_trickle` SQL only and must never inspect private catalogs, change buffers,
+or scheduler state.

--- a/pg-mdm-pg-trickle-requirements-2.md
+++ b/pg-mdm-pg-trickle-requirements-2.md
@@ -1,0 +1,298 @@
+# `pg-mdm` requirements for `pg_trickle` in v0.9 through v0.11
+
+`pg-mdm` v0.8 creates a private Graph V1 graph. v0.9 starts using that graph
+for live refresh. v0.10 tests the failure and recovery cases around that
+refresh. v0.11 qualifies the complete combination for release.
+
+This document describes what those releases need from `pg_trickle`. It is
+based on the `pg-mdm` v0.9 through v0.11 roadmap entries. The repository does
+not yet contain separate detailed plans for those releases, so these
+requirements need review before implementation starts.
+
+## Terms used here
+
+- A graph member is a `pg_trickle` stream table created from one compiled MDM
+  stage.
+- A strict refresh is a public operation that checks the expected graph
+  contract, refreshes the graph, and returns the exact source boundary used by
+  the refresh.
+- A source boundary is the complete, identified set of source changes that a
+  refresh consumed. Its digest lets `pg-mdm` record exactly what produced an
+  MDM publication.
+- An external graph is a graph with `orchestration_mode = EXTERNAL`. `pg-mdm`
+  starts its refreshes. The normal `pg_trickle` scheduler must not refresh it
+  independently.
+- A qualifying graph shape is a `pg-mdm` Graph V1 fixture whose compiled queries
+  support differential or scoped maintenance after initial population.
+
+## v0.9 requires transactional graph refresh
+
+v0.9 adds `mdm.preview()`, `mdm.refresh()`, and administrative rebuild. The
+live path must call the public `pg_trickle` strict-refresh function inside the
+same caller transaction as MDM publication.
+
+The existing Graph V1 call has this shape:
+
+```sql
+SELECT *
+FROM pgtrickle.refresh_graph_strict(
+    ARRAY['mdm_graph.member_root'::regclass],
+    expected_graph_digest,
+    'ALLOW'
+);
+```
+
+The result must include the following information:
+
+- Graph contract version 1.
+- A unique `graph_refresh_id`.
+- A machine-readable `source_boundary`.
+- A 32-byte `source_boundary_digest`.
+- A completeness result that can prove the boundary is complete.
+
+For the qualifying path, `source_boundary->>'completeness'` must be
+`PROVEN`. `pg-mdm` stores the refresh ID, boundary, and boundary digest with
+the publication observation or publication that follows the refresh.
+
+### Keep the graph and MDM transaction together
+
+The strict-refresh function must not commit independently. The caller owns
+the transaction. A successful refresh followed by a successful MDM publication
+must commit both changes together.
+
+If any later step fails, PostgreSQL must roll back all of the following:
+
+- changes to graph member rows;
+- source-change positions consumed by the graph;
+- the `graph_refresh_id` and source-boundary evidence written by `pg-mdm`;
+- MDM memberships, golden values, reviews, and publication history; and
+- public MDM output-table changes.
+
+An injected failure after graph maintenance must leave the graph and its
+source positions in their previous state. A retry must not skip source changes
+or apply them twice.
+
+### Check the graph contract before changing data
+
+`refresh_graph_strict()` must compare the supplied graph digest with the
+current Graph V1 contract before it changes a member or consumes a source
+position. A mismatch must fail without partial graph work.
+
+The operation must also reject a missing member, a changed member or source
+owner, a replaced source relation, a revoked source grant, or a changed tracked
+contract. The error must identify the failed condition with a stable upstream
+code or identifier. `pg-mdm` rejects a changed role binding before it calls the
+operation.
+
+### Return a complete source boundary
+
+The source boundary must describe the source state that the refresh used. It
+must not claim success when a source change is outside the captured or scanned
+range, when a source is unavailable, or when a required source position cannot
+be proven.
+
+When source rows change during a refresh, the operation must define which
+changes belong to the returned boundary. Changes after that boundary must
+remain for a later refresh. The operation must not silently combine an older
+graph result with a newer source position.
+
+`pg-mdm` reads the complete terminal evidence relations after a successful
+strict refresh. The member and graph contracts must continue to identify those
+relations and their dependencies through the public Graph V1 functions.
+
+### Preserve the selected role and row security
+
+Definition-derived SQL must run as the current owner of each graph member, with
+row-level security enabled. The `pg-mdm` selected execution role must therefore
+own every graph member. A helper role must not bypass that owner's table
+privileges or row-level security policies.
+
+The following cases must fail before graph mutation:
+
+- the execution role loses schema `USAGE`;
+- the execution role loses source-table `SELECT`;
+- the execution role loses source-table `MAINTAIN`;
+- the source owner changes;
+- the source relation is replaced under the same name; or
+- a tracked row-level-security policy or policy dependency changes.
+
+Graph members retain the stricter owner-equivalent requirement. Delegated
+source access does not grant permission to operate a graph member.
+
+Graph V1 does not include caller role memberships, role bindings, or
+session-dependent row-level-security inputs in its digest. `pg_trickle`
+rechecks current database authorization. `pg-mdm` must validate its selected
+role binding and session-dependent visibility inputs before it calls strict
+refresh.
+
+## v0.9 requires stable graph lifecycle behavior
+
+The v0.8 graph must remain usable by the v0.9 refresh path without private
+catalog access. The following public functions and contracts must remain
+compatible:
+
+```text
+pgtrickle.integration_capabilities()
+pgtrickle.create_stream_table(...)
+pgtrickle.stream_table_contract(regclass)
+pgtrickle.graph_contract(regclass[])
+pgtrickle.refresh_graph_strict(regclass[], bytea, text)
+pgtrickle.drop_stream_table(text, boolean)
+```
+
+Every member must continue to use these settings:
+
+```text
+initialize = false
+orchestration_mode = EXTERNAL
+cdc_mode = trigger
+refresh_mode = AUTO
+```
+
+The first strict refresh may use a `FULL` refresh to establish the baseline.
+After that baseline, qualifying graph shapes must report differential or scoped
+maintenance in `node_results`. A whole-query `FULL` refresh remains a correctness
+fallback, but it must report a stable action and reason. The qualification
+workload must measure repeated `FULL` fallback so `AUTO` cannot hide a graph that
+never refreshes incrementally.
+
+`pg_trickle` must not refresh an external graph through ordinary scheduler
+work. `pg-mdm` must be the caller that starts the strict refresh.
+
+The existing contract functions must continue to report the member owner,
+source identities, dependencies, output schema, contract generation, and
+contract digest. `graph_contract()` must continue to report the complete root
+closure, topological order, source set, member set, and graph digest.
+
+## v0.10 requires operational reliability
+
+The v0.10 roadmap does not name a new `pg_trickle` SQL feature. It requires
+the existing Graph V1 implementation to behave correctly under operational
+stress. `pg-mdm` needs the following evidence from the packaged upstream
+release.
+
+### Concurrency and lifecycle locking
+
+Concurrent refresh, graph installation, rebuild, drop, and restore operations
+must not use stale contracts or cross one another's graph members.
+
+The upstream behavior must prove that:
+
+- a refresh and a drop cannot both commit as if they ran alone;
+- a refresh detects a graph change instead of publishing against an old
+  digest;
+- concurrent source writes have a defined boundary and remain available for a
+  later refresh when they fall outside the current boundary; and
+- one execution role cannot use another role's temporary graph-creation access
+  or graph objects.
+
+### Crash recovery
+
+After a PostgreSQL or backend failure during graph refresh, recovery must leave
+the graph at a valid transaction boundary. It must not leave a graph member
+partly updated or advance a source position without the corresponding graph
+changes.
+
+`pg-mdm` then verifies that the recovered graph can pass contract inspection
+and can complete a later strict refresh. A failed refresh must not create a
+false MDM publication.
+
+### Clone, backup, restore, and upgrade
+
+The supported package must preserve Graph V1 behavior across the backup,
+restore, clone, and extension-upgrade cases that `pg-mdm` supports.
+
+For a clean logical restore, `pg-mdm` rebuilds database-local bindings after
+the roles and source relations are restored. The upstream contract must not
+require `pg-mdm` to copy private catalog rows or reuse old relation OIDs.
+
+A restored or cloned database must not refresh the original database's graph.
+Role bindings, source relation identities, member relation identities, and
+contract digests must remain local to the database where the graph runs.
+
+An extension upgrade must preserve existing Graph V1 members and their
+contracts, or reject the upgrade path before it can create an inconsistent
+graph. The upgrade test must use the packaged artifacts, not a source
+checkout.
+
+### Resource limits and fallback
+
+When the graph cannot prove a complete source boundary or cannot complete a
+required stage within its configured limits, the strict refresh must fail
+closed. It must not publish incomplete terminal evidence or advance a source
+position as if the work had completed. The qualification suite must name the
+tested lock-timeout, statement-timeout, memory, and graph-size limits.
+
+`pg-mdm` later uses its full resolver as the correctness reference. A
+`pg_trickle` whole-query full refresh allowed by `full_policy = 'ALLOW'` is an
+exact graph result, not a resource-failure state. Other resource pressure must
+abort the caller transaction or return a defined failure state. It must never
+produce a partial graph that looks valid.
+
+Errors must remain stable enough for `pg-mdm` to report an actionable result.
+The error must distinguish at least contract mismatch, incomplete source
+boundary, authorization failure, concurrent lifecycle change, and resource
+failure.
+
+## v0.11 requires release qualification
+
+v0.11 qualifies the complete system for a supported release. It does not add a
+new upstream runtime feature. The release must provide a fixed, installable
+`pg_trickle` package and evidence for the public behavior used by `pg-mdm`.
+
+The qualification must cover:
+
+- Graph V1 capability discovery and contract version checks;
+- canonical member and graph contracts;
+- durable `EXTERNAL` orchestration;
+- strict refresh and complete source boundaries;
+- commit and rollback of graph changes and source positions;
+- inserts, updates, and deletes in source tables;
+- no-op refreshes;
+- concurrent source writes and lifecycle operations;
+- injected refresh failures;
+- full rebuild and fallback behavior;
+- crash recovery;
+- clone isolation;
+- backup, restore, and extension upgrade; and
+- authorization, row-level security, and forbidden private-access checks.
+
+The qualification must run against the exact package that `pg-mdm` uses in CI.
+The package record must include the upstream version, release commit, tag
+object, package URL, PostgreSQL major, and SHA-256. `pg-mdm` records those
+values in its `DEPENDENCIES.md` and reruns the admission suite for each
+dependency update.
+
+The shared suite must compare generated graph results with the independent
+full-resolution reference path. It must cover source inserts, updates,
+deletes, stewardship changes, merges, splits, golden-value-only changes,
+rollback, concurrency, fallback, rebuild, and upgrade.
+
+## Features that are not required
+
+The v0.9 through v0.11 `pg-mdm` path does not require the following upstream
+features:
+
+- `output_delta_consumer` or Delta V1 consumption;
+- WAL capture;
+- direct access to `pg_trickle` private catalogs, change buffers, or scheduler
+  state;
+- autonomous refresh of an `EXTERNAL` graph; or
+- MDM identity resolution and publication logic inside `pg_trickle`.
+
+The V1 integration uses trigger capture and complete terminal-relation reads
+after a strict Graph V1 refresh. `pg_trickle` maintains the changing
+relational facts. `pg-mdm` resolves identity and publishes MDM results.
+
+## Release gate
+
+`pg-mdm` can complete v0.9 only when one released and checksummed
+`pg_trickle` artifact passes the strict-refresh admission tests. v0.10 cannot
+close until its pinned artifact passes the cumulative operational failure and
+recovery tests. v0.11 cannot close until its exact pinned package passes the
+shared conformance and differential-versus-full qualification suite. If the
+pinned artifact changes, `pg-mdm` must rerun every applicable earlier gate.
+
+The current `pg-mdm` baseline is `pg_trickle` `0.104.0`. The baseline supports
+the owner-equivalent Graph V1 path. It does not remove the separate v0.8 gate
+for delegated source authorization.

--- a/plans/PLAN.md
+++ b/plans/PLAN.md
@@ -10,7 +10,7 @@
 | [ROADMAP.md](../ROADMAP.md) | Current release milestones and feature backlog |
 | [roadmap/](../roadmap/) | Per-version detailed roadmap files |
 | [PLAN_0_105_0.md](PLAN_0_105_0.md) | v0.105.0 qualification contract and release evidence |
-| [PLAN_0_105_1.md](PLAN_0_105_1.md) | v0.105.1 runtime conformance and recovery qualification |
+| [PLAN_0_105_1.md](PLAN_0_105_1.md) | v0.105.1 delegated Graph V1 authorization, runtime conformance, and recovery qualification |
 | [PLAN_0_105_2.md](PLAN_0_105_2.md) | v0.105.2 package, upgrade, performance, and field validation |
 | [pg-trickle assessment and pre-1.0 roadmap](pg-trickle-assessment-and-pre-1.0-roadmap.md) | September 2026 assessment that drives v0.99.0 through v0.105.2 |
 | [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) | System architecture and design overview |

--- a/plans/PLAN_0_105_1.md
+++ b/plans/PLAN_0_105_1.md
@@ -3,11 +3,18 @@
 ## Objective
 
 Prove the frozen public contracts and recovery behavior through real PostgreSQL
-execution on a packaged v0.105.1 candidate.
+execution on a packaged v0.105.1 candidate. Qualify delegated Graph V1 source
+authorization required by `pg-mdm` v0.8.
 
 ## Scope
 
 - Graph V1 and Delta V1 public-SQL conformance.
+- Delegated base-table source authorization with schema `USAGE` and table
+  `SELECT` plus `MAINTAIN`.
+- Owner-equivalent authorization for graph members, with no delegated-member
+  path.
+- Stable Graph V1 member-authorization and source-authorization reason codes.
+- Member-owner execution with row-level security enabled.
 - DVM exact-result and effective-strategy checks.
 - WAL receipt persistence, acknowledgement, replay, retry, and restart tests.
 - Rollback, invalidation, slow-consumer, schema, permission, restore, clone,
@@ -17,18 +24,56 @@ execution on a packaged v0.105.1 candidate.
 Do not add SQL features, public APIs, integrations, or new controller actions.
 Do not require the 72-hour soak or longevity run.
 
+Keep caller ACLs, role memberships, role bindings, and session-dependent
+row-level security inputs out of the Graph V1 digest. pg_trickle rechecks live
+database authorization. The coordinator binds its selected role and session
+claims.
+
 ## Implementation order
 
-1. Run the v0.105.0 contract against the packaged v0.105.1 candidate.
-2. Replace any structural conformance check with a live public-SQL scenario.
-3. Extend the exact schema and multiset oracle to every required path.
-4. Execute the WAL fault matrix at each receipt boundary and after restart.
-5. Test graph and consumer state after rollback, savepoint, and exception.
-6. Fix release blockers, publish a new candidate, and rerun affected suites.
+1. Integrate the delegated-source behavior introduced by commit
+   `e995812`. Preserve the behavior if the commit is rebased or squashed.
+2. Split Graph V1 authorization between graph members and base-table sources.
+3. Return distinct stable reason codes for member and source authorization
+   failures.
+4. Document the `pgtrickle` schema and function grants required by a
+   coordinator. Include `refresh_graph_strict(regclass[], bytea, text)` in the
+   integration documentation's public function list.
+5. Run the v0.105.0 contract against the packaged v0.105.1 candidate.
+6. Replace each structural conformance check with a live public-SQL scenario.
+7. Add a parameterized authorization matrix for source ownership, each required
+   grant, inherited-role revocation, member ownership, row-level security, and
+   hostile `search_path` values.
+8. Define the row-level security policy dependencies that Graph V1 tracks. Test
+   source-owner changes, relation replacement, policy changes, and tracked
+   policy-dependency changes before graph mutation.
+9. Test `initialize = false`, `orchestration_mode = 'EXTERNAL'`,
+   `cdc_mode = 'trigger'`, and `refresh_mode = 'AUTO'` together. Use
+   `full_policy = 'ALLOW'` for initial population.
+10. Extend the exact schema and multiset oracle to every required path.
+11. Execute the WAL fault matrix at each receipt boundary and after restart.
+12. Test graph and consumer state after rollback, savepoint, and exception.
+13. Fix release blockers, publish a new candidate, and rerun affected suites.
 
 ## Acceptance criteria
 
 - Graph V1 and Delta V1 pass without private catalog or buffer access.
+- A caller that owns each graph member may coordinate a non-owned base-table
+  source after the source owner grants schema `USAGE` and table `SELECT` plus
+  `MAINTAIN`.
+- Revoking `SELECT`, `MAINTAIN`, schema `USAGE`, or inherited authorization
+  blocks both contract inspection and strict refresh before graph mutation.
+- A caller without owner-equivalent authority over a graph member remains
+  unauthorized even when the caller has source grants.
+- Definition-derived SQL runs as the current graph-member owner with row-level
+  security enabled. The `pg-mdm` execution role is that exact owner.
+- Policy changes and tracked policy-dependency changes invalidate the graph
+  contract. The coordinator validates session-dependent policy inputs outside
+  Graph V1. Refresh evaluates them under the current member-owner context.
+- Hostile `search_path` values and colliding names cannot redirect a bound graph
+  operation.
+- Member and source authorization failures expose distinct stable reason codes
+  in protected diagnostic detail.
 - Every committed source transaction remains accounted for after a tested
   receipt failure, retry, or restart.
 - Result schema, row multiplicity, NULL behavior, and effective refresh mode
@@ -52,6 +97,8 @@ Do not require the 72-hour soak or longevity run.
 ## Deliverables
 
 - live Graph V1 and Delta V1 conformance coverage
+- delegated-source authorization coverage and stable diagnostics
+- coordinator grant and execution-identity documentation
 - WAL and recovery fault-matrix coverage
 - candidate-bound blocker ledger and release evidence
 - v0.105.1 package, archive, and upgrade artifacts

--- a/plans/PLAN_0_105_1.md
+++ b/plans/PLAN_0_105_1.md
@@ -4,21 +4,30 @@
 
 Prove the frozen public contracts and recovery behavior through real PostgreSQL
 execution on a packaged v0.105.1 candidate. Qualify delegated Graph V1 source
-authorization required by `pg-mdm` v0.8.
+authorization and the [`pg-mdm` Graph V1 admission
+profile](../pg-mdm-pg-trickle-requirements-2.md).
 
 ## Scope
 
 - Graph V1 and Delta V1 public-SQL conformance.
+- The `pg-mdm` Graph V1 profile with external orchestration, trigger capture,
+  `AUTO` refresh, deferred initialization, and complete terminal-table reads.
 - Delegated base-table source authorization with schema `USAGE` and table
   `SELECT` plus `MAINTAIN`.
 - Owner-equivalent authorization for graph members, with no delegated-member
   path.
 - Stable Graph V1 member-authorization and source-authorization reason codes.
+- Stable contract, boundary, authorization, lifecycle, and resource reason
+  codes for the `pg-mdm` admission profile.
 - Member-owner execution with row-level security enabled.
 - DVM exact-result and effective-strategy checks.
 - WAL receipt persistence, acknowledgement, replay, retry, and restart tests.
 - Rollback, invalidation, slow-consumer, schema, permission, restore, clone,
   and upgrade coverage.
+- Atomic coordinator publication, exact source-boundary evidence, concurrent
+  source writes, lifecycle races, crash recovery, and retry.
+- Steady-state effective-strategy checks that detect repeated whole-query `FULL`
+  fallback on qualifying graph shapes.
 - Release-blocking correctness, security, and recovery fixes only.
 
 Do not add SQL features, public APIs, integrations, or new controller actions.
@@ -36,24 +45,39 @@ claims.
 2. Split Graph V1 authorization between graph members and base-table sources.
 3. Return distinct stable reason codes for member and source authorization
    failures.
-4. Document the `pgtrickle` schema and function grants required by a
-   coordinator. Include `refresh_graph_strict(regclass[], bytea, text)` in the
-   integration documentation's public function list.
-5. Run the v0.105.0 contract against the packaged v0.105.1 candidate.
-6. Replace each structural conformance check with a live public-SQL scenario.
-7. Add a parameterized authorization matrix for source ownership, each required
-   grant, inherited-role revocation, member ownership, row-level security, and
-   hostile `search_path` values.
-8. Define the row-level security policy dependencies that Graph V1 tracks. Test
+4. Define the row-level security policy dependencies that Graph V1 tracks. Test
    source-owner changes, relation replacement, policy changes, and tracked
    policy-dependency changes before graph mutation.
-9. Test `initialize = false`, `orchestration_mode = 'EXTERNAL'`,
+5. Document the `pgtrickle` schema and function grants required by a
+   coordinator. Include `refresh_graph_strict(regclass[], bytea, text)` in the
+   integration documentation's public function list.
+6. Run the v0.105.0 contract against the packaged v0.105.1 candidate.
+7. Replace each structural conformance check with a live public-SQL scenario.
+8. Add a parameterized authorization matrix for source ownership, each required
+   grant, inherited-role revocation, member ownership, row-level security, and
+   hostile `search_path` values.
+9. Build the `pg-mdm` Graph V1 admission profile with `initialize = false`,
+   `orchestration_mode = 'EXTERNAL'`,
    `cdc_mode = 'trigger'`, and `refresh_mode = 'AUTO'` together. Use
    `full_policy = 'ALLOW'` for initial population.
-10. Extend the exact schema and multiset oracle to every required path.
-11. Execute the WAL fault matrix at each receipt boundary and after restart.
-12. Test graph and consumer state after rollback, savepoint, and exception.
-13. Fix release blockers, publish a new candidate, and rerun affected suites.
+10. Verify the graph refresh ID, complete source manifest, 32-byte boundary
+    digest, and `PROVEN` result against inserts, updates, deletes, and no-op
+    refreshes.
+11. Interleave source writes around the graph boundary. Inject a failure after
+    graph maintenance, then prove rollback and retry without lost or duplicate
+    changes.
+12. Race refresh with alter, rebuild, drop, and restore operations. Require
+    serialization or a stable rejection before commit.
+13. Verify stable reason codes for contract mismatch, incomplete source
+    boundary, authorization failure, concurrent lifecycle change, and resource
+    failure.
+14. Extend the exact schema and multiset oracle to every required path. Assert
+    differential or scoped maintenance after the initial baseline for qualifying
+    graph shapes.
+15. Execute the WAL fault matrix at each receipt boundary and after restart.
+16. Test graph and consumer state after rollback, savepoint, exception, and
+    backend termination.
+17. Fix release blockers, publish a new candidate, and rerun affected suites.
 
 ## Acceptance criteria
 
@@ -81,6 +105,16 @@ claims.
 - `full_policy = 'ERROR'` rejects every whole-query FULL fallback.
 - Rollback and exception paths leave no graph, cursor, frontier, or consumer
   state that can affect a later refresh.
+- The boundary manifest covers every source. Concurrent writes either belong to
+  that boundary or remain pending for the next refresh.
+- Coordinator publication and graph maintenance commit or roll back in one
+  caller transaction. A retry neither skips nor duplicates source changes.
+- Contract-changing lifecycle operations cannot commit as if they ran alone
+  against the same graph refresh.
+- Stable reason codes distinguish contract, boundary, authorization, lifecycle,
+  and resource failures.
+- After initial population, qualifying `pg-mdm` graph shapes report
+  differential or scoped maintenance. Repeated FULL fallback fails the gate.
 - The candidate evidence records every executed and deferred suite.
 
 ## Verification
@@ -91,13 +125,16 @@ claims.
 - `just test-v104-conformance`
 - `just test-integration`
 - `just test-light-e2e`
+- `just test-e2e`
 - `just check-upgrade-all`
 - `python3 scripts/v0_105_1_release_gate.py`
 
 ## Deliverables
 
 - live Graph V1 and Delta V1 conformance coverage
+- `pg-mdm` Graph V1 admission coverage
 - delegated-source authorization coverage and stable diagnostics
+- source-boundary, lifecycle-concurrency, rollback, retry, and crash coverage
 - coordinator grant and execution-identity documentation
 - WAL and recovery fault-matrix coverage
 - candidate-bound blocker ledger and release evidence

--- a/plans/PLAN_0_105_2.md
+++ b/plans/PLAN_0_105_2.md
@@ -4,12 +4,19 @@
 
 Validate the v0.105 runtime and public contracts in supported packages and
 representative deployments without starting the deferred v1.0 qualification.
+Publish the package evidence required by the [`pg-mdm` Graph V1 admission
+profile](../pg-mdm-pg-trickle-requirements-2.md).
 
 ## Scope
 
 - Reproducible package builds and package maintenance tests.
+- Candidate-bound package provenance with the release commit, tag object,
+  package URL, PostgreSQL major, and SHA-256.
 - Active-data upgrade and recreation paths with pending changes.
+- Logical backup, restore, and clone isolation with database-local bindings.
 - Foreground-write, refresh-latency, memory, WAL, and output-log budgets.
+- Effective-strategy and whole-query FULL fallback measurements for the
+  qualifying `pg-mdm` graph workload.
 - Independent operator validation of documented lifecycle procedures.
 - Release-blocking compatibility, performance, documentation, and packaging
   fixes only.
@@ -20,10 +27,14 @@ deferred. They remain future v1.0 qualification gates.
 ## Implementation order
 
 1. Freeze package, platform, PostgreSQL, workload, and evidence requirements.
+   Require the release commit, tag object, package URL, PostgreSQL major, and
+   SHA-256 for each artifact.
 2. Build every supported artifact twice in clean environments.
-3. Run install, active refresh, pending-change upgrade, and recreation tests.
+3. Run install, active refresh, pending-change upgrade, recreation, logical
+   restore, and clone-isolation tests.
 4. Run foreground-write and refresh-performance workloads with correctness
-   assertions enabled.
+   assertions enabled. Measure repeated whole-query `FULL` fallback on the
+   qualifying `pg-mdm` graph workload.
 5. Run the documented operator procedures and capture defects.
 6. Fix blockers, publish a new patch candidate if needed, and rerun affected
    checks.
@@ -32,11 +43,17 @@ deferred. They remain future v1.0 qualification gates.
 
 - Every supported package installs and maintains real data.
 - Every supported upgrade or recreation path passes with pending changes.
+- Logical restore and clone tests rebuild database-local bindings without
+  private catalog copies or reused relation OIDs.
 - Performance results meet the frozen foreground-write and refresh budgets.
+- The qualifying `pg-mdm` workload meets its effective-strategy and whole-query
+  FULL fallback budgets.
 - Disabled output-delta consumers stay within the documented overhead budget.
 - Independent operators complete install, diagnose, alter, upgrade, restore,
   and resnapshot procedures.
 - Each limitation has a stable diagnostic and supported response.
+- Every package result names the release commit, tag object, package URL,
+  PostgreSQL major, and SHA-256.
 - No long-running soak or longevity result is required for v0.105.2.
 
 ## Verification
@@ -53,6 +70,8 @@ deferred. They remain future v1.0 qualification gates.
 ## Deliverables
 
 - package and upgrade qualification evidence
+- checksummed package provenance that downstream admission suites can pin
+- logical restore and clone-isolation evidence
 - foreground-write and refresh-performance results
 - independent operator validation records
 - v0.105.2 package, archive, and upgrade artifacts

--- a/roadmap/v0.105.1.md
+++ b/roadmap/v0.105.1.md
@@ -2,20 +2,39 @@
 
 > **Status:** Planned
 > **Scope:** Large
-> **User promise:** *"Supported contracts behave correctly under failure and replay."*
+> **User promise:** *"Supported contracts behave correctly under delegated access, failure, and replay."*
 > **Blocked by:** [v0.105.0](v0.105.0.md)
 > **Series:** [v0.105.x](v0.105.x.md)
 
 ## Theme
 
 Qualify the runtime behavior behind the frozen Graph V1, Delta V1, DVM, CDC,
-and recovery contracts. Use real PostgreSQL execution and the packaged
+and recovery contracts. Add delegated Graph V1 source authorization as a
+release-blocking security fix. Use real PostgreSQL execution and the packaged
 candidate.
 
 ## Work
 
 - Run the Graph V1 and Delta V1 suites through public SQL without private
   catalog or change-buffer access.
+- Allow a base-table source when the caller has schema `USAGE` and table
+  `SELECT` plus `MAINTAIN`. Keep owner-equivalent authority mandatory for graph
+  members.
+- Return separate stable reason codes for graph-member and graph-source
+  authorization failures.
+- Prove that contract inspection and strict refresh reject a revoked `SELECT`,
+  `MAINTAIN`, or schema `USAGE` grant before member mutation.
+- Prove inherited-role revocation, source-owner changes, and relation
+  replacement fail closed. Define which row-level security policy dependencies
+  Graph V1 tracks, then prove policy and tracked-dependency changes fail closed.
+- Run definition-derived SQL as each graph member's current owner with row-level
+  security enabled. Test the pg-mdm pattern in which the selected execution
+  role owns every member.
+- Test hostile `search_path` values and colliding object names. Use only bound
+  OIDs and schema-qualified names.
+- Document the `pgtrickle` schema and function grants required by a coordinator.
+  Include `refresh_graph_strict(regclass[], bytea, text)` in the integration
+  documentation's public function list.
 - Cover graph rollback, replay, invalidation, slow consumers, schema changes,
   permissions, restore, clone, and upgrade behavior.
 - Run the exact DVM schema and multiset oracle across supported refresh paths.
@@ -29,6 +48,19 @@ candidate.
 ## Exit criteria
 
 - [ ] Graph V1 and Delta V1 conformance passes against the packaged candidate.
+- [ ] The packaged candidate contains the delegated-source authorization
+      behavior introduced by commit `e995812`, whether merged, rebased, or
+      squashed.
+- [ ] A coordinator that does not own a base-table source can inspect and
+      refresh its graph after it receives schema `USAGE` and table `SELECT`
+      plus `MAINTAIN`.
+- [ ] Revoking any required source grant makes contract inspection and strict
+      refresh fail before graph mutation.
+- [ ] Delegated authority never applies to graph members.
+- [ ] Authorization failures expose stable member or source reason codes in
+      protected diagnostic detail.
+- [ ] The `pg-mdm` execution-role pattern retains the member owner's row-level
+      security view. Arbitrary session claims remain coordinator-owned inputs.
 - [ ] Recovery tests account for committed changes after failures and retries.
 - [ ] Exact result, schema, multiplicity, and effective-strategy checks pass.
 - [ ] No supported path silently bypasses its declared refresh policy.
@@ -40,3 +72,12 @@ candidate.
 
 Do not widen SQL admission or add public APIs. Preserve the correctness-
 preserving FULL fallback when the differential path lacks proof.
+
+Keep Graph V1 at version 1.0. Do not add caller ACLs, role memberships, or
+session settings to the canonical digest. Recheck live authorization instead.
+Because `initialize = false` requires initial population, conformance uses
+`full_policy = 'ALLOW'` for the first strict refresh.
+
+A downstream consumer may adopt a released v0.105.1 PostgreSQL 18 package after
+its own checksummed-artifact admission passes. The broader v0.105.2 package and
+field qualification is not a prerequisite for that adoption.

--- a/roadmap/v0.105.1.md
+++ b/roadmap/v0.105.1.md
@@ -5,6 +5,7 @@
 > **User promise:** *"Supported contracts behave correctly under delegated access, failure, and replay."*
 > **Blocked by:** [v0.105.0](v0.105.0.md)
 > **Series:** [v0.105.x](v0.105.x.md)
+> **Integration profile:** [`pg-mdm` Graph V1 requirements](../pg-mdm-pg-trickle-requirements-2.md)
 
 ## Theme
 
@@ -17,6 +18,9 @@ candidate.
 
 - Run the Graph V1 and Delta V1 suites through public SQL without private
   catalog or change-buffer access.
+- Add a `pg-mdm` Graph V1 admission profile that uses `initialize = false`,
+  `orchestration_mode = 'EXTERNAL'`, trigger capture, and `refresh_mode` set to
+  `'AUTO'`. Use `full_policy = 'ALLOW'` for the initial baseline.
 - Allow a base-table source when the caller has schema `USAGE` and table
   `SELECT` plus `MAINTAIN`. Keep owner-equivalent authority mandatory for graph
   members.
@@ -37,7 +41,19 @@ candidate.
   documentation's public function list.
 - Cover graph rollback, replay, invalidation, slow consumers, schema changes,
   permissions, restore, clone, and upgrade behavior.
+- Prove coordinator publication commit, rollback after graph maintenance, and
+  retry without skipped or duplicate source changes.
+- Interleave source writes with strict refresh. Prove that the returned source
+  boundary contains every admitted source, has a 32-byte digest, reports
+  `PROVEN`, and leaves changes beyond the boundary for a later refresh.
+- Race strict refresh with alter, rebuild, drop, and restore operations. Reject
+  stale contracts or serialize the operations before any result can commit.
+- Verify stable reason codes for contract mismatch, incomplete source boundary,
+  authorization failure, concurrent lifecycle change, and resource failure.
 - Run the exact DVM schema and multiset oracle across supported refresh paths.
+- Cover inserts, updates, deletes, and no-op refreshes. After the initial
+  baseline, assert that qualifying graph shapes report differential or scoped
+  maintenance instead of repeated whole-query `FULL` refreshes.
 - Run the WAL receipt fault matrix across persistence, acknowledgement, retry,
   restart, and multi-source failure boundaries.
 - Verify that `full_policy = 'ERROR'` rejects every whole-query FULL transition.
@@ -62,7 +78,17 @@ candidate.
 - [ ] The `pg-mdm` execution-role pattern retains the member owner's row-level
       security view. Arbitrary session claims remain coordinator-owned inputs.
 - [ ] Recovery tests account for committed changes after failures and retries.
+- [ ] A failed coordinator transaction rolls back graph rows, source positions,
+      refresh evidence, and coordinator-owned publication rows together.
+- [ ] Concurrent writers on both sides of the source boundary produce no lost
+      or duplicate changes.
+- [ ] Contract-changing lifecycle operations either serialize with refresh or
+      cause a stable pre-commit rejection.
+- [ ] Graph V1 errors distinguish contract, boundary, authorization, lifecycle,
+      and resource failures with stable reason codes.
 - [ ] Exact result, schema, multiplicity, and effective-strategy checks pass.
+- [ ] Qualifying steady-state `pg-mdm` graph shapes do not hide repeated FULL
+      refreshes behind `AUTO`.
 - [ ] No supported path silently bypasses its declared refresh policy.
 - [ ] Ownership, permissions, rollback, restore, clone, and upgrade checks
       pass for the frozen contracts.

--- a/roadmap/v0.105.2.md
+++ b/roadmap/v0.105.2.md
@@ -5,6 +5,7 @@
 > **User promise:** *"The released build works in the environments we support."*
 > **Blocked by:** [v0.105.1](v0.105.1.md)
 > **Series:** [v0.105.x](v0.105.x.md)
+> **Integration profile:** [`pg-mdm` Graph V1 requirements](../pg-mdm-pg-trickle-requirements-2.md)
 
 ## Theme
 
@@ -16,10 +17,15 @@ start the deferred v1.0 qualification.
 
 - Build every supported package reproducibly and run install and maintenance
   smoke tests against the packaged artifacts.
+- Publish the release commit, tag object, package URL, PostgreSQL major, and
+  SHA-256 for every supported artifact.
 - Run the supported upgrade and recreation paths with active stream tables and
   pending source changes.
+- Run logical backup and restore plus clone-isolation tests without copying
+  private catalog rows or reusing relation OIDs.
 - Measure refresh throughput, p95 and p99 latency where useful, memory, WAL,
-  output-log growth, and foreground-write impact.
+  output-log growth, foreground-write impact, and whole-query `FULL` fallback on
+  the qualifying `pg-mdm` graph workload.
 - Verify that disabled output-delta consumers add no work beyond the documented
   budget.
 - Have independent operators run install, diagnose, alter, upgrade, restore,
@@ -32,7 +38,11 @@ start the deferred v1.0 qualification.
 
 - [ ] Every supported package installs and maintains real stream-table data.
 - [ ] Every supported upgrade or recreation path passes with pending changes.
+- [ ] Logical restore and clone tests create database-local graph bindings and
+      reject stale database-instance evidence.
 - [ ] Workload results meet the frozen foreground-write and refresh budgets.
+- [ ] Each package record names the release commit, tag object, package URL,
+      PostgreSQL major, and SHA-256.
 - [ ] Package, upgrade, and field evidence names the exact candidate artifact.
 - [ ] Every remaining limitation has a stable diagnostic and supported
       response.

--- a/roadmap/v0.105.x.md
+++ b/roadmap/v0.105.x.md
@@ -31,6 +31,20 @@ The v0.104.0 Graph V1 and Delta V1 contracts remain the frozen public surface.
 Every runtime change must preserve those contracts or narrow an unproven
 behavior with a documented reason.
 
+v0.105.1 may widen Graph V1 source authorization without changing SQL
+signatures, contract encodings, or capability versions. A graph member still
+requires owner-equivalent authority. A base-table source accepts either
+owner-equivalent authority or schema `USAGE` plus table `SELECT` and
+`MAINTAIN`. pg_trickle checks these privileges on each contract inspection and
+strict refresh.
+
+Graph V1 continues to evaluate definition-derived SQL as the current owner of
+each stream table. A coordinator that requires one execution role's row-level
+security view must make that role the exact owner of every graph member. The
+coordinator owns its role binding and any session-dependent row-level security
+inputs. These values do not become part of the coordinator-independent Graph V1
+digest.
+
 ## Deferred work
 
 The following work is not part of the current v0.105 series:


### PR DESCRIPTION
## Summary

- Add the pg-mdm requirements for Graph V1 graph creation, strict refresh, recovery, and release qualification.
- Align the v0.105.1 roadmap and plan with delegated source authorization, source-boundary proof, coordinator rollback, lifecycle concurrency, stable errors, and steady-state differential behavior.
- Align the v0.105.2 roadmap and plan with package provenance, logical restore, clone isolation, and the qualifying pg-mdm workload.
- Add a feedback handoff that separates pg_trickle guarantees from pg-mdm-owned role binding, MDM semantics, and downstream admission.

## Scope decisions

- Keep the frozen Graph V1 SQL API and contract version unchanged.
- Use v0.105.1 as the minimum release for the delegated-source pg-mdm path.
- Keep v0.105.2 focused on package, upgrade, performance, and field evidence.
- Require cumulative admission whenever pg-mdm changes its pinned pg_trickle artifact.
- Allow the initial FULL baseline, but reject repeated FULL fallback for qualifying steady-state graph shapes.

## Validation

- `just fmt`
- `just lint`
- `git diff --check`
